### PR TITLE
feat(doctor): add doctor command, checkConfig Issue[], and --fix for DX phase 1

### DIFF
--- a/src/benchmark/config.ts
+++ b/src/benchmark/config.ts
@@ -21,8 +21,8 @@ function isSafeTaskId(taskId: string): boolean {
  * Load benchmark config from the given path or search for benchmark.config.json
  * in the current working directory.
  */
-export function loadConfig(configPath?: string): { config: BenchmarkConfig; configDir: string } {
-  const project = loadProjectConfig(configPath ?? DEFAULT_CONFIG_NAME);
+export async function loadConfig(configPath?: string): Promise<{ config: BenchmarkConfig; configDir: string }> {
+  const project = await loadProjectConfig(configPath ?? DEFAULT_CONFIG_NAME);
   return {
     config: toBenchmarkConfig(project),
     configDir: project.configDir,

--- a/src/benchmark/runner.ts
+++ b/src/benchmark/runner.ts
@@ -102,7 +102,7 @@ export interface RunnerOptions {
  */
 export async function runBenchmark(options: RunnerOptions = {}): Promise<BenchmarkReport> {
   // 1. Load config
-  const { config, configDir } = loadConfig(options.configPath);
+  const { config, configDir } = await loadConfig(options.configPath);
 
   console.log('================================================================');
   console.log(`  Skill Benchmark — ${config.name}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ import { printCoverage } from './benchmark/coverage.js';
 import { initBenchmark } from './benchmark/init.js';
 import { printOptimizeSummary, runOptimizeFromConfig } from './optimizer/main.js';
 import { DEFAULT_PROJECT_CONFIG_NAME, loadProjectConfig, parseModelRef } from './project/index.js';
+import { runDoctor } from './doctor/index.js';
 import { createDefaultPiTaskGenerator, generateTasksForProject, createDefaultPiCritic, discoverActionsOnly, resolveScope } from './tasks/index.js';
 import type { Recommendation } from './verdict/recommendations.js';
 import { generateRecommendations } from './verdict/recommendations.js';
@@ -47,6 +48,9 @@ const BOOLEAN_FLAGS = new Set([
   '--dry-run',
   '--no-cache',
   '--skip-generation',
+  '--check-models',
+  '--fix',
+  '--static',
 ]);
 
 const VALUE_FLAGS = new Set([
@@ -95,6 +99,7 @@ Skill Optimizer CLI — Benchmark and optimize SDK/CLI/MCP guidance
 
 Usage:
   skill-optimizer init <sdk|cli|mcp>            Scaffold config for the given surface type
+  skill-optimizer doctor [options]              Validate config pre-flight
   skill-optimizer generate-tasks [options]      Generate and freeze tasks from discovered surface
   skill-optimizer benchmark [options]           Run the benchmark
   skill-optimizer run [options]                 Run the benchmark
@@ -104,6 +109,12 @@ Usage:
 Global options:
   --dry-run                                     Discover + scope preview only; no LLM calls, no side effects
   --config <path>                               Config file (overrides per-command default)
+
+Doctor options:
+  --config <path>                               Config file (default: skill-optimizer.json)
+  --static                                      Run tier-1 structural checks only (no discovery)
+  --check-models                                Also ping each model for reachability (tier 3)
+  --fix                                         Apply auto-fixable issues and write config to disk
 
 Run options:
   --config <path>                               Config file (default: skill-optimizer.json)
@@ -128,6 +139,10 @@ Examples:
   skill-optimizer init cli
   skill-optimizer init sdk
   skill-optimizer init mcp
+  skill-optimizer doctor --config ./skill-optimizer.json
+  skill-optimizer doctor --static
+  skill-optimizer doctor --check-models
+  skill-optimizer doctor --fix
   skill-optimizer --dry-run --config ./skill-optimizer.json
   skill-optimizer benchmark --config ./skill-optimizer.json
   skill-optimizer run
@@ -205,6 +220,17 @@ async function main(): Promise<void> {
     }
     initBenchmark(process.cwd(), surface as 'sdk' | 'cli' | 'mcp');
     process.exit(0);
+  }
+
+  // ── Doctor mode ──────────────────────────────────────────────────────────────
+  if (command === 'doctor') {
+    const configPath = getFlag(args, '--config') ?? DEFAULT_PROJECT_CONFIG_NAME;
+    const exitCode = await runDoctor(configPath, {
+      staticOnly: hasFlag(args, '--static'),
+      checkModels: hasFlag(args, '--check-models'),
+      fix: hasFlag(args, '--fix'),
+    });
+    process.exit(exitCode);
   }
 
   // ── Compare mode ────────────────────────────────────────────────────────────

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -145,7 +145,7 @@ Examples:
 // ── Dry-run ───────────────────────────────────────────────────────────────────
 
 async function runDryRun(configPath: string): Promise<void> {
-  const project = loadProjectConfig(configPath);
+  const project = await loadProjectConfig(configPath);
   const discovered = discoverActionsOnly(project);
   const { inScope, outOfScope } = resolveScope(discovered, project.target.scope);
 
@@ -292,7 +292,7 @@ async function main(): Promise<void> {
   if (command === 'generate-tasks') {
     const configPath = getFlag(args, '--config') ?? DEFAULT_PROJECT_CONFIG_NAME;
     try {
-      const project = loadProjectConfig(configPath);
+      const project = await loadProjectConfig(configPath);
       if (!project.benchmark.taskGeneration.enabled) {
         throw new Error('benchmark.taskGeneration.enabled must be true to use generate-tasks');
       }
@@ -350,7 +350,7 @@ async function main(): Promise<void> {
   let project: ResolvedProjectConfig | undefined;
   let generatedCoverage: import('./benchmark/types.js').CoverageReport | undefined;
   try {
-    project = loadProjectConfig(options.configPath ?? DEFAULT_PROJECT_CONFIG_NAME);
+    project = await loadProjectConfig(options.configPath ?? DEFAULT_PROJECT_CONFIG_NAME);
     if (!existsSync(project.target.repoPath) || !statSync(project.target.repoPath).isDirectory()) {
       throw new Error(
         `target.repoPath does not exist or is not a directory: ${project.target.repoPath}. ` +

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -24,12 +24,14 @@ export function checkDiscovery(project: ResolvedProjectConfig): Issue[] {
   const { inScope } = resolveScope(discovered, project.target.scope);
 
   if (inScope.length === 0) {
-    const surfaceHint =
-      project.target.surface === 'cli'
-        ? `Add target.cli.commands pointing at a cli-commands.json manifest, or fix target.discovery.sources`
-        : project.target.surface === 'mcp'
-        ? `Add target.mcp.tools pointing at a tools.json manifest, or fix target.discovery.sources`
-        : `Fix target.discovery.sources to point at your SDK entry file`;
+    let surfaceHint: string;
+    if (project.target.surface === 'cli') {
+      surfaceHint = `Add target.cli.commands pointing at a cli-commands.json manifest, or fix target.discovery.sources`;
+    } else if (project.target.surface === 'mcp') {
+      surfaceHint = `Add target.mcp.tools pointing at a tools.json manifest, or fix target.discovery.sources`;
+    } else {
+      surfaceHint = `Fix target.discovery.sources to point at your SDK entry file`;
+    }
     issues.push({
       code: 'zero-actions-discovered', severity: 'error', field: 'target.discovery',
       message: `Discovery found 0 in-scope actions`,

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -1,0 +1,102 @@
+import type { ResolvedProjectConfig } from '../project/types.js';
+import type { Issue } from '../project/validate.js';
+import { discoverActionsOnly, resolveScope } from '../tasks/index.js';
+
+/**
+ * Tier-2: discover actions and verify scope + maxTasks.
+ */
+export function checkDiscovery(project: ResolvedProjectConfig): Issue[] {
+  const issues: Issue[] = [];
+  let discovered: ReturnType<typeof discoverActionsOnly>;
+
+  try {
+    discovered = discoverActionsOnly(project);
+  } catch (err) {
+    issues.push({
+      code: 'discovery-failed', severity: 'error', field: 'target.discovery',
+      message: `Discovery threw an error: ${err instanceof Error ? err.message : String(err)}`,
+      hint: `Check target.discovery.sources and your manifest file`,
+      fixable: false,
+    });
+    return issues;
+  }
+
+  const { inScope } = resolveScope(discovered, project.target.scope);
+
+  if (inScope.length === 0) {
+    const surfaceHint =
+      project.target.surface === 'cli'
+        ? `Add target.cli.commands pointing at a cli-commands.json manifest, or fix target.discovery.sources`
+        : project.target.surface === 'mcp'
+        ? `Add target.mcp.tools pointing at a tools.json manifest, or fix target.discovery.sources`
+        : `Fix target.discovery.sources to point at your SDK entry file`;
+    issues.push({
+      code: 'zero-actions-discovered', severity: 'error', field: 'target.discovery',
+      message: `Discovery found 0 in-scope actions`,
+      hint: surfaceHint,
+      fixable: false,
+    });
+  } else {
+    const maxTasks = project.benchmark.taskGeneration?.maxTasks ?? 0;
+    if (project.benchmark.taskGeneration?.enabled && maxTasks < inScope.length) {
+      issues.push({
+        code: 'max-tasks-too-low', severity: 'error', field: 'benchmark.taskGeneration.maxTasks',
+        message: `maxTasks (${maxTasks}) is less than the number of in-scope actions (${inScope.length})`,
+        hint: `Raise benchmark.taskGeneration.maxTasks to at least ${inScope.length}`,
+        fixable: false,
+      });
+    }
+    issues.push({
+      code: 'discovery-ok', severity: 'info', field: 'target.discovery',
+      message: `${inScope.length} action(s) discovered (${project.target.surface} surface)`,
+      fixable: false,
+    });
+  }
+
+  return issues;
+}
+
+/**
+ * Tier-3: ping each model with a 1-token request.
+ */
+export async function checkModelReachability(project: ResolvedProjectConfig): Promise<Issue[]> {
+  const issues: Issue[] = [];
+  const apiKey = process.env[project.benchmark.apiKeyEnv ?? 'OPENROUTER_API_KEY'];
+  if (!apiKey) return issues; // already reported by checkConfig
+
+  for (let i = 0; i < project.benchmark.models.length; i++) {
+    const model = project.benchmark.models[i]!;
+    try {
+      const res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: model.id.replace(/^openrouter\//, ''),
+          messages: [{ role: 'user', content: 'hi' }],
+          max_tokens: 1,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.text();
+        issues.push({
+          code: 'model-unreachable', severity: 'error', field: `benchmark.models[${i}].id`,
+          message: `Model "${model.id}" returned HTTP ${res.status}: ${body.slice(0, 120)}`,
+          hint: `Check the model ID at https://openrouter.ai/models and verify your API key`,
+          fixable: false,
+        });
+      }
+    } catch (err) {
+      issues.push({
+        code: 'model-unreachable', severity: 'error', field: `benchmark.models[${i}].id`,
+        message: `Model "${model.id}" unreachable: ${err instanceof Error ? err.message : String(err)}`,
+        hint: `Check your network and API key`,
+        fixable: false,
+      });
+    }
+  }
+
+  return issues;
+}

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -66,6 +66,16 @@ export async function checkModelReachability(project: ResolvedProjectConfig): Pr
   const apiKey = process.env[project.benchmark.apiKeyEnv ?? 'OPENROUTER_API_KEY'];
   if (!apiKey) return issues; // already reported by checkConfig
 
+  // Only PI format uses OpenRouter; skip reachability for other formats
+  if (project.benchmark.format && project.benchmark.format !== 'pi') {
+    issues.push({
+      code: 'reachability-skipped', severity: 'info', field: 'benchmark.format',
+      message: `Skipping reachability check (--check-models only supports format "pi" for now)`,
+      fixable: false,
+    });
+    return issues;
+  }
+
   for (let i = 0; i < project.benchmark.models.length; i++) {
     const model = project.benchmark.models[i]!;
     try {

--- a/src/doctor/format.ts
+++ b/src/doctor/format.ts
@@ -1,0 +1,50 @@
+import type { Issue } from '../project/validate.js';
+
+const R = '\x1b[0m';
+const RED = '\x1b[31m';
+const YEL = '\x1b[33m';
+const GRN = '\x1b[32m';
+const DIM = '\x1b[2m';
+const BOLD = '\x1b[1m';
+
+function icon(severity: Issue['severity']): string {
+  if (severity === 'error') return `${RED}✗${R}`;
+  if (severity === 'warning') return `${YEL}⚠${R}`;
+  return `${GRN}✓${R}`;
+}
+
+export function formatIssues(issues: Issue[], configPath: string): string {
+  const lines: string[] = [];
+  lines.push(`\n${BOLD}skill-optimizer doctor${R} — ${configPath}\n`);
+
+  for (const issue of issues.filter((i) => i.severity !== 'info' || i.code === 'discovery-ok')) {
+    const label = issue.code === 'discovery-ok' ? 'discovery' : issue.field;
+    const pad = ' '.repeat(Math.max(1, 32 - label.length));
+    lines.push(`  ${icon(issue.severity)} ${label}${pad}${issue.message}`);
+    if (issue.hint) lines.push(`      ${DIM}hint: ${issue.hint}${R}`);
+    if (issue.fixable) lines.push(`      ${DIM}(auto-fixable with --fix)${R}`);
+  }
+
+  const errors = issues.filter((i) => i.severity === 'error');
+  const warnings = issues.filter((i) => i.severity === 'warning');
+  const fixable = issues.filter((i) => i.fixable).length;
+
+  lines.push('');
+  if (errors.length === 0 && warnings.length === 0) {
+    lines.push(`${GRN}No issues found — config is valid${R}`);
+  } else {
+    let summary = `${errors.length} error(s), ${warnings.length} warning(s)`;
+    if (fixable > 0) summary += ` — run with ${BOLD}--fix${R} to apply ${fixable} auto-fixable change(s)`;
+    lines.push(summary);
+  }
+
+  return lines.join('\n');
+}
+
+export function formatFixResult(appliedCount: number, remainingIssues: Issue[], configPath: string): string {
+  return [
+    `\n  Applied ${appliedCount} fix(es) to ${configPath}`,
+    `  Re-running checks...\n`,
+    formatIssues(remainingIssues, configPath),
+  ].join('\n');
+}

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -1,0 +1,69 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+
+import { checkConfig } from '../project/validate.js';
+import { applyFixes } from '../project/fix.js';
+import { loadProjectConfig } from '../project/load.js';
+import { checkDiscovery, checkModelReachability } from './checks.js';
+import { formatIssues, formatFixResult } from './format.js';
+import type { Issue } from '../project/validate.js';
+
+export interface DoctorOptions {
+  staticOnly?: boolean;
+  checkModels?: boolean;
+  fix?: boolean;
+}
+
+export async function runDoctor(configPath: string, opts: DoctorOptions = {}): Promise<number> {
+  const resolvedPath = resolve(configPath);
+
+  let rawJson: Record<string, unknown>;
+  try {
+    rawJson = JSON.parse(readFileSync(resolvedPath, 'utf-8')) as Record<string, unknown>;
+  } catch (err) {
+    console.error(`ERROR: Cannot read config: ${resolvedPath}`);
+    console.error(err instanceof Error ? err.message : String(err));
+    return 2;
+  }
+
+  // Tier 1: structural + path + format checks
+  let issues: Issue[] = await checkConfig(rawJson as any, resolvedPath);
+
+  if (opts.fix) {
+    const configDir = dirname(resolvedPath);
+    const fixableCount = issues.filter((i) => i.fixable).length;
+    if (fixableCount > 0) {
+      const fixed = applyFixes(rawJson, issues, configDir);
+      writeFileSync(resolvedPath, JSON.stringify(fixed, null, 2) + '\n', 'utf-8');
+      rawJson = fixed;
+      issues = await checkConfig(rawJson as any, resolvedPath);
+      console.log(formatFixResult(fixableCount, issues, resolvedPath));
+    } else {
+      console.log('\n  No auto-fixable issues found.');
+    }
+    return issues.some((i) => i.severity === 'error') ? 1 : 0;
+  }
+
+  // Tier 2: discovery (default, skipped with --static)
+  if (!opts.staticOnly && !issues.some((i) => i.severity === 'error')) {
+    try {
+      const project = await loadProjectConfig(resolvedPath);
+      issues = [...issues, ...checkDiscovery(project)];
+    } catch {
+      // loadProjectConfig threw; static errors already cover this
+    }
+  }
+
+  // Tier 3: model reachability (--check-models)
+  if (opts.checkModels) {
+    try {
+      const project = await loadProjectConfig(resolvedPath);
+      issues = [...issues, ...(await checkModelReachability(project))];
+    } catch {
+      // skip
+    }
+  }
+
+  console.log(formatIssues(issues, resolvedPath));
+  return issues.some((i) => i.severity === 'error') ? 1 : 0;
+}

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -27,7 +27,7 @@ export async function runDoctor(configPath: string, opts: DoctorOptions = {}): P
   }
 
   // Tier 1: structural + path + format checks
-  let issues: Issue[] = await checkConfig(rawJson as any, resolvedPath);
+  let issues: Issue[] = await checkConfig(rawJson, resolvedPath);
 
   if (opts.fix) {
     const configDir = dirname(resolvedPath);
@@ -36,7 +36,7 @@ export async function runDoctor(configPath: string, opts: DoctorOptions = {}): P
       const fixed = applyFixes(rawJson, issues, configDir);
       writeFileSync(resolvedPath, JSON.stringify(fixed, null, 2) + '\n', 'utf-8');
       rawJson = fixed;
-      issues = await checkConfig(rawJson as any, resolvedPath);
+      issues = await checkConfig(rawJson, resolvedPath);
       console.log(formatFixResult(fixableCount, issues, resolvedPath));
     } else {
       console.log('\n  No auto-fixable issues found.');

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -31,13 +31,15 @@ export async function runDoctor(configPath: string, opts: DoctorOptions = {}): P
 
   if (opts.fix) {
     const configDir = dirname(resolvedPath);
-    const fixableCount = issues.filter((i) => i.fixable).length;
-    if (fixableCount > 0) {
-      const fixed = applyFixes(rawJson, issues, configDir);
-      writeFileSync(resolvedPath, JSON.stringify(fixed, null, 2) + '\n', 'utf-8');
-      rawJson = fixed;
-      issues = await checkConfig(rawJson, resolvedPath);
-      console.log(formatFixResult(fixableCount, issues, resolvedPath));
+    const initialFixableCount = issues.filter((i) => i.fixable).length;
+    if (initialFixableCount > 0) {
+      let safety = 3;
+      while (issues.some((i) => i.fixable) && safety-- > 0) {
+        rawJson = applyFixes(rawJson, issues, configDir);
+        issues = await checkConfig(rawJson, resolvedPath);
+      }
+      writeFileSync(resolvedPath, JSON.stringify(rawJson, null, 2) + '\n', 'utf-8');
+      console.log(formatFixResult(initialFixableCount, issues, resolvedPath));
     } else {
       console.log('\n  No auto-fixable issues found.');
     }
@@ -49,8 +51,9 @@ export async function runDoctor(configPath: string, opts: DoctorOptions = {}): P
     try {
       const project = await loadProjectConfig(resolvedPath);
       issues = [...issues, ...checkDiscovery(project)];
-    } catch {
+    } catch (e) {
       // loadProjectConfig threw; static errors already cover this
+      if (process.env['DEBUG']) console.error('[debug] Tier-2 skipped:', e);
     }
   }
 
@@ -59,8 +62,8 @@ export async function runDoctor(configPath: string, opts: DoctorOptions = {}): P
     try {
       const project = await loadProjectConfig(resolvedPath);
       issues = [...issues, ...(await checkModelReachability(project))];
-    } catch {
-      // skip
+    } catch (e) {
+      if (process.env['DEBUG']) console.error('[debug] Tier-3 skipped:', e);
     }
   }
 

--- a/src/optimizer/main.ts
+++ b/src/optimizer/main.ts
@@ -64,7 +64,7 @@ export async function runOptimizeFromConfig(
   manifestPath: string,
   options: { maxIterationsRaw?: string; skipGeneration?: boolean } = {},
 ) {
-  const manifest = loadOptimizeManifest(manifestPath);
+  const manifest = await loadOptimizeManifest(manifestPath);
   const maxIterations = options.maxIterationsRaw ? Number(options.maxIterationsRaw) : undefined;
   if (options.maxIterationsRaw && (!Number.isInteger(maxIterations) || (maxIterations ?? 0) <= 0)) {
     throw new Error(`Invalid --max-iterations value '${options.maxIterationsRaw}'. Must be a positive integer.`);

--- a/src/optimizer/manifest.ts
+++ b/src/optimizer/manifest.ts
@@ -2,7 +2,7 @@ import { loadProjectConfig, toOptimizeManifest } from '../project/index.js';
 
 import type { ResolvedOptimizeManifest } from './types.js';
 
-export function loadOptimizeManifest(configPath: string): ResolvedOptimizeManifest {
-  const project = loadProjectConfig(configPath);
+export async function loadOptimizeManifest(configPath: string): Promise<ResolvedOptimizeManifest> {
+  const project = await loadProjectConfig(configPath);
   return toOptimizeManifest(project);
 }

--- a/src/project/fix.ts
+++ b/src/project/fix.ts
@@ -1,0 +1,44 @@
+import type { Issue } from './validate.js';
+
+/**
+ * Apply auto-fixable changes to a raw config JSON object.
+ * Pure function — deep-clones input, never mutates, never writes to disk.
+ */
+export function applyFixes(
+  rawJson: Record<string, unknown>,
+  issues: Issue[],
+  _configDir: string,
+): Record<string, unknown> {
+  const result = JSON.parse(JSON.stringify(rawJson)) as Record<string, unknown>;
+
+  // Track which model indices had their prefix fixed so we don't also apply
+  // the dot-format fix on top (the bad-format issue was generated from the
+  // original ID before the prefix was added).
+  const prefixFixedIndices = new Set<number>();
+
+  for (const issue of issues.filter((i) => i.fixable)) {
+    if (issue.code === 'model-id-missing-prefix' || issue.code === 'model-id-bad-format') {
+      const match = issue.field.match(/^benchmark\.models\[(\d+)\]\.id$/);
+      if (!match) continue;
+      const idx = parseInt(match[1]!, 10);
+      const models = (result.benchmark as Record<string, unknown> | undefined)?.models as Array<Record<string, unknown>> | undefined;
+      if (!models?.[idx]) continue;
+
+      if (issue.code === 'model-id-missing-prefix') {
+        models[idx]!.id = `openrouter/${models[idx]!.id as string}`;
+        prefixFixedIndices.add(idx);
+      }
+
+      if (issue.code === 'model-id-bad-format' && !prefixFixedIndices.has(idx)) {
+        models[idx]!.id = (models[idx]!.id as string).replace(/(\d+)\.(\d+)/g, '$1-$2');
+      }
+    }
+
+    if (issue.code === 'deprecated-tasks-field') {
+      const benchmark = result.benchmark as Record<string, unknown> | undefined;
+      if (benchmark) delete benchmark.tasks;
+    }
+  }
+
+  return result;
+}

--- a/src/project/index.ts
+++ b/src/project/index.ts
@@ -1,7 +1,7 @@
 export { DEFAULT_PROJECT_CONFIG_NAME, LEGACY_PROJECT_CONFIG_NAME, loadProjectConfig } from './load.js';
 export { resolveProjectConfig } from './resolve.js';
 export { buildMcpToolDefinitionsFromSnapshot, buildSurfaceSnapshot, loadSurfaceSnapshotFile } from './snapshot.js';
-export { validateProjectConfig } from './validate.js';
+export { checkConfig, validateProjectConfig, type Issue, type IssueSeverity } from './validate.js';
 export { toBenchmarkConfig, toLegacyOptimizeManifest, toOptimizeManifest } from './adapters.js';
 
 export type { ActionCatalog } from '../actions/types.js';

--- a/src/project/load.ts
+++ b/src/project/load.ts
@@ -8,7 +8,7 @@ import { validateProjectConfig } from './validate.js';
 export const DEFAULT_PROJECT_CONFIG_NAME = 'skill-optimizer.json';
 export const LEGACY_PROJECT_CONFIG_NAME = 'skill-benchmark.json';
 
-export function loadProjectConfig(configPath?: string): ResolvedProjectConfig {
+export async function loadProjectConfig(configPath?: string): Promise<ResolvedProjectConfig> {
   const resolvedPath = configPath
     ? resolve(configPath)
     : resolve(process.cwd(), DEFAULT_PROJECT_CONFIG_NAME);
@@ -49,6 +49,6 @@ export function loadProjectConfig(configPath?: string): ResolvedProjectConfig {
     );
   }
 
-  validateProjectConfig(parsed, resolvedPath);
+  await validateProjectConfig(parsed, resolvedPath);
   return resolveProjectConfig(parsed, resolvedPath);
 }

--- a/src/project/validate.ts
+++ b/src/project/validate.ts
@@ -303,7 +303,7 @@ export async function checkConfig(
     const absRepo = isAbsolute(target.repoPath) ? target.repoPath : resolve(configDir, target.repoPath);
     for (const ap of optimize.allowedPaths) {
       const absAp = isAbsolute(ap) ? ap : resolve(configDir, ap);
-      if (!absAp.startsWith(absRepo)) {
+      if (!absAp.startsWith(absRepo + '/') && absAp !== absRepo) {
         issues.push({
           code: 'allowed-path-outside-repo', severity: 'error', field: 'optimize.allowedPaths',
           message: `allowedPath "${ap}" is not inside target.repoPath "${absRepo}"`,
@@ -326,7 +326,7 @@ export async function checkConfig(
   }
 
   // Check: dirty git (injection-safe: fixed arg array, no shell)
-  if (optimize?.requireCleanGit !== false && target.repoPath) {
+  if (optimize !== undefined && optimize.requireCleanGit !== false && target.repoPath) {
     const absRepo = isAbsolute(target.repoPath) ? target.repoPath : resolve(configDir, target.repoPath);
     if (existsSync(absRepo)) {
       try {

--- a/src/project/validate.ts
+++ b/src/project/validate.ts
@@ -14,7 +14,7 @@ export interface Issue {
 
 export async function checkConfig(
   config: ProjectConfig,
-  configPath: string,
+  _configPath: string,
 ): Promise<Issue[]> {
   const issues: Issue[] = [];
 

--- a/src/project/validate.ts
+++ b/src/project/validate.ts
@@ -20,7 +20,7 @@ export interface Issue {
 }
 
 export async function checkConfig(
-  config: ProjectConfig,
+  config: unknown,
   _configPath: string,
 ): Promise<Issue[]> {
   const issues: Issue[] = [];
@@ -29,17 +29,19 @@ export async function checkConfig(
     issues.push({ code, severity: 'error', field, message, hint, fixable: false });
   }
 
-  if (!config.name || typeof config.name !== 'string') {
+  const cfg = config as ProjectConfig;
+
+  if (!cfg.name || typeof cfg.name !== 'string') {
     err('missing-name', 'name', '"name" is required');
     return issues;
   }
 
-  if (!config.target || typeof config.target !== 'object') {
+  if (!cfg.target || typeof cfg.target !== 'object') {
     err('missing-target', 'target', '"target" is required');
     return issues;
   }
 
-  const { target, benchmark, optimize } = config;
+  const { target, benchmark, optimize } = cfg;
 
   if (target.surface !== 'sdk' && target.surface !== 'cli' && target.surface !== 'mcp') {
     err('invalid-surface', 'target.surface', '"target.surface" must be sdk, cli, or mcp');
@@ -95,7 +97,7 @@ export async function checkConfig(
 
   if (target.surface === 'mcp') {
     const discoveryMode = target.discovery?.mode ?? 'auto';
-    const hasCodeSources = Array.isArray(target.discovery?.sources) && target.discovery!.sources.length > 0;
+    const hasCodeSources = Array.isArray(target.discovery?.sources) && target.discovery?.sources.length > 0;
     const hasManifest = Boolean(target.mcp?.tools || target.discovery?.fallbackManifest);
     if (discoveryMode === 'manifest' && !hasManifest) {
       err('missing-mcp-manifest', 'target', 'MCP manifest mode requires target.mcp.tools or target.discovery.fallbackManifest');
@@ -220,7 +222,7 @@ export async function checkConfig(
 
   // Check: target.skill file exists
   if (target.skill !== undefined) {
-    const skillSource = typeof target.skill === 'string' ? target.skill : (target.skill as any).source;
+    const skillSource = typeof target.skill === 'string' ? target.skill : target.skill.source;
     if (skillSource) {
       const absSkill = isAbsolute(skillSource) ? skillSource : resolve(configDir, skillSource);
       if (!existsSync(absSkill)) {
@@ -250,13 +252,18 @@ export async function checkConfig(
   }
 
   // Check: CLI/MCP manifest file exists if configured
-  const manifestPath = (target as any).cli?.commands ?? (target as any).mcp?.tools ?? target.discovery?.fallbackManifest;
+  const manifestPath = target.cli?.commands ?? target.mcp?.tools ?? target.discovery?.fallbackManifest;
   if (manifestPath) {
     const absManifest = isAbsolute(manifestPath) ? manifestPath : resolve(configDir, manifestPath);
     if (!existsSync(absManifest)) {
-      const field = (target as any).cli?.commands ? 'target.cli.commands'
-        : (target as any).mcp?.tools ? 'target.mcp.tools'
-        : 'target.discovery.fallbackManifest';
+      let field: string;
+      if (target.cli?.commands) {
+        field = 'target.cli.commands';
+      } else if (target.mcp?.tools) {
+        field = 'target.mcp.tools';
+      } else {
+        field = 'target.discovery.fallbackManifest';
+      }
       issues.push({
         code: 'manifest-file-missing', severity: 'error', field,
         message: `manifest file does not exist: ${absManifest}`,
@@ -346,7 +353,7 @@ export async function checkConfig(
   }
 
   // Check: deprecated benchmark.tasks field
-  if ((benchmark as any).tasks !== undefined && benchmark.taskGeneration?.enabled === true) {
+  if (benchmark.tasks !== undefined && benchmark.taskGeneration?.enabled === true) {
     issues.push({
       code: 'deprecated-tasks-field', severity: 'warning', field: 'benchmark.tasks',
       message: '"benchmark.tasks" is set but task generation is enabled — the tasks field is deprecated',

--- a/src/project/validate.ts
+++ b/src/project/validate.ts
@@ -1,54 +1,76 @@
 import type { ProjectConfig } from './types.js';
 import { isSdkLanguage } from './types.js';
 
-export function validateProjectConfig(config: ProjectConfig, configPath: string): void {
+export type IssueSeverity = 'error' | 'warning' | 'info';
+
+export interface Issue {
+  code: string;
+  severity: IssueSeverity;
+  field: string;
+  message: string;
+  hint?: string;
+  fixable: boolean;
+}
+
+export async function checkConfig(
+  config: ProjectConfig,
+  configPath: string,
+): Promise<Issue[]> {
+  const issues: Issue[] = [];
+
+  function err(code: string, field: string, message: string, hint?: string): void {
+    issues.push({ code, severity: 'error', field, message, hint, fixable: false });
+  }
+
   if (!config.name || typeof config.name !== 'string') {
-    throw new Error(`Project config ${configPath}: "name" is required`);
+    err('missing-name', 'name', '"name" is required');
+    return issues;
   }
 
   if (!config.target || typeof config.target !== 'object') {
-    throw new Error(`Project config ${configPath}: "target" is required`);
+    err('missing-target', 'target', '"target" is required');
+    return issues;
   }
 
   const { target, benchmark, optimize } = config;
 
   if (target.surface !== 'sdk' && target.surface !== 'cli' && target.surface !== 'mcp') {
-    throw new Error(`Project config ${configPath}: "target.surface" must be sdk, cli, or mcp`);
+    err('invalid-surface', 'target.surface', '"target.surface" must be sdk, cli, or mcp');
   }
 
   if (target.skill !== undefined) {
     const skillSource = typeof target.skill === 'string' ? target.skill : target.skill?.source;
     if (!skillSource || typeof skillSource !== 'string') {
-      throw new Error(`Project config ${configPath}: "target.skill" must be a path string or { source } object`);
+      err('invalid-skill', 'target.skill', '"target.skill" must be a path string or { source } object');
     }
   }
 
   if (target.scope !== undefined) {
     if (target.scope.include !== undefined) {
       if (!Array.isArray(target.scope.include) || target.scope.include.some((s) => typeof s !== 'string')) {
-        throw new Error(`Project config ${configPath}: "target.scope.include" must be an array of glob strings`);
+        err('invalid-scope-include', 'target.scope.include', '"target.scope.include" must be an array of glob strings');
       }
     }
     if (target.scope.exclude !== undefined) {
       if (!Array.isArray(target.scope.exclude) || target.scope.exclude.some((s) => typeof s !== 'string')) {
-        throw new Error(`Project config ${configPath}: "target.scope.exclude" must be an array of glob strings`);
+        err('invalid-scope-exclude', 'target.scope.exclude', '"target.scope.exclude" must be an array of glob strings');
       }
     }
   }
 
   if (benchmark?.taskGeneration?.enabled === true && target.skill === undefined) {
-    throw new Error(`Project config ${configPath}: "target.skill" is required when benchmark.taskGeneration.enabled=true`);
+    err('missing-skill-for-generation', 'target.skill', '"target.skill" is required when benchmark.taskGeneration.enabled=true');
   }
 
   if (target.surface === 'sdk') {
     const sdkLanguage = target.sdk?.language ?? target.discovery?.language;
     if (!sdkLanguage || !isSdkLanguage(sdkLanguage)) {
-      throw new Error(`Project config ${configPath}: "target.sdk.language" must be typescript, python, or rust`);
+      err('invalid-sdk-language', 'target.sdk.language', '"target.sdk.language" must be typescript, python, or rust');
     }
     const hasCodeSources = Array.isArray(target.discovery?.sources) && target.discovery.sources.length > 0;
     const hasApiSurface = Array.isArray(target.sdk?.apiSurface) && target.sdk.apiSurface.length > 0;
     if (!hasCodeSources && !hasApiSurface) {
-      throw new Error(`Project config ${configPath}: SDK targets need discovery.sources or target.sdk.apiSurface`);
+      err('missing-sdk-surface', 'target', 'SDK targets need discovery.sources or target.sdk.apiSurface');
     }
   }
 
@@ -57,10 +79,10 @@ export function validateProjectConfig(config: ProjectConfig, configPath: string)
     const hasCodeSources = Array.isArray(target.discovery?.sources) && target.discovery.sources.length > 0;
     const hasManifest = Boolean(target.cli?.commands || target.discovery?.fallbackManifest);
     if (discoveryMode === 'manifest' && !hasManifest) {
-      throw new Error(`Project config ${configPath}: CLI manifest mode requires target.cli.commands or target.discovery.fallbackManifest`);
+      err('missing-cli-manifest', 'target', 'CLI manifest mode requires target.cli.commands or target.discovery.fallbackManifest');
     }
     if (!hasManifest && !hasCodeSources) {
-      throw new Error(`Project config ${configPath}: CLI targets need discovery.sources, target.cli.commands, or target.discovery.fallbackManifest`);
+      err('missing-cli-surface', 'target', 'CLI targets need discovery.sources, target.cli.commands, or target.discovery.fallbackManifest');
     }
   }
 
@@ -69,36 +91,43 @@ export function validateProjectConfig(config: ProjectConfig, configPath: string)
     const hasCodeSources = Array.isArray(target.discovery?.sources) && target.discovery!.sources.length > 0;
     const hasManifest = Boolean(target.mcp?.tools || target.discovery?.fallbackManifest);
     if (discoveryMode === 'manifest' && !hasManifest) {
-      throw new Error(`Project config ${configPath}: MCP manifest mode requires target.mcp.tools or target.discovery.fallbackManifest`);
+      err('missing-mcp-manifest', 'target', 'MCP manifest mode requires target.mcp.tools or target.discovery.fallbackManifest');
     }
     if (!hasManifest && !hasCodeSources) {
-      throw new Error(`Project config ${configPath}: MCP targets need discovery.sources, target.mcp.tools, or target.discovery.fallbackManifest`);
+      err('missing-mcp-surface', 'target', 'MCP targets need discovery.sources, target.mcp.tools, or target.discovery.fallbackManifest');
     }
   }
 
   if (target.discovery) {
     if (target.discovery.mode && target.discovery.mode !== 'auto' && target.discovery.mode !== 'manifest') {
-      throw new Error(`Project config ${configPath}: "target.discovery.mode" must be auto or manifest`);
+      err('invalid-discovery-mode', 'target.discovery.mode', '"target.discovery.mode" must be auto or manifest');
     }
     if (target.discovery.sources !== undefined && !Array.isArray(target.discovery.sources)) {
-      throw new Error(`Project config ${configPath}: "target.discovery.sources" must be an array when present`);
+      err('invalid-discovery-sources', 'target.discovery.sources', '"target.discovery.sources" must be an array when present');
     }
     if (target.discovery.language !== undefined && !isSdkLanguage(target.discovery.language)) {
-      throw new Error(`Project config ${configPath}: "target.discovery.language" must be typescript, python, or rust when present`);
+      err('invalid-discovery-language', 'target.discovery.language', '"target.discovery.language" must be typescript, python, or rust when present');
     }
   }
 
   if (!benchmark || typeof benchmark !== 'object') {
-    throw new Error(`Project config ${configPath}: "benchmark" is required`);
+    err('missing-benchmark', 'benchmark', '"benchmark" is required');
+    return issues;
   }
 
   if (!Array.isArray(benchmark.models) || benchmark.models.length === 0) {
-    throw new Error(`Project config ${configPath}: "benchmark.models" must be a non-empty array`);
-  }
+    err('missing-models', 'benchmark.models', '"benchmark.models" must be a non-empty array');
+  } else {
+    for (const model of benchmark.models) {
+      if (!model.id || !model.name || !model.tier) {
+        err('invalid-model', 'benchmark.models', 'each benchmark model needs id, name, and tier');
+      }
+    }
 
-  for (const model of benchmark.models) {
-    if (!model.id || !model.name || !model.tier) {
-      throw new Error(`Project config ${configPath}: each benchmark model needs id, name, and tier`);
+    for (const model of benchmark.models) {
+      if (model.weight !== undefined && (!Number.isFinite(model.weight) || model.weight < 0)) {
+        err('invalid-model-weight', `benchmark.models[${model.id}].weight`, `model "${model.id}" has invalid weight; must be a non-negative number`);
+      }
     }
   }
 
@@ -106,70 +135,76 @@ export function validateProjectConfig(config: ProjectConfig, configPath: string)
     if (benchmark.verdict.perModelFloor !== undefined) {
       const v = benchmark.verdict.perModelFloor;
       if (!Number.isFinite(v) || v < 0 || v > 1) {
-        throw new Error(`Project config ${configPath}: "benchmark.verdict.perModelFloor" must be between 0 and 1`);
+        err('invalid-per-model-floor', 'benchmark.verdict.perModelFloor', '"benchmark.verdict.perModelFloor" must be between 0 and 1');
       }
     }
     if (benchmark.verdict.targetWeightedAverage !== undefined) {
       const v = benchmark.verdict.targetWeightedAverage;
       if (!Number.isFinite(v) || v < 0 || v > 1) {
-        throw new Error(`Project config ${configPath}: "benchmark.verdict.targetWeightedAverage" must be between 0 and 1`);
+        err('invalid-target-weighted-average', 'benchmark.verdict.targetWeightedAverage', '"benchmark.verdict.targetWeightedAverage" must be between 0 and 1');
       }
-    }
-  }
-
-  for (const model of benchmark.models) {
-    if (model.weight !== undefined && (!Number.isFinite(model.weight) || model.weight < 0)) {
-      throw new Error(`Project config ${configPath}: model "${model.id}" has invalid weight; must be a non-negative number`);
     }
   }
 
   if (benchmark.format && benchmark.format !== 'pi' && benchmark.format !== 'openai' && benchmark.format !== 'anthropic') {
-    throw new Error(`Project config ${configPath}: "benchmark.format" must be pi, openai, or anthropic`);
+    err('invalid-format', 'benchmark.format', '"benchmark.format" must be pi, openai, or anthropic');
   }
 
   if (!benchmark.taskGeneration?.enabled && !benchmark.tasks) {
-    throw new Error(`Project config ${configPath}: "benchmark.tasks" is required when task generation is disabled`);
+    err('missing-tasks', 'benchmark.tasks', '"benchmark.tasks" is required when task generation is disabled');
   }
 
   if (benchmark.taskGeneration?.maxTasks !== undefined && (!Number.isInteger(benchmark.taskGeneration.maxTasks) || benchmark.taskGeneration.maxTasks <= 0)) {
-    throw new Error(`Project config ${configPath}: "benchmark.taskGeneration.maxTasks" must be a positive integer`);
+    err('invalid-max-tasks', 'benchmark.taskGeneration.maxTasks', '"benchmark.taskGeneration.maxTasks" must be a positive integer');
   }
 
   if (benchmark.taskGeneration?.seed !== undefined && (!Number.isInteger(benchmark.taskGeneration.seed) || benchmark.taskGeneration.seed < 0)) {
-    throw new Error(`Project config ${configPath}: "benchmark.taskGeneration.seed" must be a non-negative integer`);
+    err('invalid-seed', 'benchmark.taskGeneration.seed', '"benchmark.taskGeneration.seed" must be a non-negative integer');
   }
 
   if (optimize) {
     if (optimize.mode !== undefined && optimize.mode !== 'stable-surface' && optimize.mode !== 'surface-changing') {
-      throw new Error(`Project config ${configPath}: "optimize.mode" must be stable-surface or surface-changing`);
+      err('invalid-optimize-mode', 'optimize.mode', '"optimize.mode" must be stable-surface or surface-changing');
     }
     if (optimize.mode === 'surface-changing' && benchmark.taskGeneration?.enabled !== true) {
-      throw new Error(`Project config ${configPath}: surface-changing optimization requires benchmark.taskGeneration.enabled=true`);
+      err('surface-changing-needs-generation', 'optimize.mode', 'surface-changing optimization requires benchmark.taskGeneration.enabled=true');
     }
     if (optimize.enabled !== false) {
       if (!Array.isArray(optimize.allowedPaths) || optimize.allowedPaths.length === 0) {
-        throw new Error(`Project config ${configPath}: "optimize.allowedPaths" must be a non-empty array when optimization is enabled`);
+        err('missing-allowed-paths', 'optimize.allowedPaths', '"optimize.allowedPaths" must be a non-empty array when optimization is enabled');
       }
     }
 
     if (optimize.maxIterations !== undefined && (!Number.isInteger(optimize.maxIterations) || optimize.maxIterations <= 0)) {
-      throw new Error(`Project config ${configPath}: "optimize.maxIterations" must be a positive integer`);
+      err('invalid-max-iterations', 'optimize.maxIterations', '"optimize.maxIterations" must be a positive integer');
     }
 
     if (optimize.stabilityWindow !== undefined && (!Number.isInteger(optimize.stabilityWindow) || optimize.stabilityWindow <= 0)) {
-      throw new Error(`Project config ${configPath}: "optimize.stabilityWindow" must be a positive integer`);
+      err('invalid-stability-window', 'optimize.stabilityWindow', '"optimize.stabilityWindow" must be a positive integer');
     }
 
     if (optimize.minImprovement !== undefined && (!Number.isFinite(optimize.minImprovement) || optimize.minImprovement < 0)) {
-      throw new Error(`Project config ${configPath}: "optimize.minImprovement" must be a non-negative number`);
+      err('invalid-min-improvement', 'optimize.minImprovement', '"optimize.minImprovement" must be a non-negative number');
     }
 
     if (optimize.reportContextMaxBytes !== undefined && (!Number.isInteger(optimize.reportContextMaxBytes) || optimize.reportContextMaxBytes <= 0)) {
-      throw new Error(`Project config ${configPath}: "optimize.reportContextMaxBytes" must be a positive integer`);
+      err('invalid-report-context-max-bytes', 'optimize.reportContextMaxBytes', '"optimize.reportContextMaxBytes" must be a positive integer');
     }
 
     if (optimize.requireCleanGit === false) {
-      throw new Error(`Project config ${configPath}: "optimize.requireCleanGit" must remain true in v1`);
+      err('require-clean-git-disabled', 'optimize.requireCleanGit', '"optimize.requireCleanGit" must remain true in v1');
     }
+  }
+
+  // filesystem and environment checks will be added in Task 2
+
+  return issues;
+}
+
+export async function validateProjectConfig(config: ProjectConfig, configPath: string): Promise<void> {
+  const issues = await checkConfig(config, configPath);
+  const errors = issues.filter((i) => i.severity === 'error');
+  if (errors.length > 0) {
+    throw new Error(errors.map((i) => `${i.field}: ${i.message}${i.hint ? ` — ${i.hint}` : ''}`).join('\n'));
   }
 }

--- a/src/project/validate.ts
+++ b/src/project/validate.ts
@@ -1,5 +1,12 @@
+import { existsSync } from 'node:fs';
+import { resolve, dirname, isAbsolute } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
 import type { ProjectConfig } from './types.js';
 import { isSdkLanguage } from './types.js';
+
+const execFileAsync = promisify(execFile);
 
 export type IssueSeverity = 'error' | 'warning' | 'info';
 
@@ -196,7 +203,168 @@ export async function checkConfig(
     }
   }
 
-  // filesystem and environment checks will be added in Task 2
+  const configDir = dirname(_configPath);
+
+  // Check: target.repoPath exists
+  if (target.repoPath !== undefined) {
+    const absRepo = isAbsolute(target.repoPath) ? target.repoPath : resolve(configDir, target.repoPath);
+    if (!existsSync(absRepo)) {
+      issues.push({
+        code: 'repo-path-missing', severity: 'error', field: 'target.repoPath',
+        message: `"target.repoPath" does not exist: ${absRepo}`,
+        hint: `Set target.repoPath to the absolute path of your project root`,
+        fixable: false,
+      });
+    }
+  }
+
+  // Check: target.skill file exists
+  if (target.skill !== undefined) {
+    const skillSource = typeof target.skill === 'string' ? target.skill : (target.skill as any).source;
+    if (skillSource) {
+      const absSkill = isAbsolute(skillSource) ? skillSource : resolve(configDir, skillSource);
+      if (!existsSync(absSkill)) {
+        issues.push({
+          code: 'skill-file-missing', severity: 'error', field: 'target.skill',
+          message: `"target.skill" does not exist: ${absSkill}`,
+          hint: `Create SKILL.md at that path or update target.skill`,
+          fixable: false,
+        });
+      }
+    }
+  }
+
+  // Check: target.discovery.sources all exist
+  if (Array.isArray(target.discovery?.sources)) {
+    for (const src of target.discovery!.sources) {
+      const absSrc = isAbsolute(src) ? src : resolve(configDir, src);
+      if (!existsSync(absSrc)) {
+        issues.push({
+          code: 'discovery-source-missing', severity: 'error', field: 'target.discovery.sources',
+          message: `discovery source does not exist: ${absSrc}`,
+          hint: `Update target.discovery.sources to point at your entry file`,
+          fixable: false,
+        });
+      }
+    }
+  }
+
+  // Check: CLI/MCP manifest file exists if configured
+  const manifestPath = (target as any).cli?.commands ?? (target as any).mcp?.tools ?? target.discovery?.fallbackManifest;
+  if (manifestPath) {
+    const absManifest = isAbsolute(manifestPath) ? manifestPath : resolve(configDir, manifestPath);
+    if (!existsSync(absManifest)) {
+      const field = (target as any).cli?.commands ? 'target.cli.commands'
+        : (target as any).mcp?.tools ? 'target.mcp.tools'
+        : 'target.discovery.fallbackManifest';
+      issues.push({
+        code: 'manifest-file-missing', severity: 'error', field,
+        message: `manifest file does not exist: ${absManifest}`,
+        hint: `Run 'skill-optimizer init ${target.surface}' to generate a template manifest`,
+        fixable: false,
+      });
+    }
+  }
+
+  // Check: model ID format
+  if (Array.isArray(benchmark.models)) {
+    for (let i = 0; i < benchmark.models.length; i++) {
+      const model = benchmark.models[i]!;
+      if (!model.id) continue;
+
+      const hasProviderPrefix = model.id.includes('/') && (
+        model.id.startsWith('openrouter/') ||
+        model.id.startsWith('anthropic/') ||
+        model.id.startsWith('openai/')
+      );
+      if (!hasProviderPrefix) {
+        issues.push({
+          code: 'model-id-missing-prefix', severity: 'error', field: `benchmark.models[${i}].id`,
+          message: `model ID "${model.id}" is missing a provider prefix`,
+          hint: `Change to: openrouter/${model.id}`,
+          fixable: true,
+        });
+      }
+
+      if (/\d+\.\d+/.test(model.id)) {
+        const corrected = model.id.replace(/(\d+)\.(\d+)/g, '$1-$2');
+        issues.push({
+          code: 'model-id-bad-format', severity: 'warning', field: `benchmark.models[${i}].id`,
+          message: `model ID "${model.id}" uses dots in version segment — OpenRouter expects hyphens`,
+          hint: `Change to: ${corrected}`,
+          fixable: true,
+        });
+      }
+    }
+  }
+
+  // Check: optimize.allowedPaths inside target.repoPath
+  if (optimize?.allowedPaths && target.repoPath) {
+    const absRepo = isAbsolute(target.repoPath) ? target.repoPath : resolve(configDir, target.repoPath);
+    for (const ap of optimize.allowedPaths) {
+      const absAp = isAbsolute(ap) ? ap : resolve(configDir, ap);
+      if (!absAp.startsWith(absRepo)) {
+        issues.push({
+          code: 'allowed-path-outside-repo', severity: 'error', field: 'optimize.allowedPaths',
+          message: `allowedPath "${ap}" is not inside target.repoPath "${absRepo}"`,
+          hint: `Use a path inside ${absRepo}`,
+          fixable: false,
+        });
+      }
+    }
+  }
+
+  // Check: API key env var
+  const apiKeyEnv = benchmark.apiKeyEnv ?? 'OPENROUTER_API_KEY';
+  if (!process.env[apiKeyEnv]) {
+    issues.push({
+      code: 'api-key-not-set', severity: 'warning', field: 'benchmark.apiKeyEnv',
+      message: `env var "${apiKeyEnv}" is not set`,
+      hint: `Run: export ${apiKeyEnv}=sk-or-...`,
+      fixable: false,
+    });
+  }
+
+  // Check: dirty git (injection-safe: fixed arg array, no shell)
+  if (optimize?.requireCleanGit !== false && target.repoPath) {
+    const absRepo = isAbsolute(target.repoPath) ? target.repoPath : resolve(configDir, target.repoPath);
+    if (existsSync(absRepo)) {
+      try {
+        const { stdout } = await execFileAsync('git', ['status', '--porcelain'], { cwd: absRepo });
+        if (stdout.trim().length > 0) {
+          issues.push({
+            code: 'dirty-git', severity: 'error', field: 'target.repoPath',
+            message: `target repo has uncommitted changes (optimize.requireCleanGit is enabled)`,
+            hint: `Run: git stash  or commit your changes in ${absRepo}`,
+            fixable: false,
+          });
+        }
+      } catch {
+        // Not a git repo or git unavailable — skip silently
+      }
+    }
+  }
+
+  // Check: deprecated benchmark.tasks field
+  if ((benchmark as any).tasks !== undefined && benchmark.taskGeneration?.enabled === true) {
+    issues.push({
+      code: 'deprecated-tasks-field', severity: 'warning', field: 'benchmark.tasks',
+      message: '"benchmark.tasks" is set but task generation is enabled — the tasks field is deprecated',
+      hint: `Remove "tasks" from benchmark — task generation replaces it`,
+      fixable: true,
+    });
+  }
+
+  // Check: legacy skill-benchmark.json alongside skill-optimizer.json
+  const legacyPath = resolve(dirname(_configPath), 'skill-benchmark.json');
+  if (existsSync(legacyPath)) {
+    issues.push({
+      code: 'legacy-config-name', severity: 'warning', field: '(config file)',
+      message: `Found legacy "skill-benchmark.json" alongside "skill-optimizer.json"`,
+      hint: `Delete skill-benchmark.json — it is no longer used`,
+      fixable: false,
+    });
+  }
 
   return issues;
 }

--- a/src/tasks/discover.ts
+++ b/src/tasks/discover.ts
@@ -4,8 +4,8 @@ import { buildSurfaceSnapshot, loadProjectConfig } from '../project/index.js';
 
 import type { DiscoveredTaskSurface } from './types.js';
 
-export function discoverTaskSurface(configPath: string): DiscoveredTaskSurface {
-  const project = loadProjectConfig(configPath);
+export async function discoverTaskSurface(configPath: string): Promise<DiscoveredTaskSurface> {
+  const project = await loadProjectConfig(configPath);
   const skillPath = project.target.skill?.source;
   if (!skillPath) {
     throw new Error('Project config must define target.skill for task generation');

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -40,8 +40,10 @@ export async function generateTasksForProject(
   // Apply scope filter
   const { inScope, outOfScope } = resolveScope(surface.snapshot.actions, surface.project.target.scope);
   if (inScope.length === 0) {
-    throw new Error(
-      `target.scope produced zero in-scope actions. Adjust target.scope.include/exclude in ${params.configPath}.`,
+    console.warn(
+      `[warn] Discovery found 0 in-scope actions for surface "${surface.snapshot.surface}".` +
+      ` If using CLI surface, add target.cli.commands in your config.` +
+      ` Run 'skill-optimizer doctor' for a full diagnosis.`
     );
   }
   console.log(`[optimize] Scope filter: ${inScope.length} in scope, ${outOfScope.length} out of scope.`);

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -34,7 +34,7 @@ export async function generateTasksForProject(
   },
 ): Promise<GenerateTasksForProjectResult> {
   console.log('[optimize] Discovering surface for task generation...');
-  const surface = discoverTaskSurface(params.configPath);
+  const surface = await discoverTaskSurface(params.configPath);
   console.log(`[optimize] Loaded ${surface.snapshot.surface} surface with ${surface.snapshot.actions.length} actions.`);
 
   // Apply scope filter

--- a/tests/smoke-actions.ts
+++ b/tests/smoke-actions.ts
@@ -330,7 +330,7 @@ await test('loadActionSnapshotFile includes path on invalid JSON', () => {
   }
 });
 
-await test('buildSurfaceSnapshot returns expected legacy snapshot fields from discovery fixture', () => {
+await test('buildSurfaceSnapshot returns expected legacy snapshot fields from discovery fixture', async () => {
   const root = mkdtempSync(join(tmpdir(), 'skill-optimizer-snapshot-bridge-'));
   try {
     const sourcePath = join(root, 'server.ts');
@@ -375,7 +375,7 @@ await test('buildSurfaceSnapshot returns expected legacy snapshot fields from di
       },
     }, null, 2), 'utf-8');
 
-    const project = loadProjectConfig(configPath);
+    const project = await loadProjectConfig(configPath);
     const actual = buildSurfaceSnapshot(project);
 
     assertEqual(actual.surface, 'mcp', 'snapshot surface should be mcp');

--- a/tests/smoke-code.ts
+++ b/tests/smoke-code.ts
@@ -648,6 +648,61 @@ await test('computeCoverage: identifies covered and uncovered methods', () => {
   assertEqual(sendCov!.covered, false, 'FastWallet.send should NOT be covered');
 });
 
+console.log('\n=== Doctor / checkConfig Tests ===\n');
+
+await test('checkConfig: valid sdk config returns no errors', async () => {
+  const { checkConfig } = await import('../src/project/validate.js');
+  const config = {
+    name: 'my-sdk',
+    target: { surface: 'sdk' as const, discovery: { sources: ['./src/index.ts'], language: 'typescript' as const } },
+    benchmark: {
+      format: 'pi' as const,
+      models: [{ id: 'openrouter/openai/gpt-4o', name: 'GPT-4o', tier: 'flagship' as const }],
+      tasks: './tasks.json',
+    },
+  };
+  const issues = await checkConfig(config as any, '/fake/path/skill-optimizer.json');
+  const errors = issues.filter(i => i.severity === 'error');
+  assert(errors.length === 0, `expected 0 errors, got: ${errors.map(i => i.message).join(', ')}`);
+});
+
+await test('checkConfig: missing name returns error', async () => {
+  const { checkConfig } = await import('../src/project/validate.js');
+  const config = {
+    target: { surface: 'sdk' as const },
+    benchmark: { models: [] },
+  };
+  const issues = await checkConfig(config as any, '/fake/path/skill-optimizer.json');
+  const err = issues.find(i => i.code === 'missing-name');
+  assert(err !== undefined, 'expected missing-name error');
+  assert(err!.severity === 'error', 'should be error severity');
+});
+
+await test('checkConfig: invalid surface returns error', async () => {
+  const { checkConfig } = await import('../src/project/validate.js');
+  const config = {
+    name: 'test',
+    target: { surface: 'grpc' },
+    benchmark: { models: [{ id: 'openrouter/openai/gpt-4o', name: 'GPT-4o', tier: 'flagship' }] },
+  };
+  const issues = await checkConfig(config as any, '/fake/path/skill-optimizer.json');
+  const err = issues.find(i => i.code === 'invalid-surface');
+  assert(err !== undefined, 'expected invalid-surface issue');
+  assert(err!.severity === 'error', 'should be error severity');
+});
+
+await test('checkConfig: empty models array returns error', async () => {
+  const { checkConfig } = await import('../src/project/validate.js');
+  const config = {
+    name: 'test',
+    target: { surface: 'sdk' as const },
+    benchmark: { models: [] },
+  };
+  const issues = await checkConfig(config as any, '/fake/path/skill-optimizer.json');
+  const err = issues.find(i => i.code === 'missing-models');
+  assert(err !== undefined, 'expected missing-models error for benchmark.models');
+});
+
 // ── Summary ────────────────────────────────────────────────────────────────
 
 console.log(`\n${passed} passed, ${failed} failed\n`);

--- a/tests/smoke-code.ts
+++ b/tests/smoke-code.ts
@@ -105,7 +105,7 @@ await test('extractSdkCodeBlock: finds rust block', () => {
   assertEqual(result, 'let client = FastClient::new();', 'should extract rust block content');
 });
 
-await test('loadConfig: rejects unsupported sdk language', () => {
+await test('loadConfig: rejects unsupported sdk language', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'skill-optimizer-lang-'));
   try {
     const configPath = join(dir, 'skill-optimizer.json');
@@ -127,7 +127,7 @@ await test('loadConfig: rejects unsupported sdk language', () => {
 
     let threw = false;
     try {
-      loadConfig(configPath);
+      await loadConfig(configPath);
     } catch (error: any) {
       threw = true;
       assert(

--- a/tests/smoke-code.ts
+++ b/tests/smoke-code.ts
@@ -911,7 +911,8 @@ await test('doctor --fix: corrects model ID in-place', async () => {
     await runDoctor(configPath, { staticOnly: true, fix: true });
 
     const fixed = JSON.parse(readFileSync(configPath, 'utf-8')) as { benchmark: { models: Array<{ id: string }> } };
-    assertEqual(fixed.benchmark.models[0]!.id, 'openrouter/z-ai/glm-5.1', '--fix should write corrected model ID');
+    // Fixed-point loop applies both prefix and dot-normalisation fixes in sequence
+    assertEqual(fixed.benchmark.models[0]!.id, 'openrouter/z-ai/glm-5-1', '--fix should write corrected model ID');
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/smoke-code.ts
+++ b/tests/smoke-code.ts
@@ -845,6 +845,78 @@ await test('applyFixes: does not mutate input', async () => {
   assertEqual((rawJson.benchmark.models[0] as any).id, 'z-ai/glm-5.1', 'input should not be mutated');
 });
 
+console.log('\n=== Doctor command smoke tests ===\n');
+
+await test('doctor --static: exits 1 for config with model-id error', async () => {
+  const { runDoctor } = await import('../src/doctor/index.js');
+  const dir = mkdtempSync(join(tmpdir(), 'skill-optimizer-doctor-'));
+  try {
+    const configPath = join(dir, 'skill-optimizer.json');
+    writeFileSync(configPath, JSON.stringify({
+      name: 'test-bad',
+      target: { surface: 'cli', discovery: { sources: ['./src/cli.ts'] } },
+      benchmark: {
+        format: 'pi',
+        models: [{ id: 'z-ai/glm-5.1', name: 'GLM', tier: 'mid' }],
+        taskGeneration: { enabled: true, maxTasks: 5 },
+      },
+    }, null, 2), 'utf-8');
+
+    const exitCode = await runDoctor(configPath, { staticOnly: true });
+    assertEqual(exitCode, 1, 'should exit 1 for model-id-missing-prefix error');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+await test('doctor --static: exits 0 or 1 (not 2) for readable config', async () => {
+  const { runDoctor } = await import('../src/doctor/index.js');
+  const dir = mkdtempSync(join(tmpdir(), 'skill-optimizer-doctor-'));
+  try {
+    const configPath = join(dir, 'skill-optimizer.json');
+    writeFileSync(configPath, JSON.stringify({
+      name: 'test-ok',
+      target: { surface: 'mcp', discovery: { sources: ['./src/server.ts'] } },
+      benchmark: {
+        format: 'pi',
+        models: [{ id: 'openrouter/openai/gpt-4o', name: 'GPT-4o', tier: 'flagship' }],
+        taskGeneration: { enabled: true, maxTasks: 10 },
+      },
+    }, null, 2), 'utf-8');
+
+    const exitCode = await runDoctor(configPath, { staticOnly: true });
+    // discovery-source-missing fires (./src/server.ts doesn't exist in tmpdir)
+    // but config is readable JSON so it must not be exit code 2
+    assert(exitCode === 0 || exitCode === 1, `should exit 0 or 1 (config is readable JSON), got ${exitCode}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+await test('doctor --fix: corrects model ID in-place', async () => {
+  const { runDoctor } = await import('../src/doctor/index.js');
+  const dir = mkdtempSync(join(tmpdir(), 'skill-optimizer-doctor-'));
+  try {
+    const configPath = join(dir, 'skill-optimizer.json');
+    writeFileSync(configPath, JSON.stringify({
+      name: 'test-fix',
+      target: { surface: 'cli', discovery: { sources: ['./src/cli.ts'] } },
+      benchmark: {
+        format: 'pi',
+        models: [{ id: 'z-ai/glm-5.1', name: 'GLM', tier: 'mid' }],
+        taskGeneration: { enabled: true, maxTasks: 5 },
+      },
+    }, null, 2), 'utf-8');
+
+    await runDoctor(configPath, { staticOnly: true, fix: true });
+
+    const fixed = JSON.parse(readFileSync(configPath, 'utf-8')) as { benchmark: { models: Array<{ id: string }> } };
+    assertEqual(fixed.benchmark.models[0]!.id, 'openrouter/z-ai/glm-5.1', '--fix should write corrected model ID');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 // ── Summary ────────────────────────────────────────────────────────────────
 
 console.log(`\n${passed} passed, ${failed} failed\n`);

--- a/tests/smoke-code.ts
+++ b/tests/smoke-code.ts
@@ -652,18 +652,28 @@ console.log('\n=== Doctor / checkConfig Tests ===\n');
 
 await test('checkConfig: valid sdk config returns no errors', async () => {
   const { checkConfig } = await import('../src/project/validate.js');
-  const config = {
-    name: 'my-sdk',
-    target: { surface: 'sdk' as const, discovery: { sources: ['./src/index.ts'], language: 'typescript' as const } },
-    benchmark: {
-      format: 'pi' as const,
-      models: [{ id: 'openrouter/openai/gpt-4o', name: 'GPT-4o', tier: 'flagship' as const }],
-      tasks: './tasks.json',
-    },
-  };
-  const issues = await checkConfig(config as any, '/fake/path/skill-optimizer.json');
-  const errors = issues.filter(i => i.severity === 'error');
-  assert(errors.length === 0, `expected 0 errors, got: ${errors.map(i => i.message).join(', ')}`);
+  const dir = mkdtempSync(join(tmpdir(), 'skill-optimizer-check-'));
+  try {
+    // Create real files so path-existence checks pass
+    writeFileSync(join(dir, 'index.ts'), '// entry', 'utf-8');
+    writeFileSync(join(dir, 'tasks.json'), JSON.stringify({ tasks: [] }), 'utf-8');
+    const configPath = join(dir, 'skill-optimizer.json');
+    const config = {
+      name: 'my-sdk',
+      target: { surface: 'sdk' as const, discovery: { sources: ['./index.ts'], language: 'typescript' as const } },
+      benchmark: {
+        format: 'pi' as const,
+        models: [{ id: 'openrouter/openai/gpt-4o', name: 'GPT-4o', tier: 'flagship' as const }],
+        tasks: './tasks.json',
+      },
+    };
+    const issues = await checkConfig(config as any, configPath);
+    // Filter out api-key-not-set warning (env-dependent) and focus on real errors
+    const errors = issues.filter(i => i.severity === 'error');
+    assert(errors.length === 0, `expected 0 errors, got: ${errors.map(i => i.message).join(', ')}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 await test('checkConfig: missing name returns error', async () => {
@@ -701,6 +711,62 @@ await test('checkConfig: empty models array returns error', async () => {
   const issues = await checkConfig(config as any, '/fake/path/skill-optimizer.json');
   const err = issues.find(i => i.code === 'missing-models');
   assert(err !== undefined, 'expected missing-models error for benchmark.models');
+});
+
+await test('checkConfig: model ID missing openrouter/ prefix → fixable error', async () => {
+  const { checkConfig } = await import('../src/project/validate.js');
+  const config = {
+    name: 'test',
+    target: { surface: 'cli' as const, discovery: { sources: ['./src/cli.ts'] } },
+    benchmark: {
+      format: 'pi' as const,
+      models: [{ id: 'z-ai/glm-5.1', name: 'GLM', tier: 'mid' as const }],
+      taskGeneration: { enabled: true, maxTasks: 5 },
+    },
+  };
+  const issues = await checkConfig(config as any, '/fake/skill-optimizer.json');
+  const err = issues.find(i => i.code === 'model-id-missing-prefix');
+  assert(err !== undefined, 'expected model-id-missing-prefix issue');
+  assert(err!.fixable === true, 'model-id-missing-prefix should be fixable');
+  assert(err!.hint?.includes('openrouter/z-ai/glm-5.1'), `hint should show corrected ID, got: ${err!.hint}`);
+});
+
+await test('checkConfig: model ID with dot version → fixable warning', async () => {
+  const { checkConfig } = await import('../src/project/validate.js');
+  const config = {
+    name: 'test',
+    target: { surface: 'cli' as const, discovery: { sources: ['./src/cli.ts'] } },
+    benchmark: {
+      format: 'pi' as const,
+      models: [{ id: 'openrouter/anthropic/claude-sonnet-4.6', name: 'Claude', tier: 'flagship' as const }],
+      taskGeneration: { enabled: true, maxTasks: 5 },
+    },
+  };
+  const issues = await checkConfig(config as any, '/fake/skill-optimizer.json');
+  const warn = issues.find(i => i.code === 'model-id-bad-format');
+  assert(warn !== undefined, 'expected model-id-bad-format issue');
+  assert(warn!.severity === 'warning', 'should be warning severity');
+  assert(warn!.fixable === true, 'model-id-bad-format should be fixable');
+  assert(warn!.hint?.includes('4-6'), `hint should show hyphen version, got: ${warn!.hint}`);
+});
+
+await test('checkConfig: deprecated benchmark.tasks field → fixable warning', async () => {
+  const { checkConfig } = await import('../src/project/validate.js');
+  const config = {
+    name: 'test',
+    target: { surface: 'cli' as const, discovery: { sources: ['./src/cli.ts'] } },
+    benchmark: {
+      format: 'pi' as const,
+      models: [{ id: 'openrouter/openai/gpt-4o', name: 'GPT', tier: 'flagship' as const }],
+      tasks: './tasks.json',
+      taskGeneration: { enabled: true, maxTasks: 5 },
+    },
+  };
+  const issues = await checkConfig(config as any, '/fake/skill-optimizer.json');
+  const warn = issues.find(i => i.code === 'deprecated-tasks-field');
+  assert(warn !== undefined, 'expected deprecated-tasks-field issue');
+  assert(warn!.severity === 'warning', 'should be warning');
+  assert(warn!.fixable === true, 'deprecated-tasks-field should be fixable');
 });
 
 // ── Summary ────────────────────────────────────────────────────────────────

--- a/tests/smoke-code.ts
+++ b/tests/smoke-code.ts
@@ -770,6 +770,81 @@ await test('checkConfig: deprecated benchmark.tasks field → fixable warning', 
   assert(warn!.fixable === true, 'deprecated-tasks-field should be fixable');
 });
 
+await test('applyFixes: adds openrouter/ prefix to model IDs', async () => {
+  const { applyFixes } = await import('../src/project/fix.js');
+  const { checkConfig } = await import('../src/project/validate.js');
+  const rawJson = {
+    name: 'test',
+    target: { surface: 'cli', discovery: { sources: ['./src/cli.ts'] } },
+    benchmark: {
+      format: 'pi',
+      models: [
+        { id: 'z-ai/glm-5.1', name: 'GLM', tier: 'mid' },
+        { id: 'openrouter/openai/gpt-4o', name: 'GPT', tier: 'flagship' },
+      ],
+      taskGeneration: { enabled: true, maxTasks: 5 },
+    },
+  };
+  const issues = await checkConfig(rawJson as any, '/fake/skill-optimizer.json');
+  const fixed = applyFixes(rawJson as any, issues, '/fake');
+  const models = (fixed.benchmark as any).models as Array<{ id: string }>;
+  assertEqual(models[0]!.id, 'openrouter/z-ai/glm-5.1', 'prefix should be prepended');
+  assertEqual(models[1]!.id, 'openrouter/openai/gpt-4o', 'already-prefixed ID should be unchanged');
+});
+
+await test('applyFixes: normalises dot versions in model IDs', async () => {
+  const { applyFixes } = await import('../src/project/fix.js');
+  const { checkConfig } = await import('../src/project/validate.js');
+  const rawJson = {
+    name: 'test',
+    target: { surface: 'cli', discovery: { sources: ['./src/cli.ts'] } },
+    benchmark: {
+      format: 'pi',
+      models: [{ id: 'openrouter/anthropic/claude-sonnet-4.6', name: 'Claude', tier: 'flagship' }],
+      taskGeneration: { enabled: true, maxTasks: 5 },
+    },
+  };
+  const issues = await checkConfig(rawJson as any, '/fake/skill-optimizer.json');
+  const fixed = applyFixes(rawJson as any, issues, '/fake');
+  const models = (fixed.benchmark as any).models as Array<{ id: string }>;
+  assertEqual(models[0]!.id, 'openrouter/anthropic/claude-sonnet-4-6', 'dots should be replaced with hyphens');
+});
+
+await test('applyFixes: removes deprecated benchmark.tasks field', async () => {
+  const { applyFixes } = await import('../src/project/fix.js');
+  const { checkConfig } = await import('../src/project/validate.js');
+  const rawJson = {
+    name: 'test',
+    target: { surface: 'cli', discovery: { sources: ['./src/cli.ts'] } },
+    benchmark: {
+      format: 'pi',
+      models: [{ id: 'openrouter/openai/gpt-4o', name: 'GPT', tier: 'flagship' }],
+      tasks: './tasks.json',
+      taskGeneration: { enabled: true, maxTasks: 5 },
+    },
+  };
+  const issues = await checkConfig(rawJson as any, '/fake/skill-optimizer.json');
+  const fixed = applyFixes(rawJson as any, issues, '/fake');
+  assert(!(fixed.benchmark as any).tasks, 'deprecated tasks field should be removed');
+});
+
+await test('applyFixes: does not mutate input', async () => {
+  const { applyFixes } = await import('../src/project/fix.js');
+  const { checkConfig } = await import('../src/project/validate.js');
+  const rawJson = {
+    name: 'test',
+    target: { surface: 'cli', discovery: { sources: ['./src/cli.ts'] } },
+    benchmark: {
+      format: 'pi',
+      models: [{ id: 'z-ai/glm-5.1', name: 'GLM', tier: 'mid' }],
+      taskGeneration: { enabled: true, maxTasks: 5 },
+    },
+  };
+  const issues = await checkConfig(rawJson as any, '/fake/skill-optimizer.json');
+  applyFixes(rawJson as any, issues, '/fake');
+  assertEqual((rawJson.benchmark.models[0] as any).id, 'z-ai/glm-5.1', 'input should not be mutated');
+});
+
 // ── Summary ────────────────────────────────────────────────────────────────
 
 console.log(`\n${passed} passed, ${failed} failed\n`);

--- a/tests/smoke-code.ts
+++ b/tests/smoke-code.ts
@@ -728,6 +728,7 @@ await test('checkConfig: model ID missing openrouter/ prefix → fixable error',
   const err = issues.find(i => i.code === 'model-id-missing-prefix');
   assert(err !== undefined, 'expected model-id-missing-prefix issue');
   assert(err!.fixable === true, 'model-id-missing-prefix should be fixable');
+  assert(err!.severity === 'error', 'model-id-missing-prefix should be error severity');
   assert(err!.hint?.includes('openrouter/z-ai/glm-5.1'), `hint should show corrected ID, got: ${err!.hint}`);
 });
 

--- a/tests/smoke-discovery-cli.ts
+++ b/tests/smoke-discovery-cli.ts
@@ -174,7 +174,7 @@ await test('discovery remains static and does not execute source file', () => {
   }
 });
 
-await test('discovers cli actions via public action discovery entrypoint', () => {
+await test('discovers cli actions via public action discovery entrypoint', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'cli-discovery-actions-'));
   const sourcePath = join(dir, 'commands.ts');
   const configPath = join(dir, 'skill-optimizer.json');
@@ -212,7 +212,7 @@ await test('discovers cli actions via public action discovery entrypoint', () =>
       },
     }, null, 2), 'utf-8');
 
-    const project = loadProjectConfig(configPath);
+    const project = await loadProjectConfig(configPath);
     const catalog = discoverActions(project);
     assertEqual(catalog.surface, 'cli', 'surface should be cli');
     assertEqual(catalog.actions.length, 1, 'should discover one cli action');
@@ -252,7 +252,7 @@ await test('reads cli actions via actions-layer reader export', () => {
   }
 });
 
-await test('discoverActions uses manifest commands when CLI discovery mode is manifest', () => {
+await test('discoverActions uses manifest commands when CLI discovery mode is manifest', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'cli-discovery-manifest-'));
   const commandsPath = join(dir, 'commands.json');
   const configPath = join(dir, 'skill-optimizer.json');
@@ -285,7 +285,7 @@ await test('discoverActions uses manifest commands when CLI discovery mode is ma
       },
     }, null, 2), 'utf-8');
 
-    const project = loadProjectConfig(configPath);
+    const project = await loadProjectConfig(configPath);
     const catalog = discoverActions(project);
     assertEqual(catalog.surface, 'cli', 'surface should be cli');
     assertEqual(catalog.actions.length, 1, 'manifest-backed discovery should return one action');

--- a/tests/smoke-discovery-mcp.ts
+++ b/tests/smoke-discovery-mcp.ts
@@ -100,7 +100,7 @@ await test('discovery remains static and does not execute source file', () => {
   }
 });
 
-await test('code-first MCP project config works without fallback manifest', () => {
+await test('code-first MCP project config works without fallback manifest', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'mcp-project-config-'));
   try {
     const serverPath = join(dir, 'server.ts');
@@ -124,7 +124,7 @@ await test('code-first MCP project config works without fallback manifest', () =
       },
     }, null, 2), 'utf-8');
 
-    const project = loadProjectConfig(configPath);
+    const project = await loadProjectConfig(configPath);
     const snapshot = buildSurfaceSnapshot(project);
     assertEqual(snapshot.actions.length, 4, 'code-first config should discover tools without fallback manifest');
   } finally {
@@ -132,7 +132,7 @@ await test('code-first MCP project config works without fallback manifest', () =
   }
 });
 
-await test('code-first discovery fails fast when MCP source is missing', () => {
+await test('code-first discovery fails fast when MCP source is missing', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'mcp-project-config-'));
   try {
     const configPath = join(dir, 'skill-optimizer.json');
@@ -154,7 +154,7 @@ await test('code-first discovery fails fast when MCP source is missing', () => {
       },
     }, null, 2), 'utf-8');
 
-    const project = loadProjectConfig(configPath);
+    const project = await loadProjectConfig(configPath);
     let threw = false;
     try {
       buildSurfaceSnapshot(project);
@@ -168,7 +168,7 @@ await test('code-first discovery fails fast when MCP source is missing', () => {
   }
 });
 
-await test('discovers mcp actions via public action discovery entrypoint', () => {
+await test('discovers mcp actions via public action discovery entrypoint', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'mcp-discovery-actions-'));
   const sourcePath = join(dir, 'server.ts');
   const configPath = join(dir, 'skill-optimizer.json');
@@ -213,7 +213,7 @@ await test('discovers mcp actions via public action discovery entrypoint', () =>
       },
     }, null, 2), 'utf-8');
 
-    const project = loadProjectConfig(configPath);
+    const project = await loadProjectConfig(configPath);
     const catalog = discoverActions(project);
     assertEqual(catalog.surface, 'mcp', 'surface should be mcp');
     assertEqual(catalog.actions.length, 1, 'should discover one mcp action');
@@ -223,7 +223,7 @@ await test('discovers mcp actions via public action discovery entrypoint', () =>
   }
 });
 
-await test('discoverActions fails fast when MCP discovery source is missing and no fallback exists', () => {
+await test('discoverActions fails fast when MCP discovery source is missing and no fallback exists', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'mcp-actions-missing-source-'));
   const configPath = join(dir, 'skill-optimizer.json');
 
@@ -245,7 +245,7 @@ await test('discoverActions fails fast when MCP discovery source is missing and 
       },
     }, null, 2), 'utf-8');
 
-    const project = loadProjectConfig(configPath);
+    const project = await loadProjectConfig(configPath);
     let threw = false;
     try {
       discoverActions(project);

--- a/tests/smoke-discovery-mcp.ts
+++ b/tests/smoke-discovery-mcp.ts
@@ -154,13 +154,20 @@ await test('code-first discovery fails fast when MCP source is missing', async (
       },
     }, null, 2), 'utf-8');
 
-    const project = await loadProjectConfig(configPath);
+    // loadProjectConfig now validates paths eagerly — expect it to throw when source is missing
     let threw = false;
     try {
+      const project = await loadProjectConfig(configPath);
+      // If load succeeds (future behavior change), check that buildSurfaceSnapshot also fails
       buildSurfaceSnapshot(project);
     } catch (error: any) {
       threw = true;
-      assert(error.message.includes('not found'), 'missing source error should mention not found');
+      // Accept either the new validation error or the old discovery error
+      const msg: string = error.message;
+      assert(
+        msg.includes('does not exist') || msg.includes('not found'),
+        `missing source error should mention missing path, got: ${msg}`,
+      );
     }
     assert(threw, 'missing discovery source should fail fast');
   } finally {
@@ -245,13 +252,20 @@ await test('discoverActions fails fast when MCP discovery source is missing and 
       },
     }, null, 2), 'utf-8');
 
-    const project = await loadProjectConfig(configPath);
+    // loadProjectConfig now validates paths eagerly — expect it to throw when source is missing
     let threw = false;
     try {
+      const project = await loadProjectConfig(configPath);
+      // If load succeeds (future behavior change), check that discoverActions also fails
       discoverActions(project);
     } catch (error: any) {
       threw = true;
-      assert(error.message.includes('not found'), 'missing source error should mention not found');
+      // Accept either the new validation error or the old discovery error
+      const msg: string = error.message;
+      assert(
+        msg.includes('does not exist') || msg.includes('not found'),
+        `missing source error should mention missing path, got: ${msg}`,
+      );
     }
 
     assert(threw, 'missing discovery source should fail fast when no fallback exists');

--- a/tests/smoke-discovery-sdk.ts
+++ b/tests/smoke-discovery-sdk.ts
@@ -193,7 +193,7 @@ await test('discovers alias names for re-exported SDK actions', () => {
   }
 });
 
-await test('project snapshot falls back to sdk.apiSurface when discovery returns zero actions', () => {
+await test('project snapshot falls back to sdk.apiSurface when discovery returns zero actions', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'sdk-discovery-'));
   const sourcePath = join(dir, 'index.ts');
   const configPath = join(dir, 'skill-optimizer.json');
@@ -222,7 +222,7 @@ await test('project snapshot falls back to sdk.apiSurface when discovery returns
       },
     }, null, 2), 'utf-8');
 
-    const project = loadProjectConfig(configPath);
+    const project = await loadProjectConfig(configPath);
     const snapshot = buildSurfaceSnapshot(project);
     assertEqual(snapshot.actions.length, 1, 'sdk apiSurface should be used as fallback');
     assertEqual(snapshot.actions[0]?.name, 'sendTokens', 'fallback action should come from sdk.apiSurface');
@@ -255,7 +255,7 @@ await test('parses files statically and never executes source code', () => {
   }
 });
 
-await test('discovers sdk actions via public action discovery entrypoint', () => {
+await test('discovers sdk actions via public action discovery entrypoint', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'sdk-discovery-actions-'));
   const sourcePath = join(dir, 'client.ts');
   const configPath = join(dir, 'skill-optimizer.json');
@@ -290,7 +290,7 @@ await test('discovers sdk actions via public action discovery entrypoint', () =>
       },
     }, null, 2), 'utf-8');
 
-    const project = loadProjectConfig(configPath);
+    const project = await loadProjectConfig(configPath);
     const catalog = discoverActions(project);
     assertEqual(catalog.surface, 'sdk', 'surface should be sdk');
 
@@ -301,7 +301,7 @@ await test('discovers sdk actions via public action discovery entrypoint', () =>
   }
 });
 
-await test('discoverActions falls back to sdk.apiSurface when discovery returns zero actions', () => {
+await test('discoverActions falls back to sdk.apiSurface when discovery returns zero actions', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'sdk-discovery-actions-fallback-'));
   const sourcePath = join(dir, 'index.ts');
   const configPath = join(dir, 'skill-optimizer.json');
@@ -330,7 +330,7 @@ await test('discoverActions falls back to sdk.apiSurface when discovery returns 
       },
     }, null, 2), 'utf-8');
 
-    const project = loadProjectConfig(configPath);
+    const project = await loadProjectConfig(configPath);
     const catalog = discoverActions(project);
     assertEqual(catalog.surface, 'sdk', 'surface should be sdk');
     assertEqual(catalog.actions.length, 1, 'sdk apiSurface should be used as fallback');

--- a/tests/smoke-generation.ts
+++ b/tests/smoke-generation.ts
@@ -107,10 +107,10 @@ function makeFixture(): {
 
 console.log('\n=== Task Generation Smoke Tests ===\n');
 
-await test('discoverTaskSurface: resolves and loads skill/snapshot', () => {
+await test('discoverTaskSurface: resolves and loads skill/snapshot', async () => {
   const fixture = makeFixture();
   try {
-    const surface = discoverTaskSurface(fixture.benchmarkConfigPath);
+    const surface = await discoverTaskSurface(fixture.benchmarkConfigPath);
     assertEqual(surface.skillPath, resolve(fixture.skillPath), 'skill path should resolve absolute');
     assert(surface.skillMarkdown.includes('Wallet skill'), 'skill markdown should be loaded');
     assertEqual(surface.snapshot.surface, 'mcp', 'surface should be mcp');
@@ -123,7 +123,7 @@ await test('discoverTaskSurface: resolves and loads skill/snapshot', () => {
 await test('generateCandidateTasks: parses strict JSON response', async () => {
   const fixture = makeFixture();
   try {
-    const surface = discoverTaskSurface(fixture.benchmarkConfigPath);
+    const surface = await discoverTaskSurface(fixture.benchmarkConfigPath);
     const deps: TaskGeneratorDeps = {
       async complete() {
         return JSON.stringify({
@@ -151,7 +151,7 @@ await test('generateCandidateTasks: parses strict JSON response', async () => {
 await test('generateCandidateTasks: enforces maxTasks cap after parsing', async () => {
   const fixture = makeFixture();
   try {
-    const surface = discoverTaskSurface(fixture.benchmarkConfigPath);
+    const surface = await discoverTaskSurface(fixture.benchmarkConfigPath);
     const deps: TaskGeneratorDeps = {
       async complete() {
         return JSON.stringify({
@@ -174,7 +174,7 @@ await test('generateCandidateTasks: enforces maxTasks cap after parsing', async 
 await test('generateCandidateTasks: rejects unsafe task ids', async () => {
   const fixture = makeFixture();
   try {
-    const surface = discoverTaskSurface(fixture.benchmarkConfigPath);
+    const surface = await discoverTaskSurface(fixture.benchmarkConfigPath);
     const deps: TaskGeneratorDeps = {
       async complete() {
         return JSON.stringify({
@@ -201,7 +201,7 @@ await test('generateCandidateTasks: rejects unsafe task ids', async () => {
 await test('generateCandidateTasks: rejects dot-segment task ids', async () => {
   const fixture = makeFixture();
   try {
-    const surface = discoverTaskSurface(fixture.benchmarkConfigPath);
+    const surface = await discoverTaskSurface(fixture.benchmarkConfigPath);
     const deps: TaskGeneratorDeps = {
       async complete() {
         return JSON.stringify({
@@ -228,7 +228,7 @@ await test('generateCandidateTasks: rejects dot-segment task ids', async () => {
 await test('generateCandidateTasks: rejects malformed top-level shape', async () => {
   const fixture = makeFixture();
   try {
-    const surface = discoverTaskSurface(fixture.benchmarkConfigPath);
+    const surface = await discoverTaskSurface(fixture.benchmarkConfigPath);
     const deps: TaskGeneratorDeps = {
       async complete() {
         return JSON.stringify({ not_tasks: [] });
@@ -249,10 +249,10 @@ await test('generateCandidateTasks: rejects malformed top-level shape', async ()
   }
 });
 
-await test('groundTasks: rejects unknown methods and invalid args', () => {
+await test('groundTasks: rejects unknown methods and invalid args', async () => {
   const fixture = makeFixture();
   try {
-    const surface = discoverTaskSurface(fixture.benchmarkConfigPath);
+    const surface = await discoverTaskSurface(fixture.benchmarkConfigPath);
     const tasks: GeneratedTask[] = [
       {
         id: 'ok-task',
@@ -281,7 +281,7 @@ await test('groundTasks: rejects unknown methods and invalid args', () => {
   }
 });
 
-await test('freezeGeneratedBenchmark: writes artifacts and absolute paths', () => {
+await test('freezeGeneratedBenchmark: writes artifacts and absolute paths', async () => {
   const fixture = makeFixture();
   try {
     writeFileSync(fixture.benchmarkConfigPath, JSON.stringify({
@@ -315,7 +315,7 @@ await test('freezeGeneratedBenchmark: writes artifacts and absolute paths', () =
     ];
     const rejected = [{ task: kept[0], reason: 'example reason' }];
 
-    const surface = discoverTaskSurface(fixture.benchmarkConfigPath);
+    const surface = await discoverTaskSurface(fixture.benchmarkConfigPath);
     const frozen = freezeTaskArtifacts({
       project: surface.project,
       snapshot: surface.snapshot,
@@ -389,7 +389,7 @@ await test('generateTasksForProject: runs discover -> generate -> ground -> free
   }
 });
 
-await test('discoverTaskSurface: supports sdk code-first projects', () => {
+await test('discoverTaskSurface: supports sdk code-first projects', async () => {
   const root = mkdtempSync(join(tmpdir(), 'skill-optimizer-sdk-generation-'));
   try {
     writeFileSync(join(root, 'SKILL.md'), '# SDK skill\nUse SDK methods.\n', 'utf-8');
@@ -410,7 +410,7 @@ await test('discoverTaskSurface: supports sdk code-first projects', () => {
       },
     }, null, 2), 'utf-8');
 
-    const surface = discoverTaskSurface(join(root, 'skill-optimizer.json'));
+    const surface = await discoverTaskSurface(join(root, 'skill-optimizer.json'));
     assertEqual(surface.snapshot.surface, 'sdk', 'surface should be sdk');
     assert(surface.snapshot.actions.some((action) => action.name === 'Client.getBalance'), 'sdk action should be discovered');
   } finally {
@@ -418,7 +418,7 @@ await test('discoverTaskSurface: supports sdk code-first projects', () => {
   }
 });
 
-await test('discoverTaskSurface: supports cli code-first projects', () => {
+await test('discoverTaskSurface: supports cli code-first projects', async () => {
   const root = mkdtempSync(join(tmpdir(), 'skill-optimizer-cli-generation-'));
   try {
     writeFileSync(join(root, 'SKILL.md'), '# CLI skill\nUse commands.\n', 'utf-8');
@@ -447,7 +447,7 @@ await test('discoverTaskSurface: supports cli code-first projects', () => {
       },
     }, null, 2), 'utf-8');
 
-    const surface = discoverTaskSurface(join(root, 'skill-optimizer.json'));
+    const surface = await discoverTaskSurface(join(root, 'skill-optimizer.json'));
     assertEqual(surface.snapshot.surface, 'cli', 'surface should be cli');
     assert(surface.snapshot.actions.some((action) => action.name === 'wallet:create'), 'cli action should be discovered');
   } finally {
@@ -484,7 +484,7 @@ await test('cli discovery/task generation canonicalizes option keys for extracti
       },
     }, null, 2), 'utf-8');
 
-    const surface = discoverTaskSurface(join(root, 'skill-optimizer.json'));
+    const surface = await discoverTaskSurface(join(root, 'skill-optimizer.json'));
     assertEqual(surface.snapshot.actions[0]?.args[0]?.name, 'label', 'CLI arg names should be canonicalized without dashes');
 
     const grounded = groundTasks([

--- a/tests/smoke-mock-repos.ts
+++ b/tests/smoke-mock-repos.ts
@@ -53,7 +53,7 @@ for (const name of listMockRepoTemplates()) {
       assert(existsSync(join(materializedPath, '.git')), 'materialized mock repo should be git-initialized');
       assert(existsSync(projectConfigPath), 'unified project config should exist');
 
-      const { config: benchmarkConfig } = loadConfig(projectConfigPath);
+      const { config: benchmarkConfig } = await loadConfig(projectConfigPath);
 
       if (name === 'mcp-tracker-demo') {
         assertEqual(benchmarkConfig.surface, 'mcp', 'tracker demo should materialize an MCP benchmark');
@@ -72,7 +72,7 @@ for (const name of listMockRepoTemplates()) {
         );
         assert(existsSync(join(materializedPath, 'SKILL.md')), 'tracker demo should include SKILL.md');
         assert(existsSync(join(materializedPath, 'tools.json')), 'tracker demo should include tools.json');
-        const optimizeManifest = loadOptimizeManifest(projectConfigPath);
+        const optimizeManifest = await loadOptimizeManifest(projectConfigPath);
         assertEqual(optimizeManifest.targetRepo.path, materializedPath, 'optimize target should point at the materialized repo');
 
         const validation = await createValidationRunner().run(optimizeManifest.targetRepo);

--- a/tests/smoke-optimize.ts
+++ b/tests/smoke-optimize.ts
@@ -174,7 +174,7 @@ function makeManifest(): OptimizeManifest {
 
 console.log('\n=== Optimizer Smoke Tests ===\n');
 
-await test('loadOptimizeManifest: applies defaults', () => {
+await test('loadOptimizeManifest: applies defaults', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'skill-optimizer-'));
   try {
     const file = join(dir, 'skill-optimizer.json');
@@ -197,7 +197,7 @@ await test('loadOptimizeManifest: applies defaults', () => {
       },
     }), 'utf-8');
 
-    const manifest = loadOptimizeManifest(file);
+    const manifest = await loadOptimizeManifest(file);
     assertEqual(manifest.optimizer.maxIterations, 5, 'maxIterations default');
     assertEqual(manifest.optimizer.stabilityWindow, 2, 'stabilityWindow default');
     assertEqual(manifest.optimizer.taskGeneration.enabled, false, 'taskGeneration.enabled default');
@@ -208,7 +208,7 @@ await test('loadOptimizeManifest: applies defaults', () => {
   }
 });
 
-await test('loadOptimizeManifest: defaults optimize.model to the first benchmark model', () => {
+await test('loadOptimizeManifest: defaults optimize.model to the first benchmark model', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'skill-optimizer-'));
   try {
     const file = join(dir, 'skill-optimizer.json');
@@ -230,7 +230,7 @@ await test('loadOptimizeManifest: defaults optimize.model to the first benchmark
       },
     }), 'utf-8');
 
-    const manifest = loadOptimizeManifest(file);
+    const manifest = await loadOptimizeManifest(file);
     assertEqual(manifest.mutation?.provider, 'openrouter', 'mutation provider should default from the first benchmark model');
     assertEqual(manifest.mutation?.model, 'openai/gpt-5.4', 'mutation model should default from the first benchmark model');
   } finally {
@@ -238,7 +238,7 @@ await test('loadOptimizeManifest: defaults optimize.model to the first benchmark
   }
 });
 
-await test('loadOptimizeManifest: allows empty target validation commands', () => {
+await test('loadOptimizeManifest: allows empty target validation commands', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'skill-optimizer-'));
   try {
     const file = join(dir, 'skill-optimizer.json');
@@ -261,14 +261,14 @@ await test('loadOptimizeManifest: allows empty target validation commands', () =
       },
     }), 'utf-8');
 
-    const manifest = loadOptimizeManifest(file);
+    const manifest = await loadOptimizeManifest(file);
     assertEqual(manifest.targetRepo.validation.length, 0, 'empty validation array should be preserved');
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
 });
 
-await test('loadOptimizeManifest: rejects requireCleanGit=false', () => {
+await test('loadOptimizeManifest: rejects requireCleanGit=false', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'skill-optimizer-'));
   try {
     const file = join(dir, 'skill-optimizer.json');
@@ -294,7 +294,7 @@ await test('loadOptimizeManifest: rejects requireCleanGit=false', () => {
 
     let threw = false;
     try {
-      loadOptimizeManifest(file);
+      await loadOptimizeManifest(file);
     } catch (error: any) {
       threw = true;
       assert(error.message.includes('requireCleanGit'), 'error should mention requireCleanGit');
@@ -306,7 +306,7 @@ await test('loadOptimizeManifest: rejects requireCleanGit=false', () => {
   }
 });
 
-await test('loadOptimizeManifest: rejects invalid optimizer numeric values', () => {
+await test('loadOptimizeManifest: rejects invalid optimizer numeric values', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'skill-optimizer-'));
   try {
     const file = join(dir, 'skill-optimizer.json');
@@ -341,7 +341,7 @@ await test('loadOptimizeManifest: rejects invalid optimizer numeric values', () 
 
     let threw = false;
     try {
-      loadOptimizeManifest(file);
+      await loadOptimizeManifest(file);
     } catch (error: any) {
         threw = true;
         assert(

--- a/tests/smoke-optimize.ts
+++ b/tests/smoke-optimize.ts
@@ -177,12 +177,14 @@ console.log('\n=== Optimizer Smoke Tests ===\n');
 await test('loadOptimizeManifest: applies defaults', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'skill-optimizer-'));
   try {
+    const repoDir = join(dir, 'sdk');
+    mkdirSync(join(repoDir, 'src'), { recursive: true });
     const file = join(dir, 'skill-optimizer.json');
     writeFileSync(file, JSON.stringify({
       name: 'opt-defaults',
       target: {
         surface: 'sdk',
-        repoPath: '../sdk',
+        repoPath: './sdk',
         sdk: { language: 'typescript', apiSurface: ['Client.doThing'] },
       },
       benchmark: {
@@ -192,7 +194,7 @@ await test('loadOptimizeManifest: applies defaults', async () => {
       },
       optimize: {
         model: 'openrouter/openai/gpt-5.4',
-        allowedPaths: ['src'],
+        allowedPaths: ['./sdk/src'],
         validation: ['npm test'],
       },
     }), 'utf-8');
@@ -211,12 +213,14 @@ await test('loadOptimizeManifest: applies defaults', async () => {
 await test('loadOptimizeManifest: defaults optimize.model to the first benchmark model', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'skill-optimizer-'));
   try {
+    const repoDir = join(dir, 'sdk');
+    mkdirSync(join(repoDir, 'src'), { recursive: true });
     const file = join(dir, 'skill-optimizer.json');
     writeFileSync(file, JSON.stringify({
       name: 'opt-default-model',
       target: {
         surface: 'sdk',
-        repoPath: '../sdk',
+        repoPath: './sdk',
         sdk: { language: 'typescript', apiSurface: ['Client.doThing'] },
       },
       benchmark: {
@@ -225,7 +229,7 @@ await test('loadOptimizeManifest: defaults optimize.model to the first benchmark
         models: [{ id: 'openrouter/openai/gpt-5.4', name: 'GPT-5.4', tier: 'flagship' }],
       },
       optimize: {
-        allowedPaths: ['src'],
+        allowedPaths: ['./sdk/src'],
         validation: ['npm test'],
       },
     }), 'utf-8');
@@ -241,12 +245,14 @@ await test('loadOptimizeManifest: defaults optimize.model to the first benchmark
 await test('loadOptimizeManifest: allows empty target validation commands', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'skill-optimizer-'));
   try {
+    const repoDir = join(dir, 'sdk');
+    mkdirSync(join(repoDir, 'src'), { recursive: true });
     const file = join(dir, 'skill-optimizer.json');
     writeFileSync(file, JSON.stringify({
       name: 'opt-validation',
       target: {
         surface: 'sdk',
-        repoPath: '../sdk',
+        repoPath: './sdk',
         sdk: { language: 'typescript', apiSurface: ['Client.doThing'] },
       },
       benchmark: {
@@ -256,7 +262,7 @@ await test('loadOptimizeManifest: allows empty target validation commands', asyn
       },
       optimize: {
         model: 'openrouter/openai/gpt-5.4',
-        allowedPaths: ['src'],
+        allowedPaths: ['./sdk/src'],
         validation: [],
       },
     }), 'utf-8');


### PR DESCRIPTION
## Summary

- Refactors `src/project/validate.ts` to export `checkConfig(config, configPath): Promise<Issue[]>` — never throws, collects all issues; keeps `validateProjectConfig` as a thin throwing wrapper so all existing call sites stay unchanged
- 17 validation checks across 3 tiers: path existence, model ID format (missing `openrouter/` prefix, dots→hyphens), env var, deprecated fields, dirty git, allowedPaths bounds
- New `src/project/fix.ts`: `applyFixes()` pure transform for the 3 auto-fixable codes (fixed-point loop applies all fixes in sequence)
- New `src/doctor/` module: discovery check, model-reachability check (gated on `format: "pi"`), ANSI formatter, orchestrator
- New `skill-optimizer doctor [--static] [--check-models] [--fix]` command
- Runtime sweep: discovery warns loudly on zero actions with actionable fix hint

Part of the DX overhaul (Phase 1 of 4). See `docs/superpowers/specs/2026-04-13-dx-overhaul-roadmap.md`.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` — 48 smoke-code tests pass (includes doctor checkConfig, applyFixes, and doctor exit-code tests); 6 pre-existing optimizer loop failures unchanged
- [x] `skill-optimizer doctor --static` shows issues for misconfigured file, exits 1
- [x] `skill-optimizer doctor --fix` corrects model IDs in-place (prefix + dot normalisation in one pass), exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)