### PR TITLE
fix: bug fixes and init improvements from fast-cli optimizer run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,9 @@ coverage/
 # Temp directories
 tmp/
 temp/
+
+# Superpowers planning artifacts
+docs/superpowers/
+
+# Skill-optimizer generated artifacts
+.skill-optimizer/

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,9 @@ docs/superpowers/
 
 # Skill-optimizer generated artifacts
 .skill-optimizer/
+
+# Local user config (personal paths, model choices — not repo artifacts)
+skill-optimizer.json
+cli-commands.json
+tools.json
+tasks.json

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Open `skill-optimizer.json` and make these edits:
 Then run the benchmark:
 
 ```bash
-npx tsx src/cli.ts run --config ./skill-optimizer.json
+npx tsx src/cli.ts run --config ./skill-optimizer/skill-optimizer.json
 ```
 
 ## How it works

--- a/README.md
+++ b/README.md
@@ -12,20 +12,28 @@ cd skill-optimizer
 npm install
 export OPENROUTER_API_KEY=sk-or-...
 
-# Create starter files in this directory
-npx tsx src/cli.ts init
+# Scaffold config for your surface type (sdk | cli | mcp)
+npx tsx src/cli.ts init cli
 ```
 
-`init` writes three files: `skill-optimizer.json` (main config), `tasks.json` (example tasks), and `tools.json` (example MCP tool definitions).
+`init cli` creates a `skill-optimizer/` directory with:
+- `skill-optimizer.json` — the main config (task generation enabled by default)
+- `cli-commands.json` — command manifest template (used as fallback if code-first discovery finds nothing)
 
-Open `skill-optimizer.json` and make these edits:
+`init sdk` creates `skill-optimizer.json` only. `init mcp` creates `skill-optimizer.json` + `tools.json`.
+
+Open `skill-optimizer/skill-optimizer.json` and fill in these fields:
 
 | Field | What it does | Set it to |
 |-------|-------------|-----------|
-| `target.surface` | What kind of interface you're benchmarking | `"sdk"` for a library, `"cli"` for a command-line tool, `"mcp"` for an MCP server |
 | `target.repoPath` | Root of the project being benchmarked | Absolute or relative path to your repo |
-| `target.discovery.sources` | Source files to scan for callable methods/commands/tools | e.g. `["./src/index.ts"]` or `["./src/server.ts"]` |
+| `target.discovery.sources` | Source files to scan for callable methods/commands/tools | e.g. `["../src/index.ts"]` or `["../src/server.ts"]` |
 | `target.skill` | Docs file the optimizer will edit | Path to your `SKILL.md` or equivalent guidance doc |
+| `benchmark.models` | Models to benchmark | Valid [OpenRouter](https://openrouter.ai/models) model IDs |
+
+For CLI and MCP surfaces: if code-first discovery yields nothing, edit the companion manifest (`cli-commands.json` or `tools.json`) with your real commands/tools — the config already points to it as a fallback.
+
+Tasks are generated automatically from your discovered surface — you don't need to write them manually.
 
 Then run the benchmark:
 

--- a/mock-repos/README.md
+++ b/mock-repos/README.md
@@ -1,10 +1,12 @@
 # Mock Repos
 
-`mock-repos/` contains the tracked end-to-end demo template for manual benchmark and optimizer testing:
+`mock-repos/` contains tracked end-to-end demo templates for manual benchmark and optimizer testing:
 
-- `mcp-tracker-demo`
+- `mcp-tracker-demo` — MCP surface, `surface-changing` optimize mode
+- `sdk-counter-demo` — SDK surface, intentionally lossy SKILL.md
+- `cli-taskfile-demo` — CLI surface, intentionally lossy SKILL.md
 
-Use the tracked template directly for read-only benchmark runs.
+Use a tracked template directly for read-only benchmark runs.
 
 Materialize a standalone copy before running the optimizer so git checkpointing stays isolated:
 
@@ -13,6 +15,4 @@ tsx src/optimizer/materialize-mock-repo.ts mcp-tracker-demo ./.tmp/mock-repos
 npx skill-optimizer optimize --config ./.tmp/mock-repos/mcp-tracker-demo/skill-optimizer.json
 ```
 
-`mcp-tracker-demo` is the current OSS example for the unified `skill-optimizer.json` flow.
-It discovers MCP tools from `src/server.ts`, generates benchmark tasks under `./.skill-optimizer`,
-and runs the optimizer in `surface-changing` mode.
+Each demo repo's `skill-optimizer.json` is the unified config entry point for both benchmarking and optimization.

--- a/mock-repos/cli-taskfile-demo/README.md
+++ b/mock-repos/cli-taskfile-demo/README.md
@@ -1,0 +1,28 @@
+# cli-taskfile-demo
+
+A CLI surface demo for skill-optimizer.
+
+This mock repo demonstrates optimizing a CLI tool's `SKILL.md` so that LLMs can use all five commands (`add`, `list`, `done`, `delete`, `update`) with the right flags. The included `SKILL.md` intentionally omits `delete`, `update`, and flag details like `--priority` and `--due` — leaving the optimizer room to improve coverage.
+
+## What's here
+
+| File | Purpose |
+|------|---------|
+| `skill-optimizer.json` | Unified benchmark + optimizer config |
+| `SKILL.md` | Intentionally incomplete docs — the optimizer rewrites this |
+| `src/commands.ts` | CLI command definitions (the surface being benchmarked) |
+
+## Quickstart
+
+Materialize an isolated copy before running the optimizer (required for git checkpointing):
+
+```bash
+tsx src/optimizer/materialize-mock-repo.ts cli-taskfile-demo ./.tmp/mock-repos
+npx tsx src/cli.ts optimize --config ./.tmp/mock-repos/cli-taskfile-demo/skill-optimizer.json
+```
+
+Or run a benchmark-only pass against the tracked template:
+
+```bash
+npx tsx src/cli.ts run --config mock-repos/cli-taskfile-demo/skill-optimizer.json
+```

--- a/mock-repos/cli-taskfile-demo/SKILL.md
+++ b/mock-repos/cli-taskfile-demo/SKILL.md
@@ -1,0 +1,37 @@
+# taskfile CLI
+
+A simple command-line task manager.
+
+## Usage
+
+```bash
+taskfile add --title "Buy groceries"
+taskfile list
+taskfile done --id abc123
+```
+
+## Commands
+
+### add
+
+Add a new task.
+
+```bash
+taskfile add --title "Task title"
+```
+
+### list
+
+List your current tasks.
+
+```bash
+taskfile list
+```
+
+### done
+
+Mark a task as done using its ID.
+
+```bash
+taskfile done --id <id>
+```

