### PR TITLE
feat(import): import-commands — auto-extract CLI surface from source or binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "materialize:mock": "tsx src/optimizer/materialize-mock-repo.ts",
     "build": "tsc",
     "typecheck": "tsc --noEmit",
-    "test": "tsx tests/smoke-code.ts && tsx tests/smoke-sdk-python.ts && tsx tests/smoke-sdk-rust.ts && tsx tests/smoke-cli.ts && tsx tests/smoke-cli-entry.ts && tsx tests/smoke-mcp.ts && tsx tests/smoke-llm.ts && tsx tests/smoke-discovery-sdk.ts && tsx tests/smoke-discovery-cli.ts && tsx tests/smoke-discovery-mcp.ts && tsx tests/smoke-generation.ts && tsx tests/smoke-optimize.ts && tsx tests/smoke-mock-repos.ts && tsx tests/smoke-release.ts && tsx tests/smoke-scoring.ts && tsx tests/smoke-scope.ts && tsx tests/smoke-coverage.ts && tsx tests/smoke-feedback.ts && tsx tests/smoke-verdict.ts && tsx tests/smoke-dry-run.ts && tsx tests/smoke-errors.ts && tsx tests/smoke-e2e.ts"
+    "test": "tsx tests/smoke-code.ts && tsx tests/smoke-sdk-python.ts && tsx tests/smoke-sdk-rust.ts && tsx tests/smoke-cli.ts && tsx tests/smoke-cli-entry.ts && tsx tests/smoke-mcp.ts && tsx tests/smoke-llm.ts && tsx tests/smoke-discovery-sdk.ts && tsx tests/smoke-discovery-cli.ts && tsx tests/smoke-discovery-mcp.ts && tsx tests/smoke-generation.ts && tsx tests/smoke-optimize.ts && tsx tests/smoke-mock-repos.ts && tsx tests/smoke-release.ts && tsx tests/smoke-scoring.ts && tsx tests/smoke-scope.ts && tsx tests/smoke-coverage.ts && tsx tests/smoke-feedback.ts && tsx tests/smoke-verdict.ts && tsx tests/smoke-dry-run.ts && tsx tests/smoke-errors.ts && tsx tests/smoke-e2e.ts && tsx tests/smoke-import.ts"
   },
   "dependencies": {
     "@mariozechner/pi-agent-core": "^0.66.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ import { createDefaultPiTaskGenerator, generateTasksForProject, createDefaultPiC
 import type { Recommendation } from './verdict/recommendations.js';
 import { generateRecommendations } from './verdict/recommendations.js';
 import { renderVerdictConsole, renderVerdictMarkdown } from './verdict/render.js';
+import { importCommands } from './import/index.js';
 
 // ── Arg parsing helpers ───────────────────────────────────────────────────────
 
@@ -47,14 +48,18 @@ const BOOLEAN_FLAGS = new Set([
   '--dry-run',
   '--no-cache',
   '--skip-generation',
+  '--scrape',
 ]);
 
 const VALUE_FLAGS = new Set([
   '--baseline',
   '--config',
   '--current',
+  '--depth',
+  '--from',
   '--max-iterations',
   '--model',
+  '--out',
   '--task',
   '--tier',
 ]);
@@ -95,6 +100,7 @@ Skill Optimizer CLI — Benchmark and optimize SDK/CLI/MCP guidance
 
 Usage:
   skill-optimizer init <sdk|cli|mcp>            Scaffold config for the given surface type
+  skill-optimizer import-commands [options]     Extract CLI commands from source or binary
   skill-optimizer generate-tasks [options]      Generate and freeze tasks from discovered surface
   skill-optimizer benchmark [options]           Run the benchmark
   skill-optimizer run [options]                 Run the benchmark
@@ -120,6 +126,12 @@ Optimize options:
 Generate-tasks options:
   --config <path>                               Config file (default: skill-optimizer.json)
 
+Import-commands options:
+  --from <path>                                 Entry file or binary name (required)
+  --out <path>                                  Output path (default: skill-optimizer/cli-commands.json)
+  --scrape                                      Force --help scraping regardless of file type
+  --depth <n>                                   Max subcommand depth for --help scraping (default: 2)
+
 Compare options:
   --baseline <path>                             Path to baseline report.json
   --current <path>                              Path to current report.json
@@ -128,6 +140,8 @@ Examples:
   skill-optimizer init cli
   skill-optimizer init sdk
   skill-optimizer init mcp
+  skill-optimizer import-commands --from ./src/cli.ts
+  skill-optimizer import-commands --from fast-cli --scrape
   skill-optimizer --dry-run --config ./skill-optimizer.json
   skill-optimizer benchmark --config ./skill-optimizer.json
   skill-optimizer run
@@ -204,6 +218,26 @@ async function main(): Promise<void> {
       process.exit(1);
     }
     initBenchmark(process.cwd(), surface as 'sdk' | 'cli' | 'mcp');
+    process.exit(0);
+  }
+
+  // ── Import-commands mode ─────────────────────────────────────────────────────
+  if (command === 'import-commands') {
+    const fromFlag = getFlag(args, '--from');
+    if (!fromFlag) {
+      console.error('ERROR: --from <path> is required for import-commands.');
+      console.error('  Example: skill-optimizer import-commands --from ./src/cli.ts');
+      process.exit(1);
+    }
+    const outFlag = getFlag(args, '--out') ?? 'skill-optimizer/cli-commands.json';
+    const depthRaw = getFlag(args, '--depth');
+    await importCommands({
+      from: fromFlag,
+      out: outFlag,
+      scrape: hasFlag(args, '--scrape'),
+      depth: depthRaw ? parseInt(depthRaw, 10) : 2,
+      cwd: process.cwd(),
+    });
     process.exit(0);
   }
 