--- a/mock-repos/cli-taskfile-demo/skill-optimizer.json
+++ b/mock-repos/cli-taskfile-demo/skill-optimizer.json
@@ -1,0 +1,33 @@
+{
+  "name": "cli-taskfile-demo",
+  "target": {
+    "surface": "cli",
+    "repoPath": ".",
+    "skill": "./SKILL.md",
+    "discovery": {
+      "mode": "auto",
+      "sources": ["./src/commands.ts"]
+    },
+    "scope": { "include": ["*"], "exclude": [] }
+  },
+  "benchmark": {
+    "format": "pi",
+    "apiKeyEnv": "OPENROUTER_API_KEY",
+    "models": [
+      { "id": "openrouter/openai/gpt-4o-mini", "name": "GPT-4o mini", "tier": "low" },
+      { "id": "openrouter/anthropic/claude-sonnet-4.6", "name": "Claude 4.6", "tier": "mid" }
+    ],
+    "verdict": { "perModelFloor": 0.6, "targetWeightedAverage": 0.7 },
+    "taskGeneration": { "enabled": true, "maxTasks": 10, "seed": 1, "outputDir": "./.skill-optimizer" }
+  },
+  "optimize": {
+    "enabled": true,
+    "model": "openrouter/anthropic/claude-sonnet-4.6",
+    "apiKeyEnv": "OPENROUTER_API_KEY",
+    "allowedPaths": ["SKILL.md"],
+    "validation": [],
+    "maxIterations": 3,
+    "minImprovement": 0.02,
+    "reportContextMaxBytes": 16000
+  }
+}

--- a/mock-repos/cli-taskfile-demo/src/commands.ts
+++ b/mock-repos/cli-taskfile-demo/src/commands.ts
@@ -1,0 +1,49 @@
+/**
+ * CLI command definitions for the taskfile demo.
+ * Exported as a literal array so the skill-optimizer can discover the surface
+ * via static analysis — no runtime evaluation needed.
+ */
+export const COMMANDS = [
+  {
+    command: "add",
+    description: "Add a new task to the list",
+    options: [
+      { name: "title", takesValue: true, description: "Task title (required)" },
+      { name: "priority", takesValue: true, description: "Priority level: low, medium, or high (default: medium)" },
+      { name: "due", takesValue: true, description: "Due date in YYYY-MM-DD format" },
+    ],
+  },
+  {
+    command: "list",
+    description: "List tasks, optionally filtered",
+    options: [
+      { name: "status", takesValue: true, description: "Filter by status: pending, done, or all (default: pending)" },
+      { name: "priority", takesValue: true, description: "Filter by priority level" },
+    ],
+  },
+  {
+    command: "done",
+    description: "Mark a task as completed",
+    options: [
+      { name: "id", takesValue: true, description: "Task ID to mark as done (required)" },
+    ],
+  },
+  {
+    command: "delete",
+    description: "Permanently delete a task",
+    options: [
+      { name: "id", takesValue: true, description: "Task ID to delete (required)" },
+      { name: "force", takesValue: false, description: "Skip the confirmation prompt" },
+    ],
+  },
+  {
+    command: "update",
+    description: "Update one or more fields of an existing task",
+    options: [
+      { name: "id", takesValue: true, description: "Task ID to update (required)" },
+      { name: "title", takesValue: true, description: "New task title" },
+      { name: "priority", takesValue: true, description: "New priority level" },
+      { name: "due", takesValue: true, description: "New due date in YYYY-MM-DD format" },
+    ],
+  },
+];

--- a/src/benchmark/evaluator.ts
+++ b/src/benchmark/evaluator.ts
@@ -12,6 +12,28 @@ import { getExpectedActionName, getExpectedActions } from './types.js';
 // ── Argument matching ──────────────────────────────────────────────────────
 
 /**
+ * Resolve an argument value from an extracted call's args, with positional fallback.
+ *
+ * CLI commands often take positional arguments (e.g. `fast account set-default myname`)
+ * which the extractor records as `_positional_0`, `_positional_1`, etc. When the expected
+ * args use the semantic name (e.g. `{name: "myname"}`), we look for the value in positionals
+ * as a fallback so that positional and named-flag invocations both match.
+ */
+function resolveArgValue(args: Record<string, unknown>, key: string, expectedValue: unknown): unknown {
+  const direct = args[key];
+  if (direct !== undefined) return direct;
+  // Positional fallback: if expected is a plain string, check _positional_N entries
+  if (typeof expectedValue === 'string') {
+    for (const [k, v] of Object.entries(args)) {
+      if (k.startsWith('_positional_') && v === expectedValue) {
+        return v;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
  * Compare an extracted argument value against an expected string value.
  *
  * Rules:
@@ -175,7 +197,7 @@ export function matchTools(
         const trialArgResults: Record<string, { expected: string; got: unknown; match: boolean }> = {};
         let allArgsMatch = true;
         for (const [key, expectedValue] of Object.entries(expected.args!)) {
-          if (!matchExpectedValue(expectedValue, extractedCalls[i].args[key], key, trialArgResults)) {
+          if (!matchExpectedValue(expectedValue, resolveArgValue(extractedCalls[i].args, key, expectedValue), key, trialArgResults)) {
             allArgsMatch = false;
           }
         }
@@ -191,7 +213,7 @@ export function matchTools(
         const found = extractedCalls[perfectMatchIndex];
         const argResults: Record<string, { expected: string; got: unknown; match: boolean }> = {};
         for (const [key, expectedValue] of Object.entries(expected.args!)) {
-          matchExpectedValue(expectedValue, found.args[key], key, argResults);
+          matchExpectedValue(expectedValue, resolveArgValue(found.args, key, expectedValue), key, argResults);
         }
         return {
           expected,
@@ -231,7 +253,7 @@ export function matchTools(
       const argResults: Record<string, { expected: string; got: unknown; match: boolean }> = {};
       let allArgsMatch = true;
       for (const [key, expectedValue] of Object.entries(expected.args!)) {
-        if (!matchExpectedValue(expectedValue, found.args[key], key, argResults)) {
+        if (!matchExpectedValue(expectedValue, resolveArgValue(found.args, key, expectedValue), key, argResults)) {
           allArgsMatch = false;
         }
       }

--- a/src/benchmark/extractors/cli-extractor.ts
+++ b/src/benchmark/extractors/cli-extractor.ts
@@ -138,12 +138,21 @@ function splitCommandChain(command: string, line: number): CommandLine[] {
   return parts;
 }
 
+// Shell control-flow keywords that can appear as the first token of a split command
+// (e.g. "then fast account list" after splitting "if ...; then fast account list; fi" on ';')
+const SHELL_CONTROL_KEYWORDS = new Set(['then', 'else', 'elif', 'do', 'fi', 'done', 'esac']);
+
 function parseSingleCommand(command: string, line: number, knownCommands?: readonly string[]): ExtractedCall | null {
   const tokens = tokenizeShell(command);
   if (tokens.length === 0) return null;
 
   let i = 0;
   const env: Record<string, string> = {};
+
+  // Skip leading shell control-flow keywords (then, else, elif, do, fi, done, esac)
+  while (i < tokens.length && SHELL_CONTROL_KEYWORDS.has(tokens[i])) {
+    i++;
+  }
 
   while (i < tokens.length && isEnvAssignment(tokens[i])) {
     const [key, ...rest] = tokens[i].split('=');

--- a/src/benchmark/extractors/cli-extractor.ts
+++ b/src/benchmark/extractors/cli-extractor.ts
@@ -228,6 +228,23 @@ function parseSingleCommand(command: string, line: number, knownCommands?: reado
   };
 }
 
+function findKnownCommand(
+  tokens: string[],
+  fromIndex: number,
+  knownSet: Set<string>,
+): { methodParts: string[]; nextIndex: number } | null {
+  for (let end = tokens.length; end > fromIndex; end--) {
+    const candidateTokens = tokens.slice(fromIndex, end);
+    if (candidateTokens.some((token) => token === '--' || token.startsWith('-'))) {
+      continue;
+    }
+    if (knownSet.has(candidateTokens.join(' '))) {
+      return { methodParts: candidateTokens, nextIndex: end };
+    }
+  }
+  return null;
+}
+
 function resolveMethod(
   tokens: string[],
   startIndex: number,
@@ -235,17 +252,13 @@ function resolveMethod(
 ): { methodParts: string[]; nextIndex: number } {
   if (knownCommands && knownCommands.length > 0) {
     const knownSet = new Set(knownCommands.map((command) => command.trim()).filter(Boolean));
-    for (let end = tokens.length; end > startIndex; end--) {
-      const candidateTokens = tokens.slice(startIndex, end);
-      if (candidateTokens.some((token) => token === '--' || token.startsWith('-'))) {
-        continue;
-      }
 
-      const candidate = candidateTokens.join(' ');
-      if (knownSet.has(candidate)) {
-        return { methodParts: candidateTokens, nextIndex: end };
-      }
-    }
+    // Try matching from startIndex first, then skip one token (the executable name, e.g. "fast")
+    const match =
+      findKnownCommand(tokens, startIndex, knownSet) ??
+      (startIndex + 1 < tokens.length ? findKnownCommand(tokens, startIndex + 1, knownSet) : null);
+
+    if (match) return match;
   }
 
   const executable = tokens[startIndex];

--- a/src/benchmark/init.ts
+++ b/src/benchmark/init.ts
@@ -1,15 +1,21 @@
-import { writeFileSync, existsSync } from 'node:fs';
+import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 /**
  * Scaffold benchmark config, tasks, and example tools for a new project.
+ * All files are written into a `skill-optimizer/` subdirectory so they
+ * don't clutter the project root.
  */
 export function initBenchmark(targetDir: string = process.cwd()): void {
-  const configPath = resolve(targetDir, 'skill-optimizer.json');
-  const tasksPath = resolve(targetDir, 'tasks.json');
-  const toolsPath = resolve(targetDir, 'tools.json');
+  const configDir = resolve(targetDir, 'skill-optimizer');
+  mkdirSync(configDir, { recursive: true });
+
+  const configPath = resolve(configDir, 'skill-optimizer.json');
+  const tasksPath = resolve(configDir, 'tasks.json');
+  const toolsPath = resolve(configDir, 'tools.json');
 
   // skill-optimizer.json
+  // Paths use "../" because this config lives one level below the project root.
   if (existsSync(configPath)) {
     console.log(`[init] Skipping ${configPath} (already exists)`);
   } else {
@@ -17,11 +23,11 @@ export function initBenchmark(targetDir: string = process.cwd()): void {
       name: "my-sdk",
       target: {
         surface: "sdk",
-        repoPath: ".",
-        skill: "./SKILL.md",
+        repoPath: "..",
+        skill: "../SKILL.md",
         discovery: {
           mode: "auto",
-          sources: ["./src/index.ts"]
+          sources: ["../src/index.ts"]
         },
         sdk: {
           language: "typescript",
@@ -42,14 +48,14 @@ export function initBenchmark(targetDir: string = process.cwd()): void {
           { id: "openrouter/anthropic/claude-sonnet-4.6", name: "Claude Sonnet 4.6", tier: "mid" }
         ],
         output: {
-          dir: "./benchmark-results"
+          dir: "../benchmark-results"
         }
       },
       optimize: {
         enabled: false,
         model: "openrouter/openai/gpt-5.4",
         apiKeyEnv: "OPENROUTER_API_KEY",
-        allowedPaths: ["SKILL.md"],
+        allowedPaths: ["../SKILL.md"],
         validation: []
       }
     };
@@ -132,8 +138,8 @@ export function initBenchmark(targetDir: string = process.cwd()): void {
   }
 
   console.log('\n[init] Done! Next steps:');
-  console.log('  1. Edit skill-optimizer.json with your surface (sdk/cli/mcp) details');
+  console.log('  1. Edit skill-optimizer/skill-optimizer.json with your surface (sdk/cli/mcp) details');
   console.log('     For SDK benchmarks, set sdk.language to typescript, python, or rust.');
-  console.log('  2. Edit tasks.json with your test cases');
-  console.log('  3. Run: npx skill-optimizer run');
+  console.log('  2. Edit skill-optimizer/tasks.json with your test cases');
+  console.log('  3. Run: npx tsx src/cli.ts run --config ./skill-optimizer/skill-optimizer.json');
 }

--- a/src/benchmark/init.ts
+++ b/src/benchmark/init.ts
@@ -2,144 +2,207 @@ import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 /**
- * Scaffold benchmark config, tasks, and example tools for a new project.
+ * Scaffold benchmark config and surface-specific files for a new project.
  * All files are written into a `skill-optimizer/` subdirectory so they
  * don't clutter the project root.
+ *
+ * - sdk: creates skill-optimizer.json only (code-first discovery via sources)
+ * - cli: creates skill-optimizer.json + cli-commands.json manifest template
+ * - mcp: creates skill-optimizer.json + tools.json manifest template
+ *
+ * Tasks are never scaffolded — task generation (benchmark.taskGeneration.enabled)
+ * handles them automatically at run time.
  */
-export function initBenchmark(targetDir: string = process.cwd()): void {
+export function initBenchmark(targetDir: string = process.cwd(), surface: 'sdk' | 'cli' | 'mcp' = 'sdk'): void {
   const configDir = resolve(targetDir, 'skill-optimizer');
   mkdirSync(configDir, { recursive: true });
 
   const configPath = resolve(configDir, 'skill-optimizer.json');
-  const tasksPath = resolve(configDir, 'tasks.json');
-  const toolsPath = resolve(configDir, 'tools.json');
 
-  // skill-optimizer.json
+  // ── skill-optimizer.json ─────────────────────────────────────────────────
   // Paths use "../" because this config lives one level below the project root.
   if (existsSync(configPath)) {
     console.log(`[init] Skipping ${configPath} (already exists)`);
   } else {
-    const config = {
-      name: "my-sdk",
-      target: {
-        surface: "sdk",
-        repoPath: "..",
-        skill: "../SKILL.md",
-        discovery: {
-          mode: "auto",
-          sources: ["../src/index.ts"]
-        },
-        sdk: {
-          language: "typescript",
-          apiSurface: [
-            "MyClient.constructor",
-            "MyClient.getData",
-            "MyClient.sendData"
-          ]
-        }
-      },
-      benchmark: {
-        tasks: "./tasks.json",
-        apiKeyEnv: "OPENROUTER_API_KEY",
-        format: "pi",
-        timeout: 240000,
-        models: [
-          { id: "openrouter/openai/gpt-5.4", name: "GPT-5.4", tier: "flagship" },
-          { id: "openrouter/anthropic/claude-sonnet-4.6", name: "Claude Sonnet 4.6", tier: "mid" }
-        ],
-        output: {
-          dir: "../benchmark-results"
-        }
-      },
-      optimize: {
-        enabled: false,
-        model: "openrouter/openai/gpt-5.4",
-        apiKeyEnv: "OPENROUTER_API_KEY",
-        allowedPaths: ["../SKILL.md"],
-        validation: []
-      }
-    };
+    const config = buildConfig(surface);
     writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
     console.log(`[init] Created ${configPath}`);
   }
 
-  // tasks.json
-  if (existsSync(tasksPath)) {
-    console.log(`[init] Skipping ${tasksPath} (already exists)`);
-  } else {
-    const tasks = {
-      tasks: [
+  // ── Surface-specific companion files ─────────────────────────────────────
+  if (surface === 'cli') {
+    const commandsPath = resolve(configDir, 'cli-commands.json');
+    if (existsSync(commandsPath)) {
+      console.log(`[init] Skipping ${commandsPath} (already exists)`);
+    } else {
+      const commands = [
         {
-          id: "example-create",
-          prompt: "Create a new MyClient instance connected to the test environment.",
-          expected_actions: [
-            { name: "MyClient.constructor" }
-          ]
+          command: 'example-create',
+          description: 'Create a new item',
+          options: [
+            { name: '--name', takesValue: true, description: 'Name for the item' },
+          ],
         },
         {
-          id: "example-get-data",
-          prompt: "Get data for item 'abc123' using the client.",
-          expected_actions: [
-            { name: "MyClient.constructor" },
-            { name: "MyClient.getData", args: { "_positional_0": "abc123" } }
-          ]
+          command: 'example-list',
+          description: 'List all items',
+          options: [
+            { name: '--format', takesValue: true, description: 'Output format: json | table (default: table)' },
+          ],
+        },
+      ];
+      writeFileSync(commandsPath, JSON.stringify(commands, null, 2) + '\n', 'utf-8');
+      console.log(`[init] Created ${commandsPath}`);
+    }
+  }
+
+  if (surface === 'mcp') {
+    const toolsPath = resolve(configDir, 'tools.json');
+    if (existsSync(toolsPath)) {
+      console.log(`[init] Skipping ${toolsPath} (already exists)`);
+    } else {
+      const tools = [
+        {
+          type: 'function',
+          function: {
+            name: 'get_data',
+            description: 'Get data for a given item ID',
+            parameters: {
+              type: 'object',
+              properties: {
+                item_id: { type: 'string', description: 'The item identifier' },
+              },
+              required: ['item_id'],
+            },
+          },
         },
         {
-          id: "example-send-data",
-          prompt: "Send data with value 'hello' to recipient 'user1'.",
-          expected_actions: [
-            { name: "MyClient.constructor" },
-            { name: "MyClient.sendData", args: { value: "hello", recipient: "user1" } }
-          ]
-        }
-      ]
-    };
-    writeFileSync(tasksPath, JSON.stringify(tasks, null, 2) + '\n', 'utf-8');
-    console.log(`[init] Created ${tasksPath}`);
+          type: 'function',
+          function: {
+            name: 'send_data',
+            description: 'Send data to a recipient',
+            parameters: {
+              type: 'object',
+              properties: {
+                value: { type: 'string', description: 'The data to send' },
+                recipient: { type: 'string', description: 'The recipient identifier' },
+              },
+              required: ['value', 'recipient'],
+            },
+          },
+        },
+      ];
+      writeFileSync(toolsPath, JSON.stringify(tools, null, 2) + '\n', 'utf-8');
+      console.log(`[init] Created ${toolsPath}`);
+    }
   }
 
-  // tools.json (MCP surface example)
-  if (existsSync(toolsPath)) {
-    console.log(`[init] Skipping ${toolsPath} (already exists)`);
-  } else {
-    const tools = [
-      {
-        type: "function",
-        function: {
-          name: "get_data",
-          description: "Get data for a given item ID",
-          parameters: {
-            type: "object",
-            properties: {
-              item_id: { type: "string", description: "The item identifier" }
-            },
-            required: ["item_id"]
-          }
-        }
-      },
-      {
-        type: "function",
-        function: {
-          name: "send_data",
-          description: "Send data to a recipient",
-          parameters: {
-            type: "object",
-            properties: {
-              value: { type: "string", description: "The data to send" },
-              recipient: { type: "string", description: "The recipient identifier" }
-            },
-            required: ["value", "recipient"]
-          }
-        }
-      }
-    ];
-    writeFileSync(toolsPath, JSON.stringify(tools, null, 2) + '\n', 'utf-8');
-    console.log(`[init] Created ${toolsPath} (MCP surface example)`);
-  }
-
+  // ── Next steps ────────────────────────────────────────────────────────────
   console.log('\n[init] Done! Next steps:');
-  console.log('  1. Edit skill-optimizer/skill-optimizer.json with your surface (sdk/cli/mcp) details');
-  console.log('     For SDK benchmarks, set sdk.language to typescript, python, or rust.');
-  console.log('  2. Edit skill-optimizer/tasks.json with your test cases');
-  console.log('  3. Run: npx tsx src/cli.ts run --config ./skill-optimizer/skill-optimizer.json');
+  console.log('  1. Edit skill-optimizer/skill-optimizer.json:');
+  console.log('       target.repoPath  → path to your repo');
+  console.log('       target.skill     → path to your SKILL.md');
+
+  if (surface === 'sdk') {
+    console.log('       target.discovery.sources → entry file(s) for SDK discovery');
+  } else if (surface === 'cli') {
+    console.log('       target.discovery.sources → CLI entry file (for code-first discovery)');
+    console.log('       skill-optimizer/cli-commands.json → replace example commands with your real commands');
+    console.log('       (cli-commands.json is used as a fallback if code-first discovery finds nothing)');
+  } else {
+    console.log('       target.discovery.sources → MCP server file (for code-first discovery)');
+    console.log('       skill-optimizer/tools.json → replace example tools with your real tools');
+    console.log('       (tools.json is used as a fallback if code-first discovery finds nothing)');
+  }
+
+  console.log('       benchmark.models → update with real OpenRouter model IDs');
+  console.log('  2. Run: npx tsx src/cli.ts run --config ./skill-optimizer/skill-optimizer.json');
+}
+
+function buildConfig(surface: 'sdk' | 'cli' | 'mcp'): object {
+  const commonBenchmark = {
+    apiKeyEnv: 'OPENROUTER_API_KEY',
+    format: 'pi',
+    timeout: 240000,
+    taskGeneration: {
+      enabled: true,
+      maxTasks: 20,
+      outputDir: './.skill-optimizer',
+    },
+    models: [
+      { id: 'openrouter/openai/gpt-4o', name: 'GPT-4o', tier: 'flagship' },
+      { id: 'openrouter/google/gemini-2.0-flash-001', name: 'Gemini 2.0 Flash', tier: 'mid' },
+    ],
+    output: {
+      dir: '../benchmark-results',
+    },
+    verdict: {
+      perModelFloor: 0.6,
+      targetWeightedAverage: 0.7,
+    },
+  };
+
+  const commonOptimize = {
+    model: 'openrouter/anthropic/claude-sonnet-4-6',
+    apiKeyEnv: 'OPENROUTER_API_KEY',
+    allowedPaths: ['../SKILL.md'],
+    validation: [],
+    maxIterations: 5,
+  };
+
+  if (surface === 'sdk') {
+    return {
+      name: 'my-sdk',
+      target: {
+        surface: 'sdk',
+        repoPath: '..',
+        skill: '../SKILL.md',
+        discovery: {
+          mode: 'auto',
+          sources: ['../src/index.ts'],
+        },
+      },
+      benchmark: commonBenchmark,
+      optimize: commonOptimize,
+    };
+  }
+
+  if (surface === 'cli') {
+    return {
+      name: 'my-cli',
+      target: {
+        surface: 'cli',
+        repoPath: '..',
+        skill: '../SKILL.md',
+        discovery: {
+          mode: 'auto',
+          sources: ['../src/cli.ts'],
+        },
+        cli: {
+          commands: './cli-commands.json',
+        },
+      },
+      benchmark: commonBenchmark,
+      optimize: commonOptimize,
+    };
+  }
+
+  // mcp
+  return {
+    name: 'my-mcp',
+    target: {
+      surface: 'mcp',
+      repoPath: '..',
+      skill: '../SKILL.md',
+      discovery: {
+        mode: 'auto',
+        sources: ['../src/server.ts'],
+      },
+      mcp: {
+        tools: './tools.json',
+      },
+    },
+    benchmark: commonBenchmark,
+    optimize: commonOptimize,
+  };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -94,7 +94,7 @@ function printUsage(): void {
 Skill Optimizer CLI — Benchmark and optimize SDK/CLI/MCP guidance
 
 Usage:
-  skill-optimizer init                          Scaffold config and example tasks
+  skill-optimizer init <sdk|cli|mcp>            Scaffold config for the given surface type
   skill-optimizer generate-tasks [options]      Generate and freeze tasks from discovered surface
   skill-optimizer benchmark [options]           Run the benchmark
   skill-optimizer run [options]                 Run the benchmark
@@ -125,7 +125,9 @@ Compare options:
   --current <path>                              Path to current report.json
 
 Examples:
-  skill-optimizer init
+  skill-optimizer init cli
+  skill-optimizer init sdk
+  skill-optimizer init mcp
   skill-optimizer --dry-run --config ./skill-optimizer.json
   skill-optimizer benchmark --config ./skill-optimizer.json
   skill-optimizer run
@@ -192,7 +194,16 @@ async function main(): Promise<void> {
 
   // ── Init mode ────────────────────────────────────────────────────────────────
   if (command === 'init') {
-    initBenchmark();
+    const surface = pos[1];
+    if (!surface || !['sdk', 'cli', 'mcp'].includes(surface)) {
+      console.error('Usage: skill-optimizer init <surface>');
+      console.error('');
+      console.error('  sdk  — TypeScript / Python / Rust library');
+      console.error('  cli  — command-line tool with subcommands');
+      console.error('  mcp  — MCP server with tools');
+      process.exit(1);
+    }
+    initBenchmark(process.cwd(), surface as 'sdk' | 'cli' | 'mcp');
     process.exit(0);
   }
 

--- a/src/optimizer/loop.ts
+++ b/src/optimizer/loop.ts
@@ -355,8 +355,9 @@ function summarizeTopFailures(report: BenchmarkReport, limit = 3): string[] {
 }
 
 function validateChangedFiles(changedFiles: string[], manifest: ResolvedOptimizeManifest) {
+  const repoRoot = manifest.targetRepo.path;
   const disallowedFiles = changedFiles.filter(
-    (file) => !isFrameworkArtifactPath(file, manifest) && !isAllowedPath(file, manifest.targetRepo.allowedPaths),
+    (file) => !isFrameworkArtifactPath(file, manifest) && !isAllowedPath(file, manifest.targetRepo.allowedPaths, repoRoot),
   );
   if (disallowedFiles.length === 0) {
     return null;
@@ -397,8 +398,11 @@ function toRelativeTargetPath(path: string, manifest: ResolvedOptimizeManifest):
   return path;
 }
 
-function isAllowedPath(file: string, allowedPaths: string[]): boolean {
-  const normalizedFile = normalizeRelativePath(file);
+function isAllowedPath(file: string, allowedPaths: string[], repoRoot?: string): boolean {
+  // Resolve relative changed file against the repo root so it can be compared
+  // with absolute allowedPaths entries (and vice versa).
+  const absoluteFile = repoRoot && !file.startsWith('/') ? `${repoRoot}/${file}` : file;
+  const normalizedFile = normalizeRelativePath(absoluteFile);
   return allowedPaths.some((allowedPath) => {
     const normalizedAllowed = normalizeRelativePath(allowedPath);
     return normalizedFile === normalizedAllowed || normalizedFile.startsWith(`${normalizedAllowed}/`);

--- a/src/optimizer/loop.ts
+++ b/src/optimizer/loop.ts
@@ -1,5 +1,5 @@
-import { mkdirSync } from 'node:fs';
-import { relative, resolve } from 'node:path';
+import { existsSync, mkdirSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
 
 import { analyzeFailures } from './failure-analysis.js';
 import { accept } from '../benchmark/scoring.js';
@@ -42,6 +42,13 @@ export async function runOptimizeLoop(
       `[optimize] Using generated benchmark config: ${generation.benchmarkConfigPath} ` +
         `(tasks=${generation.taskCount}, rejected=${generation.rejectedCount})`,
     );
+  } else {
+    // Task generation disabled (e.g. --skip-generation). Try to reuse existing frozen benchmark config.
+    const frozenConfigPath = join(outputDir, 'benchmark.generated.json');
+    if (existsSync(frozenConfigPath)) {
+      resolvedManifest.benchmarkConfig = frozenConfigPath;
+      console.log(`[optimize] Using existing frozen benchmark config: ${frozenConfigPath}`);
+    }
   }
   if (resolvedManifest.optimizer.mode === 'surface-changing' && !resolvedManifest.optimizer.taskGeneration.enabled) {
     throw new Error('surface-changing optimize mode requires task generation to stay enabled so new epochs can regenerate tasks');

--- a/src/optimizer/mock-repos.ts
+++ b/src/optimizer/mock-repos.ts
@@ -6,7 +6,7 @@ import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
 
-const MOCK_REPO_NAMES = ['sdk-demo', 'cli-demo', 'mcp-demo', 'mcp-tracker-demo', 'sdk-counter-demo'] as const;
+const MOCK_REPO_NAMES = ['sdk-demo', 'cli-demo', 'mcp-demo', 'mcp-tracker-demo', 'sdk-counter-demo', 'cli-taskfile-demo'] as const;
 
 export type MockRepoName = (typeof MOCK_REPO_NAMES)[number];
 

--- a/src/tasks/generate.ts
+++ b/src/tasks/generate.ts
@@ -117,14 +117,15 @@ function validateTask(task: unknown, index: number): GeneratedTask {
     throw new Error(`Task ${taskId} must match ${SAFE_TASK_ID.toString()} and cannot be . or ..`);
   }
 
-  const rawExpectedActions = Array.isArray(candidate.expected_actions)
-    ? candidate.expected_actions
-    : Array.isArray(candidate.expected_tools)
-      ? candidate.expected_tools
-      : null;
+  const rawExpectedActions = (
+    ['expected_actions', 'expected_tools', 'actions', 'steps', 'calls', 'expected_calls', 'tool_calls'] as const
+  )
+    .map((key) => candidate[key])
+    .find((v) => Array.isArray(v)) as unknown[] | undefined;
 
   if (!rawExpectedActions) {
-    throw new Error(`Task ${taskId} must include an expected_actions array`);
+    const received = JSON.stringify(Object.keys(candidate));
+    throw new Error(`Task ${taskId} must include an expected_actions array (received keys: ${received})`);
   }
 
   const expected_actions = rawExpectedActions.map((action, actionIndex) => validateExpectedAction(taskId, action, actionIndex));

--- a/src/tasks/generate.ts
+++ b/src/tasks/generate.ts
@@ -60,10 +60,16 @@ function buildPrompt(surface: DiscoveredTaskSurface, config: TaskGeneratorConfig
   ].join('\n');
 }
 
+function stripCodeFence(raw: string): string {
+  const trimmed = raw.trim();
+  const match = trimmed.match(/^```(?:json)?\s*\n([\s\S]*?)\n```\s*$/);
+  return match ? match[1].trim() : trimmed;
+}
+
 function parseGeneratedTasks(raw: string): GeneratedTask[] {
   let parsed: unknown;
   try {
-    parsed = JSON.parse(raw);
+    parsed = JSON.parse(stripCodeFence(raw));
   } catch (error) {
     throw new Error(`Task generator returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`);
   }

--- a/src/tasks/generate.ts
+++ b/src/tasks/generate.ts
@@ -86,26 +86,33 @@ function parseGeneratedTasks(raw: string): GeneratedTask[] {
   return tasks.map((task, index) => validateTask(task, index));
 }
 
+function resolveStringField(obj: Record<string, unknown>, ...keys: string[]): string | null {
+  for (const key of keys) {
+    if (typeof obj[key] === 'string' && (obj[key] as string).trim() !== '') {
+      return (obj[key] as string).trim();
+    }
+  }
+  return null;
+}
+
 function validateTask(task: unknown, index: number): GeneratedTask {
   if (!task || typeof task !== 'object') {
     throw new Error(`Task at index ${index} must be an object`);
   }
 
-  const candidate = task as {
-    id?: unknown;
-    prompt?: unknown;
-    expected_actions?: unknown;
-    expected_tools?: unknown;
-  };
+  const candidate = task as Record<string, unknown>;
 
-  if (typeof candidate.id !== 'string' || candidate.id.trim() === '') {
-    throw new Error(`Task at index ${index} must include a non-empty string id`);
+  const taskId = resolveStringField(candidate, 'id', 'task_id', 'taskId', 'name');
+  if (!taskId) {
+    const received = JSON.stringify(Object.keys(candidate));
+    throw new Error(`Task at index ${index} must include a non-empty string id (received keys: ${received})`);
   }
-  if (typeof candidate.prompt !== 'string' || candidate.prompt.trim() === '') {
-    throw new Error(`Task ${candidate.id} must include a non-empty string prompt`);
+
+  const taskPrompt = resolveStringField(candidate, 'prompt', 'description', 'instruction', 'task');
+  if (!taskPrompt) {
+    const received = JSON.stringify(Object.keys(candidate));
+    throw new Error(`Task ${taskId} must include a non-empty string prompt (received keys: ${received})`);
   }
-  const taskId = candidate.id;
-  const taskPrompt = candidate.prompt;
   if (!isSafeTaskId(taskId)) {
     throw new Error(`Task ${taskId} must match ${SAFE_TASK_ID.toString()} and cannot be . or ..`);
   }

--- a/src/tasks/generate.ts
+++ b/src/tasks/generate.ts
@@ -34,19 +34,25 @@ function buildPrompt(surface: DiscoveredTaskSurface, config: TaskGeneratorConfig
   return [
     `Generate benchmark tasks for a ${surface.snapshot.surface} callable surface.`,
     '',
-    'Return JSON only. The top-level shape must be:',
+    'Return a JSON object with EXACTLY this shape and no other keys:',
     '{"tasks":[{"id":"string","prompt":"string","expected_actions":[{"name":"string","args":{"key":"value"}}]}]}',
+    '',
+    'STRICT SCHEMA RULES - violations cause test failures:',
+    '- Each task object has EXACTLY three keys: id, prompt, expected_actions.',
+    '- Do NOT add keys like: cli_command, instruction, action, description, expected_outcome, expected_args, source, steps, calls.',
+    '- expected_actions is an ARRAY of objects, each with exactly two keys: name and args.',
+    '- name is the action name string (e.g. "account create", "network list").',
+    '- args is a flat object of key-value argument pairs (e.g. {"name": "my-wallet"}).',
     '',
     `Task count limit: produce at most ${clampedMax} tasks.`,
     `Seed for deterministic variety: ${config.seed}.`,
     'Variety requirement: include a mix of simple, medium, and multi-step tasks using different actions and argument combinations.',
     '',
-    'Critical rules:',
+    'Additional rules:',
     '1) Use ONLY action names that exist in the provided discovered surface snapshot.',
     '2) For each expected_actions entry, args keys MUST match discovered action argument names.',
     '3) Include required params in args when an action marks them as required.',
     '4) expected_actions must never be empty.',
-    '5) Do not include any keys beyond id, prompt, expected_actions at task level; and name, args at expected_actions level.',
     '',
     'Full SKILL.md:',
     '---BEGIN SKILL---',
@@ -117,11 +123,20 @@ function validateTask(task: unknown, index: number): GeneratedTask {
     throw new Error(`Task ${taskId} must match ${SAFE_TASK_ID.toString()} and cannot be . or ..`);
   }
 
-  const rawExpectedActions = (
-    ['expected_actions', 'expected_tools', 'actions', 'steps', 'calls', 'expected_calls', 'tool_calls'] as const
+  let rawExpectedActions = (
+    ['expected_actions', 'expected_tools', 'actions', 'steps', 'calls', 'expected_calls', 'tool_calls', 'cli_command'] as const
   )
     .map((key) => candidate[key])
     .find((v) => Array.isArray(v)) as unknown[] | undefined;
+
+  // Fallback: model returned a single action at task level (e.g. {action:"send", args:{...}})
+  if (!rawExpectedActions) {
+    const actionName = typeof candidate['action'] === 'string' ? candidate['action'] :
+                       typeof candidate['method'] === 'string' ? candidate['method'] : null;
+    if (actionName && actionName.trim()) {
+      rawExpectedActions = [{ name: actionName.trim(), args: candidate['args'] }];
+    }
+  }
 
   if (!rawExpectedActions) {
     const received = JSON.stringify(Object.keys(candidate));

--- a/tests/smoke-code.ts
+++ b/tests/smoke-code.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -298,21 +298,57 @@ await test('extract factory dispatches surface=sdk', async () => {
   assertEqual(calls[0].method, 'FastProvider.constructor', 'method should be parsed');
 });
 
-await test('initBenchmark scaffolds sdk apiSurface', () => {
+await test('initBenchmark sdk: creates skill-optimizer.json with task generation enabled', () => {
   const dir = mkdtempSync(join(tmpdir(), 'skill-optimizer-init-'));
   try {
-    initBenchmark(dir);
+    initBenchmark(dir, 'sdk');
     const config = JSON.parse(readFileSync(join(dir, 'skill-optimizer', 'skill-optimizer.json'), 'utf-8')) as {
-      target: {
-        surface: string;
-        sdk: { apiSurface?: string[]; methods?: string[] };
-      };
+      target: { surface: string };
+      benchmark: { taskGeneration?: { enabled?: boolean }; tasks?: string };
     };
+    assertEqual(config.target.surface, 'sdk', 'sdk scaffold should emit sdk surface');
+    assert(config.benchmark.taskGeneration?.enabled === true, 'scaffold should enable task generation');
+    assert(!config.benchmark.tasks, 'scaffold should not set benchmark.tasks when task generation is on');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
-    assertEqual(config.target.surface, 'sdk', 'scaffold should default to sdk surface');
-    assert(Array.isArray(config.target.sdk.apiSurface), 'scaffold should emit sdk.apiSurface');
-    assert(config.target.sdk.apiSurface!.length > 0, 'scaffold apiSurface should contain entries');
-    assertEqual(config.target.sdk.methods, undefined, 'scaffold should not emit deprecated sdk.methods');
+await test('initBenchmark cli: creates cli-commands.json and sets target.cli.commands', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'skill-optimizer-init-'));
+  try {
+    initBenchmark(dir, 'cli');
+    const configPath = join(dir, 'skill-optimizer', 'skill-optimizer.json');
+    const commandsPath = join(dir, 'skill-optimizer', 'cli-commands.json');
+    const config = JSON.parse(readFileSync(configPath, 'utf-8')) as {
+      target: { surface: string; cli?: { commands?: string } };
+      benchmark: { taskGeneration?: { enabled?: boolean }; tasks?: string };
+    };
+    assertEqual(config.target.surface, 'cli', 'cli scaffold should emit cli surface');
+    assert(existsSync(commandsPath), 'cli scaffold should create cli-commands.json');
+    assert(typeof config.target.cli?.commands === 'string', 'cli scaffold should set target.cli.commands');
+    assert(config.benchmark.taskGeneration?.enabled === true, 'cli scaffold should enable task generation');
+    assert(!config.benchmark.tasks, 'cli scaffold should not set benchmark.tasks');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+await test('initBenchmark mcp: creates tools.json and sets target.mcp.tools', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'skill-optimizer-init-'));
+  try {
+    initBenchmark(dir, 'mcp');
+    const configPath = join(dir, 'skill-optimizer', 'skill-optimizer.json');
+    const toolsPath = join(dir, 'skill-optimizer', 'tools.json');
+    const config = JSON.parse(readFileSync(configPath, 'utf-8')) as {
+      target: { surface: string; mcp?: { tools?: string } };
+      benchmark: { taskGeneration?: { enabled?: boolean }; tasks?: string };
+    };
+    assertEqual(config.target.surface, 'mcp', 'mcp scaffold should emit mcp surface');
+    assert(existsSync(toolsPath), 'mcp scaffold should create tools.json');
+    assert(typeof config.target.mcp?.tools === 'string', 'mcp scaffold should set target.mcp.tools');
+    assert(config.benchmark.taskGeneration?.enabled === true, 'mcp scaffold should enable task generation');
+    assert(!config.benchmark.tasks, 'mcp scaffold should not set benchmark.tasks');
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/smoke-code.ts
+++ b/tests/smoke-code.ts
@@ -302,7 +302,7 @@ await test('initBenchmark scaffolds sdk apiSurface', () => {
   const dir = mkdtempSync(join(tmpdir(), 'skill-optimizer-init-'));
   try {
     initBenchmark(dir);
-    const config = JSON.parse(readFileSync(join(dir, 'skill-optimizer.json'), 'utf-8')) as {
+    const config = JSON.parse(readFileSync(join(dir, 'skill-optimizer', 'skill-optimizer.json'), 'utf-8')) as {
       target: {
         surface: string;
         sdk: { apiSurface?: string[]; methods?: string[] };

--- a/tests/smoke-mock-repos.ts
+++ b/tests/smoke-mock-repos.ts
@@ -40,6 +40,7 @@ await test('listMockRepoTemplates: exposes tracked templates that exist in the w
   assert(templates.length >= 1, 'should expose at least one template');
   assert(templates.includes('mcp-tracker-demo'), 'should include mcp-tracker-demo');
   assert(templates.includes('sdk-counter-demo'), 'should include sdk-counter-demo');
+  assert(templates.includes('cli-taskfile-demo'), 'should include cli-taskfile-demo');
 });
 
 for (const name of listMockRepoTemplates()) {
@@ -89,6 +90,19 @@ for (const name of listMockRepoTemplates()) {
         assert(typeof projectConfigRaw.benchmark?.verdict?.perModelFloor === 'number', 'sdk-counter-demo should define verdict.perModelFloor');
         assert(existsSync(join(materializedPath, 'SKILL.md')), 'sdk-counter-demo should include SKILL.md');
         assert(existsSync(join(materializedPath, 'src', 'counter.ts')), 'sdk-counter-demo should include src/counter.ts');
+      }
+
+      if (name === 'cli-taskfile-demo') {
+        assertEqual(benchmarkConfig.surface, 'cli', 'cli-taskfile-demo should materialize a CLI benchmark');
+        const projectConfigRaw = JSON.parse(readFileSync(projectConfigPath, 'utf-8')) as {
+          target?: { surface?: string; scope?: { include?: string[] } };
+          benchmark?: { verdict?: { perModelFloor?: number } };
+        };
+        assert(projectConfigRaw.target?.surface === 'cli', 'cli-taskfile-demo should have cli surface');
+        assert(Array.isArray(projectConfigRaw.target?.scope?.include), 'cli-taskfile-demo should define scope.include');
+        assert(typeof projectConfigRaw.benchmark?.verdict?.perModelFloor === 'number', 'cli-taskfile-demo should define verdict.perModelFloor');
+        assert(existsSync(join(materializedPath, 'SKILL.md')), 'cli-taskfile-demo should include SKILL.md');
+        assert(existsSync(join(materializedPath, 'src', 'commands.ts')), 'cli-taskfile-demo should include src/commands.ts');
       }
     } finally {
       rmSync(destRoot, { recursive: true, force: true });

--- a/tests/smoke-release.ts
+++ b/tests/smoke-release.ts
@@ -53,6 +53,7 @@ await test('repo includes a root LICENSE file', () => {
 await test('mock-repos README matches the tracked templates', () => {
   const readme = readFileSync(join(process.cwd(), 'mock-repos', 'README.md'), 'utf-8');
   assert(readme.includes('mcp-tracker-demo'), 'mock-repos README should mention mcp-tracker-demo');
+  assert(readme.includes('cli-taskfile-demo'), 'mock-repos README should mention cli-taskfile-demo');
   assert(!readme.includes('sdk-demo'), 'mock-repos README should not mention removed sdk-demo template');
   assert(!readme.includes('cli-demo'), 'mock-repos README should not mention removed cli-demo template');
   assert(!readme.includes('mcp-demo'), 'mock-repos README should not mention removed mcp-demo template');


### PR DESCRIPTION
## Summary

Bug fixes and init improvements discovered during a real optimizer run against fast-cli. Clean cherry-pick of 9 commits onto main.

- `feat(init)`: writes config to `skill-optimizer/` subfolder; adds `cli-taskfile-demo` mock repo
- `feat(init)`: surface-aware scaffolding; adds `.skill-optimizer/` and `docs/superpowers/` to `.gitignore`
- `fix(tasks)`: strip markdown code fence before parsing generated tasks
- `fix(tasks)`: handle common LLM field name variations in generated task parser
- `fix(tasks)`: extend `expected_actions` aliases to cover `actions/steps/calls` variants
- `fix(extractor)`: skip executable prefix when matching known CLI commands
- `fix(eval)`: positional arg fallback, shell keyword stripping, skip-gen frozen config reuse
- `fix(optimizer)`: **critical** — resolve relative changed files against repo root for `allowedPaths` check (without this, every optimizer mutation is silently rolled back)
- `chore(gitignore)`: ignore local user config files (`skill-optimizer.json`, `cli-commands.json`, `tools.json`, `tasks.json`)

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm test` passes
- [ ] `skill-optimizer init cli` creates `skill-optimizer/` subfolder with correct config
- [ ] Optimizer run against a target repo accepts mutations instead of silently rolling them back

🤖 Generated with [Claude Code](https://claude.com/claude-code)