--- a/src/import/detect.ts
+++ b/src/import/detect.ts
@@ -1,0 +1,58 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { extname, resolve, basename } from 'node:path';
+import type { DetectionResult } from './types.js';
+
+function inferBinaryHint(fromPath: string, cwd: string): string | undefined {
+  const pkgPath = resolve(cwd, 'package.json');
+  if (existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as Record<string, unknown>;
+      const bin = pkg['bin'];
+      if (typeof bin === 'string') return bin;
+      if (typeof bin === 'object' && bin !== null) {
+        const keys = Object.keys(bin as object);
+        if (keys.length > 0) return keys[0];
+      }
+    } catch { /* ignore */ }
+  }
+
+  const pyprojPath = resolve(cwd, 'pyproject.toml');
+  if (existsSync(pyprojPath)) {
+    const content = readFileSync(pyprojPath, 'utf-8');
+    const m = content.match(/\[project\.scripts\][\s\S]*?\n(\S+)\s*=/);
+    if (m) return m[1];
+  }
+
+  return basename(fromPath).replace(/\.[^.]+$/, '') || undefined;
+}
+
+export function detectFramework(fromPath: string, cwd: string): DetectionResult {
+  const abs = resolve(cwd, fromPath);
+  const ext = extname(abs).toLowerCase();
+  const binaryHint = inferBinaryHint(fromPath, cwd);
+
+  if (ext === '.py') {
+    if (!existsSync(abs)) return { kind: 'unknown', binaryHint };
+    const content = readFileSync(abs, 'utf-8');
+    if (/import typer|from typer/.test(content)) return { kind: 'typer', binaryHint };
+    if (/import click|from click/.test(content)) return { kind: 'click', binaryHint };
+    if (/import argparse|from argparse/.test(content)) return { kind: 'argparse', binaryHint };
+    return { kind: 'unknown', binaryHint };
+  }
+
+  if (ext === '.rs' || basename(abs) === 'Cargo.toml') {
+    return { kind: 'clap', binaryHint };
+  }
+
+  if (['.ts', '.tsx', '.js', '.mjs', '.cjs'].includes(ext)) {
+    if (!existsSync(abs)) return { kind: 'unknown', binaryHint };
+    const content = readFileSync(abs, 'utf-8');
+    if (/from ['"]commander['"]|require\(['"]commander['"]\)/.test(content)) return { kind: 'commander', binaryHint };
+    if (/from ['"]yargs['"]|require\(['"]yargs['"]\)/.test(content)) return { kind: 'yargs', binaryHint };
+    if (/\{\s*command\s*:/.test(content)) return { kind: 'optique', binaryHint };
+    return { kind: 'unknown', binaryHint };
+  }
+
+  // No recognized extension — treat fromPath as a binary name
+  return { kind: 'unknown', binaryHint: fromPath };
+}

--- a/src/import/extractors/help-scraper.ts
+++ b/src/import/extractors/help-scraper.ts
@@ -21,8 +21,8 @@ export function parseHelpOutput(text: string, prefix: string[]): CliCommandDefin
   const OPTIONS_HEADER = /^(Options|Flags|Global Options):\s*$/i;
   // Match a subcommand line: leading whitespace, non-dash first char, name token, optional description
   const CMD_LINE = /^\s+(\S+)\s*(.*)/;
-  // Match an option line: leading whitespace, dash-starting flag
-  const OPT_LINE = /^\s+(-\S+(?:,\s*--\S+)?)\s+(.*)/;
+  // Match an option line: "-x[, --long-form]" or "--long-form"
+  const OPT_LINE = /^\s+(-[a-zA-Z](?:,\s*--\S+)?|--\S+)\s*(.*)/;
 
   for (const line of lines) {
     const trimmed = line.trim();
@@ -76,14 +76,11 @@ export function parseHelpOutput(text: string, prefix: string[]): CliCommandDefin
     }
   }
 
-  // If we have options and prefix is non-empty, attach them to the command
-  // whose name matches prefix.join(' ')
+  // Options on a subcommand page belong to the parent command (prefix.join(' ')).
+  // Return a synthetic parent entry so scrapeHelp can merge options onto it.
   if (prefix.length > 0 && optionsBuf.length > 0) {
     const parentName = prefix.join(' ');
-    const parentCmd = commands.find((c) => c.command === parentName);
-    if (parentCmd) {
-      parentCmd.options = optionsBuf;
-    }
+    commands.push({ command: parentName, options: optionsBuf });
   }
 
   return commands;
@@ -125,13 +122,16 @@ export async function scrapeHelp(
     const discovered = parseHelpOutput(stdout, prefix);
 
     for (const cmd of discovered) {
-      if (!seen.has(cmd.command)) {
+      const existing = all.find((c) => c.command === cmd.command);
+      if (existing) {
+        // Merge options onto an already-discovered parent command
+        if (cmd.options && cmd.options.length > 0) {
+          existing.options = cmd.options;
+        }
+      } else {
         seen.add(cmd.command);
         all.push(cmd);
-
-        // Only recurse if we haven't reached max depth
         if (prefix.length < depth) {
-          // The next prefix is the parts of this command name
           queue.push(cmd.command.split(' '));
         }
       }

--- a/src/import/extractors/help-scraper.ts
+++ b/src/import/extractors/help-scraper.ts
@@ -70,7 +70,7 @@ export function parseHelpOutput(text: string, prefix: string[]): CliCommandDefin
         optionsBuf.push({
           name: flagStr,
           description: desc || undefined,
-          ...(takesValue ? { takesValue: true } : {}),
+          takesValue,
         });
       }
     }

--- a/src/import/extractors/help-scraper.ts
+++ b/src/import/extractors/help-scraper.ts
@@ -1,0 +1,142 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { CliCommandDefinition, CliCommandOptionDefinition } from '../types.js';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Pure parser: given the text output of `<binary> [prefix...] --help`,
+ * returns the subcommands and their options found in that output.
+ */
+export function parseHelpOutput(text: string, prefix: string[]): CliCommandDefinition[] {
+  const lines = text.split('\n');
+
+  let inCommands = false;
+  let inOptions = false;
+
+  const commands: CliCommandDefinition[] = [];
+  const optionsBuf: CliCommandOptionDefinition[] = [];
+
+  const COMMANDS_HEADER = /^(Commands|Subcommands):\s*$/;
+  const OPTIONS_HEADER = /^(Options|Flags|Global Options):\s*$/;
+  // Match a subcommand line: leading whitespace, non-dash first char, name token, optional description
+  const CMD_LINE = /^\s+(\S+)\s*(.*)/;
+  // Match an option line: leading whitespace, dash-starting flag
+  const OPT_LINE = /^\s+(-\S+(?:,\s*--\S+)?)\s+(.*)/;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Blank line resets section state
+    if (trimmed === '') {
+      inCommands = false;
+      inOptions = false;
+      continue;
+    }
+
+    // Detect section headers
+    if (COMMANDS_HEADER.test(trimmed)) {
+      inCommands = true;
+      inOptions = false;
+      continue;
+    }
+    if (OPTIONS_HEADER.test(trimmed)) {
+      inOptions = true;
+      inCommands = false;
+      continue;
+    }
+
+    if (inCommands) {
+      const m = CMD_LINE.exec(line);
+      if (m) {
+        const rawName = m[1]!;
+        // Skip if it looks like a flag line
+        if (rawName.startsWith('-')) continue;
+        // Strip positional hints like <name> or [name] from the token
+        const name = rawName.replace(/[<[].*/g, '').trim();
+        if (!name) continue;
+        const description = m[2]!.trim();
+
+        const commandStr = prefix.length > 0 ? [...prefix, name].join(' ') : name;
+        commands.push({ command: commandStr, description: description || undefined });
+      }
+    } else if (inOptions) {
+      const m = OPT_LINE.exec(line);
+      if (m) {
+        const flagStr = m[1]!.trim();
+        const desc = m[2]!.trim();
+        // takesValue if the flag string contains <word> or [word]
+        const takesValue = /<\w+>|\[\w+\]/.test(flagStr);
+        optionsBuf.push({
+          name: flagStr,
+          description: desc || undefined,
+          ...(takesValue ? { takesValue: true } : {}),
+        });
+      }
+    }
+  }
+
+  // If we have options and prefix is non-empty, attach them to the command
+  // whose name matches prefix.join(' ')
+  if (prefix.length > 0 && optionsBuf.length > 0) {
+    const parentName = prefix.join(' ');
+    const parentCmd = commands.find((c) => c.command === parentName);
+    if (parentCmd) {
+      parentCmd.options = optionsBuf;
+    }
+  }
+
+  return commands;
+}
+
+/**
+ * BFS scraper: runs `binary [prefix...] --help` for each discovered subcommand
+ * up to `opts.depth` levels deep.
+ */
+export async function scrapeHelp(
+  binary: string,
+  opts: { depth: number; cwd?: string },
+): Promise<CliCommandDefinition[]> {
+  const { depth, cwd } = opts;
+  const all: CliCommandDefinition[] = [];
+  const seen = new Set<string>();
+
+  // BFS queue of prefix arrays
+  const queue: string[][] = [[]];
+
+  while (queue.length > 0) {
+    const prefix = queue.shift()!;
+    const args = [...prefix, '--help'];
+
+    let stdout = '';
+    try {
+      const result = await execFileAsync(binary, args, {
+        cwd,
+        encoding: 'utf-8',
+        timeout: 5000,
+      });
+      stdout = result.stdout;
+    } catch (err: unknown) {
+      // Some CLIs exit non-zero for --help or print to stderr
+      const e = err as { stdout?: string; stderr?: string };
+      stdout = e.stdout ?? e.stderr ?? '';
+    }
+
+    const discovered = parseHelpOutput(stdout, prefix);
+
+    for (const cmd of discovered) {
+      if (!seen.has(cmd.command)) {
+        seen.add(cmd.command);
+        all.push(cmd);
+
+        // Only recurse if we haven't reached max depth
+        if (prefix.length < depth) {
+          // The next prefix is the parts of this command name
+          queue.push(cmd.command.split(' '));
+        }
+      }
+    }
+  }
+
+  return all;
+}

--- a/src/import/extractors/help-scraper.ts
+++ b/src/import/extractors/help-scraper.ts
@@ -17,8 +17,8 @@ export function parseHelpOutput(text: string, prefix: string[]): CliCommandDefin
   const commands: CliCommandDefinition[] = [];
   const optionsBuf: CliCommandOptionDefinition[] = [];
 
-  const COMMANDS_HEADER = /^(Commands|Subcommands):\s*$/;
-  const OPTIONS_HEADER = /^(Options|Flags|Global Options):\s*$/;
+  const COMMANDS_HEADER = /^(Commands|Subcommands):\s*$/i;
+  const OPTIONS_HEADER = /^(Options|Flags|Global Options):\s*$/i;
   // Match a subcommand line: leading whitespace, non-dash first char, name token, optional description
   const CMD_LINE = /^\s+(\S+)\s*(.*)/;
   // Match an option line: leading whitespace, dash-starting flag

--- a/src/import/extractors/py-argparse.ts
+++ b/src/import/extractors/py-argparse.ts
@@ -2,6 +2,21 @@ import { readFileSync } from 'node:fs';
 import { getSdkParser } from '../../benchmark/extractors/sdk/parser.js';
 import type { CliCommandDefinition, CliCommandOptionDefinition } from '../types.js';
 
+/** Extract the content of a paren-balanced block starting at `start` (the opening paren). */
+function extractParenBlock(source: string, start: number): string {
+  let depth = 0;
+  let i = start;
+  while (i < source.length) {
+    if (source[i] === '(') depth++;
+    else if (source[i] === ')') {
+      depth--;
+      if (depth === 0) return source.slice(start, i + 1);
+    }
+    i++;
+  }
+  return source.slice(start);
+}
+
 export async function extractArgparse(filePath: string): Promise<CliCommandDefinition[]> {
   const source = readFileSync(filePath, 'utf-8');
   // Use tree-sitter just to validate it parses (will throw on syntax error)
@@ -21,42 +36,47 @@ export async function extractArgparse(filePath: string): Promise<CliCommandDefin
   // Find parser variables and commands
   const commands: CliCommandDefinition[] = [];
   const parserVarToCmd = new Map<string, CliCommandDefinition>();
-  // Escape the subparsers variable name for use in regex
   const escapedSub = subparsersVar.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-  for (const line of lines) {
-    const m = line.match(
-      new RegExp(`(\\w+)\\s*=\\s*${escapedSub}\\.add_parser\\s*\\(\\s*['"]([^'"]+)['"](?:\\s*,\\s*help\\s*=\\s*['"]([^'"]+)['"])?`)
-    );
-    if (!m) continue;
+  // Scan full source for add_parser calls (handles multi-line calls)
+  const addParserRe = new RegExp(`(\\w+)\\s*=\\s*${escapedSub}\\.add_parser\\s*\\(`, 'g');
+  let m: RegExpExecArray | null;
+  while ((m = addParserRe.exec(source)) !== null) {
     const parserVar = m[1]!;
-    const commandName = m[2]!;
-    const helpText = m[3];
-    const def: CliCommandDefinition = { command: commandName, description: helpText };
+    const blockStart = m.index + m[0].length - 1; // position of '('
+    const block = extractParenBlock(source, blockStart);
+    const nameMatch = block.match(/^\(\s*['"]([^'"]+)['"]/);
+    if (!nameMatch) continue;
+    const commandName = nameMatch[1]!;
+    const helpMatch = block.match(/help\s*=\s*['"]([^'"]+)['"]/);
+    const def: CliCommandDefinition = { command: commandName, description: helpMatch?.[1] };
     commands.push(def);
     parserVarToCmd.set(parserVar, def);
   }
 
-  // Find add_argument calls for each parser variable
+  // Find add_argument calls for each parser variable — use paren-block extraction
+  // so multi-line calls and arbitrary kwarg ordering are handled correctly.
   for (const [parserVar, def] of parserVarToCmd) {
     const escapedVar = parserVar.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const argRegex = new RegExp(
-      `${escapedVar}\\.add_argument\\s*\\(\\s*['"](-[^'"]+)['"](?:\\s*,\\s*help\\s*=\\s*['"]([^'"]+)['"])?`,
-      'g'
-    );
+    const addArgRe = new RegExp(`${escapedVar}\\.add_argument\\s*\\(`, 'g');
     let argMatch: RegExpExecArray | null;
-    while ((argMatch = argRegex.exec(source)) !== null) {
-      const flagName = argMatch[1]!;
-      if (!flagName.startsWith('-')) continue; // skip positionals
-      const helpText2 = argMatch[2];
-      // Find the full line to check for store_true
-      const lineStart = source.lastIndexOf('\n', argMatch.index) + 1;
-      const lineEnd = source.indexOf('\n', argMatch.index);
-      const fullLine = source.slice(lineStart, lineEnd === -1 ? undefined : lineEnd);
-      const isStoreTrue = /action\s*=\s*['"]store_true['"]/.test(fullLine);
+    while ((argMatch = addArgRe.exec(source)) !== null) {
+      const blockStart = argMatch.index + argMatch[0].length - 1;
+      const block = extractParenBlock(source, blockStart);
+
+      // First string arg — must start with '-' to be a flag (not a positional)
+      const flagMatch = block.match(/^\(\s*['"](-[^'"]+)['"]/);
+      if (!flagMatch) continue;
+      const flagName = flagMatch[1]!;
+
+      // help= anywhere in the block
+      const helpMatch = block.match(/help\s*=\s*['"]([^'"]+)['"]/);
+      // action='store_true' anywhere in the block (handles multi-line)
+      const isStoreTrue = /action\s*=\s*['"]store_true['"]/.test(block);
+
       const opt: CliCommandOptionDefinition = {
         name: flagName,
-        description: helpText2,
+        description: helpMatch?.[1],
         takesValue: !isStoreTrue,
       };
       if (!def.options) def.options = [];

--- a/src/import/extractors/py-argparse.ts
+++ b/src/import/extractors/py-argparse.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from 'node:fs';
+import { getSdkParser } from '../../benchmark/extractors/sdk/parser.js';
+import type { CliCommandDefinition, CliCommandOptionDefinition } from '../types.js';
+
+export async function extractArgparse(filePath: string): Promise<CliCommandDefinition[]> {
+  const source = readFileSync(filePath, 'utf-8');
+  // Use tree-sitter just to validate it parses (will throw on syntax error)
+  const parser = await getSdkParser('python');
+  parser.parse(source); // validate only
+
+  const lines = source.split('\n');
+
+  // Find subparsers variable
+  let subparsersVar: string | null = null;
+  for (const line of lines) {
+    const m = line.match(/(\w+)\s*=\s*\w+\.add_subparsers\s*\(/);
+    if (m) { subparsersVar = m[1]!; break; }
+  }
+  if (!subparsersVar) return [];
+
+  // Find parser variables and commands
+  const commands: CliCommandDefinition[] = [];
+  const parserVarToCmd = new Map<string, CliCommandDefinition>();
+  // Escape the subparsers variable name for use in regex
+  const escapedSub = subparsersVar.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+  for (const line of lines) {
+    const m = line.match(
+      new RegExp(`(\\w+)\\s*=\\s*${escapedSub}\\.add_parser\\s*\\(\\s*['"]([^'"]+)['"](?:\\s*,\\s*help\\s*=\\s*['"]([^'"]+)['"])?`)
+    );
+    if (!m) continue;
+    const parserVar = m[1]!;
+    const commandName = m[2]!;
+    const helpText = m[3];
+    const def: CliCommandDefinition = { command: commandName, description: helpText };
+    commands.push(def);
+    parserVarToCmd.set(parserVar, def);
+  }
+
+  // Find add_argument calls for each parser variable
+  for (const [parserVar, def] of parserVarToCmd) {
+    const escapedVar = parserVar.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const argRegex = new RegExp(
+      `${escapedVar}\\.add_argument\\s*\\(\\s*['"](-[^'"]+)['"](?:\\s*,\\s*help\\s*=\\s*['"]([^'"]+)['"])?`,
+      'g'
+    );
+    let argMatch: RegExpExecArray | null;
+    while ((argMatch = argRegex.exec(source)) !== null) {
+      const flagName = argMatch[1]!;
+      if (!flagName.startsWith('-')) continue; // skip positionals
+      const helpText2 = argMatch[2];
+      // Find the full line to check for store_true
+      const lineStart = source.lastIndexOf('\n', argMatch.index) + 1;
+      const lineEnd = source.indexOf('\n', argMatch.index);
+      const fullLine = source.slice(lineStart, lineEnd === -1 ? undefined : lineEnd);
+      const isStoreTrue = /action\s*=\s*['"]store_true['"]/.test(fullLine);
+      const opt: CliCommandOptionDefinition = {
+        name: flagName,
+        description: helpText2,
+        takesValue: !isStoreTrue,
+      };
+      if (!def.options) def.options = [];
+      if (!def.options.find(o => o.name === flagName)) {
+        def.options.push(opt);
+      }
+    }
+  }
+
+  return commands;
+}

--- a/src/import/extractors/py-click.ts
+++ b/src/import/extractors/py-click.ts
@@ -1,0 +1,112 @@
+import { readFileSync } from 'node:fs';
+import type Parser from 'web-tree-sitter';
+import { getSdkParser } from '../../benchmark/extractors/sdk/parser.js';
+import type { CliCommandDefinition, CliCommandOptionDefinition } from '../types.js';
+
+function stripDocstring(raw: string): string {
+  const m = raw.match(/^['"]{1,3}([\s\S]*?)['"]{1,3}$/);
+  if (m) return m[1]!.trim();
+  return raw.trim();
+}
+
+function getDocstring(funcDef: Parser.SyntaxNode): string | undefined {
+  // Find the 'block' child of the function definition
+  let block: Parser.SyntaxNode | null = null;
+  for (const child of funcDef.children) {
+    if (child.type === 'block') {
+      block = child;
+      break;
+    }
+  }
+  if (!block) return undefined;
+
+  // First child of block that is expression_statement containing a string
+  for (const child of block.children) {
+    if (child.type === 'expression_statement') {
+      for (const inner of child.children) {
+        if (inner.type === 'string') {
+          return stripDocstring(inner.text);
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
+function walkTree(node: Parser.SyntaxNode, source: string): CliCommandDefinition[] {
+  const results: CliCommandDefinition[] = [];
+
+  if (node.type === 'decorated_definition') {
+    const decorators: Parser.SyntaxNode[] = [];
+    let funcDef: Parser.SyntaxNode | null = null;
+
+    for (const child of node.children) {
+      if (child.type === 'decorator') {
+        decorators.push(child);
+      } else if (child.type === 'function_definition') {
+        funcDef = child;
+      }
+    }
+
+    if (funcDef) {
+      // Check if any decorator is a command decorator (but not group)
+      let isCommand = false;
+      const options: CliCommandOptionDefinition[] = [];
+
+      for (const dec of decorators) {
+        const decoratorText = source.slice(dec.startIndex, dec.endIndex);
+        const isCommandDec =
+          /\.command\s*\(\s*\)/.test(decoratorText) ||
+          /^@click\.command\s*\(/.test(decoratorText);
+        const isOptionDec = /\.option\s*\(/.test(decoratorText);
+
+        if (isCommandDec) {
+          isCommand = true;
+        } else if (isOptionDec) {
+          const flagMatch = decoratorText.match(/\.option\s*\(\s*['"]([^'"]+)['"]/);
+          const helpMatch = decoratorText.match(/help\s*=\s*['"]([^'"]+)['"]/);
+          const isFlag = /is_flag\s*=\s*True/.test(decoratorText);
+
+          if (flagMatch) {
+            options.push({
+              name: flagMatch[1]!,
+              description: helpMatch ? helpMatch[1] : undefined,
+              takesValue: !isFlag,
+            });
+          }
+        }
+      }
+
+      if (isCommand) {
+        const nameNode = funcDef.childForFieldName('name');
+        const rawName = nameNode ? nameNode.text : '';
+        const commandName = rawName.replace(/_/g, '-');
+        const description = getDocstring(funcDef);
+
+        const def: CliCommandDefinition = { command: commandName };
+        if (description !== undefined) def.description = description;
+        if (options.length > 0) def.options = options;
+
+        results.push(def);
+      }
+    }
+  }
+
+  // Recurse into children
+  for (const child of node.children) {
+    const childResults = walkTree(child, source);
+    for (const r of childResults) results.push(r);
+  }
+
+  return results;
+}
+
+/**
+ * Extract click command definitions from a Python source file using tree-sitter.
+ */
+export async function extractClick(filePath: string): Promise<CliCommandDefinition[]> {
+  const source = readFileSync(filePath, 'utf-8');
+  const parser = await getSdkParser('python');
+  const tree = parser.parse(source);
+  return walkTree(tree.rootNode, source);
+}

--- a/src/import/extractors/py-click.ts
+++ b/src/import/extractors/py-click.ts
@@ -94,8 +94,7 @@ function walkTree(node: Parser.SyntaxNode, source: string): CliCommandDefinition
 
   // Recurse into children
   for (const child of node.children) {
-    const childResults = walkTree(child, source);
-    for (const r of childResults) results.push(r);
+    results.push(...walkTree(child, source));
   }
 
   return results;

--- a/src/import/extractors/rs-clap.ts
+++ b/src/import/extractors/rs-clap.ts
@@ -1,0 +1,82 @@
+import { readFileSync } from 'node:fs';
+import { getSdkParser } from '../../benchmark/extractors/sdk/parser.js';
+import type { CliCommandDefinition, CliCommandOptionDefinition } from '../types.js';
+
+function extractParenBlock(source: string, start: number): string {
+  let depth = 0;
+  let i = start;
+  while (i < source.length) {
+    if (source[i] === '(') depth++;
+    else if (source[i] === ')') {
+      depth--;
+      if (depth === 0) return source.slice(start, i + 1);
+    }
+    i++;
+  }
+  return source.slice(start);
+}
+
+/**
+ * Extract clap command definitions from a Rust source file using tree-sitter for validation,
+ * then text-based analysis for extraction.
+ */
+export async function extractClap(filePath: string): Promise<CliCommandDefinition[]> {
+  const source = readFileSync(filePath, 'utf-8');
+  const parser = await getSdkParser('rust');
+  parser.parse(source); // validate only
+
+  const commands: CliCommandDefinition[] = [];
+  const subcommandSearchStr = '.subcommand(';
+  let searchStart = 0;
+
+  while (true) {
+    const subIdx = source.indexOf(subcommandSearchStr, searchStart);
+    if (subIdx === -1) break;
+
+    // Extract the block starting at the '(' of .subcommand(
+    const blockStart = subIdx + subcommandSearchStr.length - 1; // position of '('
+    const block = extractParenBlock(source, blockStart);
+
+    // Find Command::new("name") in this block
+    const nameMatch = block.match(/Command\s*::\s*new\s*\(\s*"([^"]+)"\s*\)/);
+    if (!nameMatch) { searchStart = subIdx + 1; continue; }
+    const commandName = nameMatch[1]!;
+
+    // Find .about("description")
+    const aboutMatch = block.match(/\.about\s*\(\s*"([^"]+)"\s*\)/);
+    const description = aboutMatch ? aboutMatch[1] : undefined;
+
+    // Find options by scanning for .arg( calls in the block and extracting each arg's paren block
+    const options: CliCommandOptionDefinition[] = [];
+    const argSearchStr = '.arg(';
+    let argSearchStart = 0;
+    while (true) {
+      const argIdx = block.indexOf(argSearchStr, argSearchStart);
+      if (argIdx === -1) break;
+
+      // Extract the arg block starting at the '(' of .arg(
+      const argBlockStart = argIdx + argSearchStr.length - 1;
+      const argBlock = extractParenBlock(block, argBlockStart);
+
+      // Find .long("flag") within this arg block
+      const longMatch = argBlock.match(/\.long\s*\(\s*"([^"]+)"\s*\)/);
+      if (longMatch) {
+        const longFlag = '--' + longMatch[1];
+        const helpMatch = argBlock.match(/\.help\s*\(\s*"([^"]+)"\s*\)/);
+        const isBool = /SetTrue|SetFalse|store_true/.test(argBlock);
+        options.push({
+          name: longFlag,
+          description: helpMatch ? helpMatch[1] : undefined,
+          takesValue: !isBool,
+        });
+      }
+
+      argSearchStart = argIdx + 1;
+    }
+
+    commands.push({ command: commandName, description, options: options.length > 0 ? options : undefined });
+    searchStart = subIdx + 1;
+  }
+
+  return commands;
+}

--- a/src/import/extractors/ts-commander.ts
+++ b/src/import/extractors/ts-commander.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from 'node:fs';
+
+import ts from 'typescript';
+
+import type { CliCommandDefinition } from '../types.js';
+
+function getScriptKind(filePath: string): ts.ScriptKind {
+  if (filePath.endsWith('.tsx')) return ts.ScriptKind.TSX;
+  if (filePath.endsWith('.js')) return ts.ScriptKind.JS;
+  return ts.ScriptKind.TS;
+}
+
+function walkChainUp(node: ts.Node, def: CliCommandDefinition): void {
+  // node.parent is the PropertyAccessExpression (the `.command`/`.description`/etc access)
+  // node.parent.parent is the next CallExpression in the chain
+  const propAccess = node.parent;
+  if (!propAccess || !ts.isPropertyAccessExpression(propAccess)) return;
+  const nextCall = propAccess.parent;
+  if (!nextCall || !ts.isCallExpression(nextCall)) return;
+
+  const method = propAccess.name.text;
+  if (method === 'description' && nextCall.arguments[0] !== undefined && ts.isStringLiteral(nextCall.arguments[0])) {
+    def.description = nextCall.arguments[0].text;
+  } else if (method === 'option' && nextCall.arguments[0] !== undefined && ts.isStringLiteral(nextCall.arguments[0])) {
+    const flagStr = nextCall.arguments[0].text;
+    const desc =
+      nextCall.arguments[1] !== undefined && ts.isStringLiteral(nextCall.arguments[1])
+        ? nextCall.arguments[1].text
+        : undefined;
+    const takesValue = /<\w+>|\[\w+\]/.test(flagStr);
+    if (!def.options) def.options = [];
+    def.options.push({ name: flagStr, description: desc, takesValue });
+  }
+  // Continue walking up the chain
+  walkChainUp(nextCall, def);
+}
+
+/**
+ * Extract commander.js command definitions from a TypeScript/JavaScript source file
+ * using the TypeScript Compiler API.
+ */
+export function extractCommander(filePath: string): CliCommandDefinition[] {
+  const source = readFileSync(filePath, 'utf-8');
+  const scriptKind = getScriptKind(filePath);
+  const sourceFile = ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, true, scriptKind);
+
+  const commands: CliCommandDefinition[] = [];
+
+  function visit(node: ts.Node): void {
+    if (ts.isCallExpression(node)) {
+      const expr = node.expression;
+      if (
+        ts.isPropertyAccessExpression(expr) &&
+        expr.name.text === 'command' &&
+        node.arguments[0] !== undefined &&
+        ts.isStringLiteral(node.arguments[0])
+      ) {
+        const rawName = node.arguments[0].text;
+        // Strip positional placeholders: 'delete <id>' → 'delete'
+        const commandName = rawName.split(' ')[0]!;
+
+        const def: CliCommandDefinition = { command: commandName };
+        walkChainUp(node, def);
+        commands.push(def);
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+
+  return commands;
+}

--- a/src/import/extractors/ts-yargs.ts
+++ b/src/import/extractors/ts-yargs.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from 'node:fs';
+import { extname } from 'node:path';
+import ts from 'typescript';
+import type { CliCommandDefinition, CliCommandOptionDefinition } from '../types.js';
+
+function scriptKind(filePath: string): ts.ScriptKind {
+  const ext = extname(filePath).toLowerCase();
+  if (ext === '.tsx') return ts.ScriptKind.TSX;
+  if (ext === '.js' || ext === '.mjs' || ext === '.cjs') return ts.ScriptKind.JS;
+  return ts.ScriptKind.TS;
+}
+
+function extractOptionsFromBuilder(builder: ts.Expression): CliCommandOptionDefinition[] {
+  const options: CliCommandOptionDefinition[] = [];
+
+  function visitForOptions(node: ts.Node): void {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === 'option' &&
+      node.arguments.length >= 1 &&
+      ts.isStringLiteral(node.arguments[0]!)
+    ) {
+      const optName = `--${node.arguments[0].text}`;
+      let desc: string | undefined;
+      let takesValue = false;
+
+      const config = node.arguments[1];
+      if (config && ts.isObjectLiteralExpression(config)) {
+        for (const prop of config.properties) {
+          if (!ts.isPropertyAssignment(prop)) continue;
+          const key = ts.isIdentifier(prop.name) ? prop.name.text : null;
+          if (key === 'describe' && ts.isStringLiteral(prop.initializer)) {
+            desc = prop.initializer.text;
+          }
+          if (key === 'type' && ts.isStringLiteral(prop.initializer)) {
+            const t = prop.initializer.text;
+            takesValue = t === 'string' || t === 'array' || t === 'number';
+          }
+        }
+      }
+
+      options.push({ name: optName, description: desc, takesValue });
+    }
+    ts.forEachChild(node, visitForOptions);
+  }
+
+  visitForOptions(builder);
+  return options;
+}
+
+export function extractYargs(filePath: string): CliCommandDefinition[] {
+  const source = readFileSync(filePath, 'utf-8');
+  const sf = ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, true, scriptKind(filePath));
+  const commands: CliCommandDefinition[] = [];
+
+  function visit(node: ts.Node): void {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === 'command' &&
+      node.arguments.length >= 2 &&
+      ts.isStringLiteral(node.arguments[0]!) &&
+      ts.isStringLiteral(node.arguments[1]!)
+    ) {
+      const commandName = node.arguments[0].text.split(' ')[0]!;
+      const description = node.arguments[1].text;
+      const def: CliCommandDefinition = { command: commandName, description };
+
+      const builder = node.arguments[2];
+      if (builder) {
+        const opts = extractOptionsFromBuilder(builder);
+        if (opts.length > 0) def.options = opts;
+      }
+
+      commands.push(def);
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sf);
+  return commands;
+}

--- a/src/import/index.ts
+++ b/src/import/index.ts
@@ -1,0 +1,87 @@
+import { existsSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import type { ImportOptions } from './types.js';
+import type { CliCommandDefinition } from './types.js';
+import { detectFramework } from './detect.js';
+import { extractCommander } from './extractors/ts-commander.js';
+import { extractYargs } from './extractors/ts-yargs.js';
+import { extractClick } from './extractors/py-click.js';
+import { extractArgparse } from './extractors/py-argparse.js';
+import { extractClap } from './extractors/rs-clap.js';
+import { scrapeHelp } from './extractors/help-scraper.js';
+import { discoverCliSurfaceFromSources } from '../discovery/cli.js';
+import { promptOverwrite, writeOutput } from './output.js';
+
+export async function importCommands(opts: ImportOptions): Promise<void> {
+  const { from, out, scrape, depth, cwd } = opts;
+  const absFrom = resolve(cwd, from);
+  const absOut = resolve(cwd, out);
+
+  const detection = scrape ? { kind: 'unknown' as const, binaryHint: from } : detectFramework(from, cwd);
+  console.log(`\nskill-optimizer import-commands — detecting framework from ${from}`);
+  if (detection.kind !== 'unknown') {
+    console.log(`  Detected: ${detection.kind}`);
+  }
+
+  let commands: CliCommandDefinition[] = [];
+  if (!scrape) {
+    console.log('  Extracting commands...');
+    try {
+      if (detection.kind === 'commander') {
+        commands = extractCommander(absFrom);
+      } else if (detection.kind === 'yargs') {
+        commands = extractYargs(absFrom);
+      } else if (detection.kind === 'optique') {
+        const snapshot = discoverCliSurfaceFromSources([absFrom]);
+        commands = snapshot.actions.map(a => ({
+          command: a.name,
+          description: a.description,
+          options: a.args.map(arg => ({
+            name: arg.name,
+            description: arg.description,
+            takesValue: arg.type === 'string',
+          })),
+        }));
+      } else if (detection.kind === 'click' || detection.kind === 'typer') {
+        commands = await extractClick(absFrom);
+      } else if (detection.kind === 'argparse') {
+        commands = await extractArgparse(absFrom);
+      } else if (detection.kind === 'clap') {
+        commands = await extractClap(absFrom);
+      }
+    } catch (err) {
+      console.error(`  Warning: static extraction failed: ${err instanceof Error ? err.message : err}`);
+      commands = [];
+    }
+  }
+
+  if (commands.length === 0 && detection.binaryHint) {
+    console.log('  Static extraction yielded 0 commands — falling back to --help scraping...');
+    try {
+      commands = await scrapeHelp(detection.binaryHint, { depth, cwd });
+    } catch (err) {
+      console.error(`  Warning: --help scraping failed: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+
+  if (commands.length === 0) {
+    console.error('\n  ERROR: No commands found after all strategies.');
+    console.error('  Try: skill-optimizer import-commands --from <binary> --scrape');
+    process.exit(1);
+  }
+
+  console.log(`  Found ${commands.length} commands`);
+
+  if (existsSync(absOut)) {
+    const overwrite = await promptOverwrite(absOut);
+    if (!overwrite) {
+      console.log('\n  Aborted. Output file unchanged.');
+      process.exit(0);
+    }
+  }
+
+  mkdirSync(dirname(absOut), { recursive: true });
+  await writeOutput(commands, absOut);
+  console.log(`\n  Wrote ${commands.length} commands to ${out}`);
+  console.log(`  Done. Review the file and run 'skill-optimizer doctor' to validate.\n`);
+}

--- a/src/import/index.ts
+++ b/src/import/index.ts
@@ -1,7 +1,6 @@
 import { existsSync, mkdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
-import type { ImportOptions } from './types.js';
-import type { CliCommandDefinition } from './types.js';
+import type { ImportOptions, CliCommandDefinition } from './types.js';
 import { detectFramework } from './detect.js';
 import { extractCommander } from './extractors/ts-commander.js';
 import { extractYargs } from './extractors/ts-yargs.js';

--- a/src/import/index.ts
+++ b/src/import/index.ts
@@ -80,7 +80,7 @@ export async function importCommands(opts: ImportOptions): Promise<void> {
   }
 
   mkdirSync(dirname(absOut), { recursive: true });
-  await writeOutput(commands, absOut);
+  writeOutput(commands, absOut);
   console.log(`\n  Wrote ${commands.length} commands to ${out}`);
   console.log(`  Done. Review the file and run 'skill-optimizer doctor' to validate.\n`);
 }

--- a/src/import/output.ts
+++ b/src/import/output.ts
@@ -16,6 +16,6 @@ export async function promptOverwrite(outPath: string): Promise<boolean> {
   });
 }
 
-export async function writeOutput(commands: CliCommandDefinition[], outPath: string): Promise<void> {
+export function writeOutput(commands: CliCommandDefinition[], outPath: string): void {
   writeFileSync(outPath, JSON.stringify(commands, null, 2) + '\n', 'utf-8');
 }

--- a/src/import/output.ts
+++ b/src/import/output.ts
@@ -3,8 +3,12 @@ import { createInterface } from 'node:readline';
 import type { CliCommandDefinition } from './types.js';
 
 export async function promptOverwrite(outPath: string): Promise<boolean> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const rl = createInterface({ input: process.stdin, output: process.stdout });
+    rl.on('error', (err) => {
+      rl.close();
+      reject(err);
+    });
     rl.question(`  Output: ${outPath} already exists.\n  Overwrite? [y/N] `, (answer) => {
       rl.close();
       resolve(answer.trim().toLowerCase() === 'y');

--- a/src/import/output.ts
+++ b/src/import/output.ts
@@ -1,0 +1,17 @@
+import { writeFileSync } from 'node:fs';
+import { createInterface } from 'node:readline';
+import type { CliCommandDefinition } from './types.js';
+
+export async function promptOverwrite(outPath: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(`  Output: ${outPath} already exists.\n  Overwrite? [y/N] `, (answer) => {
+      rl.close();
+      resolve(answer.trim().toLowerCase() === 'y');
+    });
+  });
+}
+
+export async function writeOutput(commands: CliCommandDefinition[], outPath: string): Promise<void> {
+  writeFileSync(outPath, JSON.stringify(commands, null, 2) + '\n', 'utf-8');
+}

--- a/src/import/types.ts
+++ b/src/import/types.ts
@@ -1,0 +1,24 @@
+export type { CliCommandDefinition, CliCommandOptionDefinition } from '../benchmark/types.js';
+
+export type FrameworkKind =
+  | 'commander'
+  | 'yargs'
+  | 'optique'
+  | 'click'
+  | 'typer'
+  | 'argparse'
+  | 'clap'
+  | 'unknown';
+
+export interface DetectionResult {
+  kind: FrameworkKind;
+  binaryHint?: string;
+}
+
+export interface ImportOptions {
+  from: string;
+  out: string;
+  scrape: boolean;
+  depth: number;
+  cwd: string;
+}

--- a/tests/fixtures/import-commands/argparse-sample.py
+++ b/tests/fixtures/import-commands/argparse-sample.py
@@ -1,0 +1,13 @@
+import argparse
+
+parser = argparse.ArgumentParser(description='CLI tool')
+subparsers = parser.add_subparsers(dest='command')
+
+create_parser = subparsers.add_parser('create', help='Create a new item')
+create_parser.add_argument('--name', help='Item name')
+create_parser.add_argument('--count', type=int, help='Count')
+
+list_parser = subparsers.add_parser('list', help='List all items')
+list_parser.add_argument('--limit', type=int, help='Max results')
+
+args = parser.parse_args()

--- a/tests/fixtures/import-commands/clap-sample.rs
+++ b/tests/fixtures/import-commands/clap-sample.rs
@@ -1,0 +1,17 @@
+use clap::{Command, Arg};
+
+fn main() {
+    let matches = Command::new("mycli")
+        .subcommand(
+            Command::new("create")
+                .about("Create a new item")
+                .arg(Arg::new("name").long("name").help("Item name").required(false))
+                .arg(Arg::new("verbose").long("verbose").help("Verbose output").action(clap::ArgAction::SetTrue))
+        )
+        .subcommand(
+            Command::new("delete")
+                .about("Delete an item")
+                .arg(Arg::new("id").long("id").help("Item ID").required(true))
+        )
+        .get_matches();
+}

--- a/tests/fixtures/import-commands/click-sample.py
+++ b/tests/fixtures/import-commands/click-sample.py
@@ -1,0 +1,23 @@
+import click
+
+@click.group()
+def cli():
+    """CLI app."""
+    pass
+
+@cli.command()
+@click.option('--name', help='Item name')
+@click.option('--verbose', is_flag=True, help='Verbose output')
+def create(name, verbose):
+    """Create a new item."""
+    pass
+
+@cli.command()
+@click.argument('item_id')
+@click.option('--force', is_flag=True, help='Skip confirmation')
+def delete(item_id, force):
+    """Delete an item."""
+    pass
+
+if __name__ == '__main__':
+    cli()

--- a/tests/fixtures/import-commands/commander-sample.ts
+++ b/tests/fixtures/import-commands/commander-sample.ts
@@ -1,0 +1,23 @@
+import { Command } from 'commander';
+
+const program = new Command();
+
+program
+  .command('create')
+  .description('Create a new item')
+  .option('--name <value>', 'Item name')
+  .option('--dry-run', 'Preview only')
+  .action(() => {});
+
+program
+  .command('delete <id>')
+  .description('Delete an item by ID')
+  .action(() => {});
+
+program
+  .command('list')
+  .description('List all items')
+  .option('--limit <n>', 'Max results')
+  .action(() => {});
+
+program.parse(process.argv);

--- a/tests/fixtures/import-commands/help-output-account.txt
+++ b/tests/fixtures/import-commands/help-output-account.txt
@@ -1,0 +1,9 @@
+Usage: fast-cli account [options] [command]
+
+Commands:
+  create       Create a new account
+  list         List all accounts
+  delete <name>  Delete an account
+
+Options:
+  -h, --help  output usage information

--- a/tests/fixtures/import-commands/help-output-sample.txt
+++ b/tests/fixtures/import-commands/help-output-sample.txt
@@ -1,0 +1,13 @@
+Usage: fast-cli [options] [command]
+
+Commands:
+  account     Account management
+  network     Network management
+  send        Send tokens
+  fund        Fund account
+  pay         Pay a URL
+  help [cmd]  display help for [cmd]
+
+Options:
+  -h, --help     output usage information
+  -V, --version  output the version number

--- a/tests/fixtures/import-commands/yargs-sample.ts
+++ b/tests/fixtures/import-commands/yargs-sample.ts
@@ -1,0 +1,18 @@
+import yargs from 'yargs';
+
+yargs
+  .command(
+    'create',
+    'Create a new item',
+    (y) => y
+      .option('name', { describe: 'Item name', type: 'string' })
+      .option('verbose', { describe: 'Verbose output', type: 'boolean' }),
+    (_argv) => {},
+  )
+  .command(
+    'delete <id>',
+    'Delete an item',
+    (y) => y.positional('id', { describe: 'Item ID', type: 'string' }),
+    (_argv) => {},
+  )
+  .parse();

--- a/tests/smoke-import.ts
+++ b/tests/smoke-import.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { CliCommandDefinition } from '../src/import/types.js';
 import { writeOutput } from '../src/import/output.js';
+import { parseHelpOutput } from '../src/import/extractors/help-scraper.js';
 
 // === Types check ===
 const _typeCheck: CliCommandDefinition = { command: 'create', description: 'Create item' };
@@ -23,28 +24,21 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
   assert.strictEqual(written[0]!.command, 'create');
 }
 
-import { parseHelpOutput } from '../src/import/extractors/help-scraper.js';
-import { readFileSync } from 'node:fs';
-
 // === help-scraper: parseHelpOutput (root) ===
 {
   const rootHelp = readFileSync('tests/fixtures/import-commands/help-output-sample.txt', 'utf-8');
   const commands = parseHelpOutput(rootHelp, []);
-  // Should find: account, network, send, fund, pay (5 commands; skip "help" as it starts with 'h' not '-')
-  // Actually "help" is a valid command name — should be 6. But "help [cmd]" — the name is "help" without brackets.
-  // Filter: exclude "help" since it's a meta-command? No — just parse everything non-dash.
-  // Expected: at minimum 5 real commands (account, network, send, fund, pay). "help" may or may not be included.
-  assert.ok(commands.length >= 5, `Expected >=5 commands, got ${commands.length}: ${commands.map(c=>c.command).join(', ')}`);
+  assert.ok(commands.length >= 5, `Expected >=5 commands, got ${commands.length}: ${commands.map(c => c.command).join(', ')}`);
   const accountCmd = commands.find(c => c.command === 'account');
   assert.ok(accountCmd !== undefined, 'Should find "account" command');
   assert.strictEqual(accountCmd?.description, 'Account management');
 }
 
-// === help-scraper: parseHelpOutput (subcommand) ===
+// === help-scraper: parseHelpOutput (subcommand with prefix) ===
 {
   const subHelp = readFileSync('tests/fixtures/import-commands/help-output-account.txt', 'utf-8');
   const commands = parseHelpOutput(subHelp, ['account']);
-  assert.strictEqual(commands.length, 3, `Expected 3, got ${commands.length}: ${commands.map(c=>c.command).join(', ')}`);
+  assert.strictEqual(commands.length, 3, `Expected 3, got ${commands.length}: ${commands.map(c => c.command).join(', ')}`);
   assert.ok(commands.find(c => c.command === 'account create') !== undefined);
   assert.ok(commands.find(c => c.command === 'account delete') !== undefined);
 }

--- a/tests/smoke-import.ts
+++ b/tests/smoke-import.ts
@@ -8,6 +8,7 @@ import { parseHelpOutput } from '../src/import/extractors/help-scraper.js';
 import { extractCommander } from '../src/import/extractors/ts-commander.js';
 import { extractYargs } from '../src/import/extractors/ts-yargs.js';
 import { extractClick } from '../src/import/extractors/py-click.js';
+import { extractArgparse } from '../src/import/extractors/py-argparse.js';
 
 // === Types check ===
 const _typeCheck: CliCommandDefinition = { command: 'create', description: 'Create item' };
@@ -110,6 +111,25 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
 
   const deleteCmd = commands.find(c => c.command === 'delete');
   assert.ok(deleteCmd !== undefined, 'Should find "delete" command');
+}
+
+// === py-argparse extractor ===
+{
+  const fixturePath = join('tests/fixtures/import-commands/argparse-sample.py');
+  const commands = await extractArgparse(fixturePath);
+  assert.strictEqual(commands.length, 2, `Expected 2 commands, got ${commands.length}: ${commands.map(c => c.command).join(', ')}`);
+
+  const create = commands.find(c => c.command === 'create');
+  assert.ok(create !== undefined, 'Should find "create" command');
+  assert.strictEqual(create?.description, 'Create a new item');
+
+  const nameOpt = create?.options?.find(o => o.name === '--name');
+  assert.ok(nameOpt !== undefined, 'Should find --name option');
+  assert.strictEqual(nameOpt?.takesValue, true);
+
+  const listCmd = commands.find(c => c.command === 'list');
+  assert.ok(listCmd !== undefined, 'Should find "list" command');
+  assert.strictEqual(listCmd?.description, 'List all items');
 }
 
 console.log('smoke-import: all tests passed');

--- a/tests/smoke-import.ts
+++ b/tests/smoke-import.ts
@@ -9,6 +9,7 @@ import { extractCommander } from '../src/import/extractors/ts-commander.js';
 import { extractYargs } from '../src/import/extractors/ts-yargs.js';
 import { extractClick } from '../src/import/extractors/py-click.js';
 import { extractArgparse } from '../src/import/extractors/py-argparse.js';
+import { extractClap } from '../src/import/extractors/rs-clap.js';
 
 // === Types check ===
 const _typeCheck: CliCommandDefinition = { command: 'create', description: 'Create item' };
@@ -130,6 +131,28 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
   const listCmd = commands.find(c => c.command === 'list');
   assert.ok(listCmd !== undefined, 'Should find "list" command');
   assert.strictEqual(listCmd?.description, 'List all items');
+}
+
+// === rs-clap extractor ===
+{
+  const fixturePath = join('tests/fixtures/import-commands/clap-sample.rs');
+  const commands = await extractClap(fixturePath);
+  assert.ok(commands.length >= 2, `Expected >=2 commands, got ${commands.length}`);
+
+  const create = commands.find(c => c.command === 'create');
+  assert.ok(create !== undefined, 'Should find "create" command');
+  assert.strictEqual(create?.description, 'Create a new item');
+
+  const nameOpt = create?.options?.find(o => o.name === '--name');
+  assert.ok(nameOpt !== undefined, 'Should find --name option');
+  assert.strictEqual(nameOpt?.takesValue, true);
+
+  const verboseOpt = create?.options?.find(o => o.name === '--verbose');
+  assert.ok(verboseOpt !== undefined, 'Should find --verbose option');
+  assert.strictEqual(verboseOpt?.takesValue, false); // SetTrue → takesValue false
+
+  const deleteCmd = commands.find(c => c.command === 'delete');
+  assert.ok(deleteCmd !== undefined, 'Should find "delete" command');
 }
 
 console.log('smoke-import: all tests passed');

--- a/tests/smoke-import.ts
+++ b/tests/smoke-import.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'node:assert';
-import { mkdtempSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { mkdtempSync, existsSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { CliCommandDefinition } from '../src/import/types.js';
@@ -24,7 +24,7 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
   const commands: CliCommandDefinition[] = [
     { command: 'create', description: 'Create item', options: [{ name: '--name', takesValue: true }] },
   ];
-  await writeOutput(commands, outPath);
+  writeOutput(commands, outPath);
   assert.strictEqual(existsSync(outPath), true);
   const written = JSON.parse(readFileSync(outPath, 'utf-8')) as CliCommandDefinition[];
   assert.strictEqual(written.length, 1);
@@ -45,9 +45,13 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
 {
   const subHelp = readFileSync('tests/fixtures/import-commands/help-output-account.txt', 'utf-8');
   const commands = parseHelpOutput(subHelp, ['account']);
-  assert.strictEqual(commands.length, 3, `Expected 3, got ${commands.length}: ${commands.map(c => c.command).join(', ')}`);
+  // 3 subcommands + 1 synthetic parent entry with options
+  assert.ok(commands.length >= 3, `Expected >=3, got ${commands.length}: ${commands.map(c => c.command).join(', ')}`);
   assert.ok(commands.find(c => c.command === 'account create') !== undefined);
   assert.ok(commands.find(c => c.command === 'account delete') !== undefined);
+  // Parent entry includes options from the page
+  const parent = commands.find(c => c.command === 'account');
+  assert.ok(parent !== undefined, 'Should find synthetic parent "account" entry with options');
 }
 
 // === ts-commander extractor ===
@@ -106,11 +110,11 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
 
   const nameOpt = create?.options?.find(o => o.name === '--name');
   assert.ok(nameOpt !== undefined, 'Should find --name option');
-  assert.strictEqual(nameOpt?.takesValue, true);  // no is_flag → takesValue true
+  assert.strictEqual(nameOpt?.takesValue, true);
 
   const verboseOpt = create?.options?.find(o => o.name === '--verbose');
   assert.ok(verboseOpt !== undefined, 'Should find --verbose option');
-  assert.strictEqual(verboseOpt?.takesValue, false);  // is_flag=True → takesValue false
+  assert.strictEqual(verboseOpt?.takesValue, false);
 
   const deleteCmd = commands.find(c => c.command === 'delete');
   assert.ok(deleteCmd !== undefined, 'Should find "delete" command');
@@ -151,7 +155,7 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
 
   const verboseOpt = create?.options?.find(o => o.name === '--verbose');
   assert.ok(verboseOpt !== undefined, 'Should find --verbose option');
-  assert.strictEqual(verboseOpt?.takesValue, false); // SetTrue → takesValue false
+  assert.strictEqual(verboseOpt?.takesValue, false);
 
   const deleteCmd = commands.find(c => c.command === 'delete');
   assert.ok(deleteCmd !== undefined, 'Should find "delete" command');
@@ -171,6 +175,11 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
 {
   const result = detectFramework('tests/fixtures/import-commands/commander-sample.ts', process.cwd());
   assert.strictEqual(result.kind, 'commander');
+}
+
+{
+  const result = detectFramework('tests/fixtures/import-commands/clap-sample.rs', process.cwd());
+  assert.strictEqual(result.kind, 'clap');
 }
 
 // === importCommands orchestration ===

--- a/tests/smoke-import.ts
+++ b/tests/smoke-import.ts
@@ -1,0 +1,26 @@
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { CliCommandDefinition } from '../src/import/types.js';
+import { writeOutput } from '../src/import/output.js';
+
+// === Types check ===
+const _typeCheck: CliCommandDefinition = { command: 'create', description: 'Create item' };
+assert.strictEqual(typeof _typeCheck.command, 'string');
+
+// === writeOutput ===
+{
+  const dir = mkdtempSync(join(tmpdir(), 'import-test-'));
+  const outPath = join(dir, 'cli-commands.json');
+  const commands: CliCommandDefinition[] = [
+    { command: 'create', description: 'Create item', options: [{ name: '--name', takesValue: true }] },
+  ];
+  await writeOutput(commands, outPath);
+  assert.strictEqual(existsSync(outPath), true);
+  const written = JSON.parse(readFileSync(outPath, 'utf-8')) as CliCommandDefinition[];
+  assert.strictEqual(written.length, 1);
+  assert.strictEqual(written[0]!.command, 'create');
+}
+
+console.log('smoke-import: all tests passed');

--- a/tests/smoke-import.ts
+++ b/tests/smoke-import.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import type { CliCommandDefinition } from '../src/import/types.js';
 import { writeOutput } from '../src/import/output.js';
 import { parseHelpOutput } from '../src/import/extractors/help-scraper.js';
+import { extractCommander } from '../src/import/extractors/ts-commander.js';
 
 // === Types check ===
 const _typeCheck: CliCommandDefinition = { command: 'create', description: 'Create item' };
@@ -41,6 +42,28 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
   assert.strictEqual(commands.length, 3, `Expected 3, got ${commands.length}: ${commands.map(c => c.command).join(', ')}`);
   assert.ok(commands.find(c => c.command === 'account create') !== undefined);
   assert.ok(commands.find(c => c.command === 'account delete') !== undefined);
+}
+
+// === ts-commander extractor ===
+{
+  const fixturePath = join('tests/fixtures/import-commands/commander-sample.ts');
+  const commands = extractCommander(fixturePath);
+  assert.strictEqual(commands.length, 3, `Expected 3 commands, got ${commands.length}: ${commands.map(c => c.command).join(', ')}`);
+
+  const create = commands.find(c => c.command === 'create');
+  assert.ok(create !== undefined, 'Should find "create" command');
+  assert.strictEqual(create?.description, 'Create a new item');
+
+  const nameOpt = create?.options?.find(o => o.name === '--name <value>');
+  assert.ok(nameOpt !== undefined, 'Should find --name option');
+  assert.strictEqual(nameOpt?.takesValue, true);
+
+  const dryRun = create?.options?.find(o => o.name === '--dry-run');
+  assert.ok(dryRun !== undefined, 'Should find --dry-run option');
+  assert.strictEqual(dryRun?.takesValue, false);
+
+  const deleteCmd = commands.find(c => c.command === 'delete');
+  assert.ok(deleteCmd !== undefined, 'Should find "delete" command (positional stripped)');
 }
 
 console.log('smoke-import: all tests passed');

--- a/tests/smoke-import.ts
+++ b/tests/smoke-import.ts
@@ -6,6 +6,7 @@ import type { CliCommandDefinition } from '../src/import/types.js';
 import { writeOutput } from '../src/import/output.js';
 import { parseHelpOutput } from '../src/import/extractors/help-scraper.js';
 import { extractCommander } from '../src/import/extractors/ts-commander.js';
+import { extractYargs } from '../src/import/extractors/ts-yargs.js';
 
 // === Types check ===
 const _typeCheck: CliCommandDefinition = { command: 'create', description: 'Create item' };
@@ -61,6 +62,28 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
   const dryRun = create?.options?.find(o => o.name === '--dry-run');
   assert.ok(dryRun !== undefined, 'Should find --dry-run option');
   assert.strictEqual(dryRun?.takesValue, false);
+
+  const deleteCmd = commands.find(c => c.command === 'delete');
+  assert.ok(deleteCmd !== undefined, 'Should find "delete" command (positional stripped)');
+}
+
+// === ts-yargs extractor ===
+{
+  const fixturePath = join('tests/fixtures/import-commands/yargs-sample.ts');
+  const commands = extractYargs(fixturePath);
+  assert.strictEqual(commands.length, 2, `Expected 2 commands, got ${commands.length}: ${commands.map(c => c.command).join(', ')}`);
+
+  const create = commands.find(c => c.command === 'create');
+  assert.ok(create !== undefined, 'Should find "create" command');
+  assert.strictEqual(create?.description, 'Create a new item');
+
+  const nameOpt = create?.options?.find(o => o.name === '--name');
+  assert.ok(nameOpt !== undefined, 'Should find --name option');
+  assert.strictEqual(nameOpt?.takesValue, true);
+
+  const verboseOpt = create?.options?.find(o => o.name === '--verbose');
+  assert.ok(verboseOpt !== undefined, 'Should find --verbose option');
+  assert.strictEqual(verboseOpt?.takesValue, false);
 
   const deleteCmd = commands.find(c => c.command === 'delete');
   assert.ok(deleteCmd !== undefined, 'Should find "delete" command (positional stripped)');

--- a/tests/smoke-import.ts
+++ b/tests/smoke-import.ts
@@ -52,7 +52,7 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
 
 // === ts-commander extractor ===
 {
-  const fixturePath = join('tests/fixtures/import-commands/commander-sample.ts');
+  const fixturePath = 'tests/fixtures/import-commands/commander-sample.ts';
   const commands = extractCommander(fixturePath);
   assert.strictEqual(commands.length, 3, `Expected 3 commands, got ${commands.length}: ${commands.map(c => c.command).join(', ')}`);
 
@@ -74,7 +74,7 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
 
 // === ts-yargs extractor ===
 {
-  const fixturePath = join('tests/fixtures/import-commands/yargs-sample.ts');
+  const fixturePath = 'tests/fixtures/import-commands/yargs-sample.ts';
   const commands = extractYargs(fixturePath);
   assert.strictEqual(commands.length, 2, `Expected 2 commands, got ${commands.length}: ${commands.map(c => c.command).join(', ')}`);
 
@@ -96,7 +96,7 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
 
 // === py-click extractor ===
 {
-  const fixturePath = join('tests/fixtures/import-commands/click-sample.py');
+  const fixturePath = 'tests/fixtures/import-commands/click-sample.py';
   const commands = await extractClick(fixturePath);
   assert.strictEqual(commands.length, 2, `Expected 2 commands, got ${commands.length}: ${commands.map(c => c.command).join(', ')}`);
 
@@ -118,7 +118,7 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
 
 // === py-argparse extractor ===
 {
-  const fixturePath = join('tests/fixtures/import-commands/argparse-sample.py');
+  const fixturePath = 'tests/fixtures/import-commands/argparse-sample.py';
   const commands = await extractArgparse(fixturePath);
   assert.strictEqual(commands.length, 2, `Expected 2 commands, got ${commands.length}: ${commands.map(c => c.command).join(', ')}`);
 
@@ -137,7 +137,7 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
 
 // === rs-clap extractor ===
 {
-  const fixturePath = join('tests/fixtures/import-commands/clap-sample.rs');
+  const fixturePath = 'tests/fixtures/import-commands/clap-sample.rs';
   const commands = await extractClap(fixturePath);
   assert.ok(commands.length >= 2, `Expected >=2 commands, got ${commands.length}`);
 
@@ -159,20 +159,17 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
 
 // === detectFramework ===
 {
-  const clickFixture = join('tests/fixtures/import-commands/click-sample.py');
-  const result = detectFramework(clickFixture, process.cwd());
+  const result = detectFramework('tests/fixtures/import-commands/click-sample.py', process.cwd());
   assert.strictEqual(result.kind, 'click');
 }
 
 {
-  const argparseFixture = join('tests/fixtures/import-commands/argparse-sample.py');
-  const result = detectFramework(argparseFixture, process.cwd());
+  const result = detectFramework('tests/fixtures/import-commands/argparse-sample.py', process.cwd());
   assert.strictEqual(result.kind, 'argparse');
 }
 
 {
-  const commanderFixture = join('tests/fixtures/import-commands/commander-sample.ts');
-  const result = detectFramework(commanderFixture, process.cwd());
+  const result = detectFramework('tests/fixtures/import-commands/commander-sample.ts', process.cwd());
   assert.strictEqual(result.kind, 'commander');
 }
 

--- a/tests/smoke-import.ts
+++ b/tests/smoke-import.ts
@@ -23,4 +23,30 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
   assert.strictEqual(written[0]!.command, 'create');
 }
 
+import { parseHelpOutput } from '../src/import/extractors/help-scraper.js';
+import { readFileSync } from 'node:fs';
+
+// === help-scraper: parseHelpOutput (root) ===
+{
+  const rootHelp = readFileSync('tests/fixtures/import-commands/help-output-sample.txt', 'utf-8');
+  const commands = parseHelpOutput(rootHelp, []);
+  // Should find: account, network, send, fund, pay (5 commands; skip "help" as it starts with 'h' not '-')
+  // Actually "help" is a valid command name — should be 6. But "help [cmd]" — the name is "help" without brackets.
+  // Filter: exclude "help" since it's a meta-command? No — just parse everything non-dash.
+  // Expected: at minimum 5 real commands (account, network, send, fund, pay). "help" may or may not be included.
+  assert.ok(commands.length >= 5, `Expected >=5 commands, got ${commands.length}: ${commands.map(c=>c.command).join(', ')}`);
+  const accountCmd = commands.find(c => c.command === 'account');
+  assert.ok(accountCmd !== undefined, 'Should find "account" command');
+  assert.strictEqual(accountCmd?.description, 'Account management');
+}
+
+// === help-scraper: parseHelpOutput (subcommand) ===
+{
+  const subHelp = readFileSync('tests/fixtures/import-commands/help-output-account.txt', 'utf-8');
+  const commands = parseHelpOutput(subHelp, ['account']);
+  assert.strictEqual(commands.length, 3, `Expected 3, got ${commands.length}: ${commands.map(c=>c.command).join(', ')}`);
+  assert.ok(commands.find(c => c.command === 'account create') !== undefined);
+  assert.ok(commands.find(c => c.command === 'account delete') !== undefined);
+}
+
 console.log('smoke-import: all tests passed');

--- a/tests/smoke-import.ts
+++ b/tests/smoke-import.ts
@@ -7,6 +7,7 @@ import { writeOutput } from '../src/import/output.js';
 import { parseHelpOutput } from '../src/import/extractors/help-scraper.js';
 import { extractCommander } from '../src/import/extractors/ts-commander.js';
 import { extractYargs } from '../src/import/extractors/ts-yargs.js';
+import { extractClick } from '../src/import/extractors/py-click.js';
 
 // === Types check ===
 const _typeCheck: CliCommandDefinition = { command: 'create', description: 'Create item' };
@@ -87,6 +88,28 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
 
   const deleteCmd = commands.find(c => c.command === 'delete');
   assert.ok(deleteCmd !== undefined, 'Should find "delete" command (positional stripped)');
+}
+
+// === py-click extractor ===
+{
+  const fixturePath = join('tests/fixtures/import-commands/click-sample.py');
+  const commands = await extractClick(fixturePath);
+  assert.strictEqual(commands.length, 2, `Expected 2 commands, got ${commands.length}: ${commands.map(c => c.command).join(', ')}`);
+
+  const create = commands.find(c => c.command === 'create');
+  assert.ok(create !== undefined, 'Should find "create" command');
+  assert.strictEqual(create?.description, 'Create a new item.');
+
+  const nameOpt = create?.options?.find(o => o.name === '--name');
+  assert.ok(nameOpt !== undefined, 'Should find --name option');
+  assert.strictEqual(nameOpt?.takesValue, true);  // no is_flag → takesValue true
+
+  const verboseOpt = create?.options?.find(o => o.name === '--verbose');
+  assert.ok(verboseOpt !== undefined, 'Should find --verbose option');
+  assert.strictEqual(verboseOpt?.takesValue, false);  // is_flag=True → takesValue false
+
+  const deleteCmd = commands.find(c => c.command === 'delete');
+  assert.ok(deleteCmd !== undefined, 'Should find "delete" command');
 }
 
 console.log('smoke-import: all tests passed');

--- a/tests/smoke-import.ts
+++ b/tests/smoke-import.ts
@@ -10,6 +10,8 @@ import { extractYargs } from '../src/import/extractors/ts-yargs.js';
 import { extractClick } from '../src/import/extractors/py-click.js';
 import { extractArgparse } from '../src/import/extractors/py-argparse.js';
 import { extractClap } from '../src/import/extractors/rs-clap.js';
+import { detectFramework } from '../src/import/detect.js';
+import { importCommands } from '../src/import/index.js';
 
 // === Types check ===
 const _typeCheck: CliCommandDefinition = { command: 'create', description: 'Create item' };
@@ -153,6 +155,41 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
 
   const deleteCmd = commands.find(c => c.command === 'delete');
   assert.ok(deleteCmd !== undefined, 'Should find "delete" command');
+}
+
+// === detectFramework ===
+{
+  const clickFixture = join('tests/fixtures/import-commands/click-sample.py');
+  const result = detectFramework(clickFixture, process.cwd());
+  assert.strictEqual(result.kind, 'click');
+}
+
+{
+  const argparseFixture = join('tests/fixtures/import-commands/argparse-sample.py');
+  const result = detectFramework(argparseFixture, process.cwd());
+  assert.strictEqual(result.kind, 'argparse');
+}
+
+{
+  const commanderFixture = join('tests/fixtures/import-commands/commander-sample.ts');
+  const result = detectFramework(commanderFixture, process.cwd());
+  assert.strictEqual(result.kind, 'commander');
+}
+
+// === importCommands orchestration ===
+{
+  const dir = mkdtempSync(join(tmpdir(), 'import-orch-'));
+  const outPath = join(dir, 'cli-commands.json');
+  await importCommands({
+    from: 'tests/fixtures/import-commands/commander-sample.ts',
+    out: outPath,
+    scrape: false,
+    depth: 2,
+    cwd: process.cwd(),
+  });
+  assert.strictEqual(existsSync(outPath), true);
+  const written = JSON.parse(readFileSync(outPath, 'utf-8')) as CliCommandDefinition[];
+  assert.strictEqual(written.length, 3);
 }
 
 console.log('smoke-import: all tests passed');


### PR DESCRIPTION
## Summary

- Adds `skill-optimizer import-commands --from <entry-file> [--out <path>]` command
- Auto-detects CLI framework (Commander.js, Yargs, Click/Typer, argparse, Clap) from file extension + import sniffing
- Static extractors for each framework: TS Compiler API for Commander/Yargs, tree-sitter WASM for Python/Rust
- Falls back to BFS `--help` scraping when static extraction yields 0 commands or `--scrape` is passed
- Adds `cli-commands.json` output: `CliCommandDefinition[]` manifest ready for task generation

## New files

- `src/import/types.ts` — re-exports `CliCommandDefinition`, adds `FrameworkKind`, `DetectionResult`, `ImportOptions`
- `src/import/output.ts` — `writeOutput` (sync) + `promptOverwrite` (interactive overwrite guard)
- `src/import/detect.ts` — `detectFramework` + `inferBinaryHint` (package.json bin / pyproject.toml)
- `src/import/index.ts` — `importCommands` orchestrator
- `src/import/extractors/ts-commander.ts` — TS Compiler API, walks chain-up from `.command()`
- `src/import/extractors/ts-yargs.ts` — TS Compiler API, walks builder fn for `.option()`
- `src/import/extractors/py-click.ts` — tree-sitter Python, finds `@cli.command()` decorated functions
- `src/import/extractors/py-argparse.ts` — tree-sitter Python + balanced-paren extraction for multi-line calls
- `src/import/extractors/rs-clap.ts` — tree-sitter Rust + balanced-paren extraction for `.subcommand()` blocks
- `src/import/extractors/help-scraper.ts` — `parseHelpOutput` (pure parser) + `scrapeHelp` (BFS subprocess)
- `tests/smoke-import.ts` — full extractor + orchestrator smoke tests
- `tests/fixtures/import-commands/` — fixture files for each extractor

## Test plan

- [x] `npx tsx tests/smoke-import.ts` — all extractors pass
- [x] `npm run typecheck` — clean
- [x] `npm test` — smoke-import included in chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)