### PR TITLE
feat(init): interactive wizard with model multiselect, --yes, and --answers CI mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,38 @@ cd skill-optimizer
 npm install
 export OPENROUTER_API_KEY=sk-or-...
 
-# Scaffold config for your surface type (sdk | cli | mcp)
-npx tsx src/cli.ts init cli
+# Interactive wizard — asks surface, repo path, models, task limits, entry file
+npx tsx src/cli.ts init
+
+# Or pre-fill the surface to skip the first question
+npx tsx src/cli.ts init cli       # or: init sdk, init mcp
+
+# Non-interactive: accept all defaults
+npx tsx src/cli.ts init cli --yes
+
+# CI mode: load answers from a JSON file
+npx tsx src/cli.ts init --answers answers.json
 ```
 
-`init cli` creates a `skill-optimizer/` directory with:
-- `skill-optimizer.json` — the main config (task generation enabled by default)
-- `cli-commands.json` — command manifest template (used as fallback if code-first discovery finds nothing)
+`init` creates a `skill-optimizer/` directory with:
+- `skill-optimizer.json` — the main config (commit this)
+- `skill-optimizer/.skill-optimizer/` — generated artifacts (gitignored)
+  - `cli-commands.json` — CLI surface: auto-extracted via `import-commands`, or template
+  - `tools.json` — MCP surface: template to edit with your real tools
 
-`init sdk` creates `skill-optimizer.json` only. `init mcp` creates `skill-optimizer.json` + `tools.json`.
+**`answers.json` format for CI/`--answers` mode:**
+```json
+{
+  "surface": "cli",
+  "repoPath": "/absolute/path/to/your-repo",
+  "models": ["openrouter/anthropic/claude-sonnet-4-6", "openrouter/openai/gpt-4o"],
+  "maxTasks": 20,
+  "maxIterations": 5,
+  "entryFile": "src/cli.ts"
+}
+```
 
-Open `skill-optimizer/skill-optimizer.json` and fill in these fields:
+Open `skill-optimizer/skill-optimizer.json` and review these fields:
 
 | Field | What it does | Set it to |
 |-------|-------------|-----------|

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@clack/prompts": "^1.2.0",
         "@mariozechner/pi-agent-core": "^0.66.1",
         "@mariozechner/pi-ai": "^0.66.1",
         "@mariozechner/pi-coding-agent": "^0.66.1",
@@ -778,6 +779,28 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.2.0.tgz",
+      "integrity": "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-wrap-ansi": "^0.1.3",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.2.0.tgz",
+      "integrity": "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.2.0",
+        "fast-string-width": "^1.1.0",
+        "fast-wrap-ansi": "^0.1.3",
+        "sisteransi": "^1.0.5"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2802,6 +2825,21 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-1.2.1.tgz",
+      "integrity": "sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-1.1.0.tgz",
+      "integrity": "sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^1.2.0"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -2817,6 +2855,15 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.1.6.tgz",
+      "integrity": "sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^1.1.0"
+      }
     },
     "node_modules/fast-xml-builder": {
       "version": "1.1.4",
@@ -3680,6 +3727,12 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "test": "tsx tests/smoke-code.ts && tsx tests/smoke-sdk-python.ts && tsx tests/smoke-sdk-rust.ts && tsx tests/smoke-cli.ts && tsx tests/smoke-cli-entry.ts && tsx tests/smoke-mcp.ts && tsx tests/smoke-llm.ts && tsx tests/smoke-discovery-sdk.ts && tsx tests/smoke-discovery-cli.ts && tsx tests/smoke-discovery-mcp.ts && tsx tests/smoke-generation.ts && tsx tests/smoke-optimize.ts && tsx tests/smoke-mock-repos.ts && tsx tests/smoke-release.ts && tsx tests/smoke-scoring.ts && tsx tests/smoke-scope.ts && tsx tests/smoke-coverage.ts && tsx tests/smoke-feedback.ts && tsx tests/smoke-verdict.ts && tsx tests/smoke-dry-run.ts && tsx tests/smoke-errors.ts && tsx tests/smoke-e2e.ts && tsx tests/smoke-import.ts"
   },
   "dependencies": {
+    "@clack/prompts": "^1.2.0",
     "@mariozechner/pi-agent-core": "^0.66.1",
     "@mariozechner/pi-ai": "^0.66.1",
     "@mariozechner/pi-coding-agent": "^0.66.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "materialize:mock": "tsx src/optimizer/materialize-mock-repo.ts",
     "build": "tsc",
     "typecheck": "tsc --noEmit",
-    "test": "tsx tests/smoke-code.ts && tsx tests/smoke-sdk-python.ts && tsx tests/smoke-sdk-rust.ts && tsx tests/smoke-cli.ts && tsx tests/smoke-cli-entry.ts && tsx tests/smoke-mcp.ts && tsx tests/smoke-llm.ts && tsx tests/smoke-discovery-sdk.ts && tsx tests/smoke-discovery-cli.ts && tsx tests/smoke-discovery-mcp.ts && tsx tests/smoke-generation.ts && tsx tests/smoke-optimize.ts && tsx tests/smoke-mock-repos.ts && tsx tests/smoke-release.ts && tsx tests/smoke-scoring.ts && tsx tests/smoke-scope.ts && tsx tests/smoke-coverage.ts && tsx tests/smoke-feedback.ts && tsx tests/smoke-verdict.ts && tsx tests/smoke-dry-run.ts && tsx tests/smoke-errors.ts && tsx tests/smoke-e2e.ts && tsx tests/smoke-import.ts"
+    "test": "tsx tests/smoke-code.ts && tsx tests/smoke-sdk-python.ts && tsx tests/smoke-sdk-rust.ts && tsx tests/smoke-cli.ts && tsx tests/smoke-cli-entry.ts && tsx tests/smoke-mcp.ts && tsx tests/smoke-llm.ts && tsx tests/smoke-discovery-sdk.ts && tsx tests/smoke-discovery-cli.ts && tsx tests/smoke-discovery-mcp.ts && tsx tests/smoke-generation.ts && tsx tests/smoke-optimize.ts && tsx tests/smoke-mock-repos.ts && tsx tests/smoke-release.ts && tsx tests/smoke-scoring.ts && tsx tests/smoke-scope.ts && tsx tests/smoke-coverage.ts && tsx tests/smoke-feedback.ts && tsx tests/smoke-verdict.ts && tsx tests/smoke-dry-run.ts && tsx tests/smoke-errors.ts && tsx tests/smoke-e2e.ts && tsx tests/smoke-import.ts && tsx tests/smoke-init.ts"
   },
   "dependencies": {
     "@clack/prompts": "^1.2.0",

--- a/src/benchmark/init.ts
+++ b/src/benchmark/init.ts
@@ -15,7 +15,9 @@ import { resolve } from 'node:path';
  */
 export function initBenchmark(targetDir: string = process.cwd(), surface: 'sdk' | 'cli' | 'mcp' = 'sdk'): void {
   const configDir = resolve(targetDir, 'skill-optimizer');
+  const generatedDir = resolve(configDir, '.skill-optimizer');
   mkdirSync(configDir, { recursive: true });
+  mkdirSync(generatedDir, { recursive: true });
 
   const configPath = resolve(configDir, 'skill-optimizer.json');
 
@@ -31,7 +33,7 @@ export function initBenchmark(targetDir: string = process.cwd(), surface: 'sdk' 
 
   // ── Surface-specific companion files ─────────────────────────────────────
   if (surface === 'cli') {
-    const commandsPath = resolve(configDir, 'cli-commands.json');
+    const commandsPath = resolve(generatedDir, 'cli-commands.json');
     if (existsSync(commandsPath)) {
       console.log(`[init] Skipping ${commandsPath} (already exists)`);
     } else {
@@ -57,7 +59,7 @@ export function initBenchmark(targetDir: string = process.cwd(), surface: 'sdk' 
   }
 
   if (surface === 'mcp') {
-    const toolsPath = resolve(configDir, 'tools.json');
+    const toolsPath = resolve(generatedDir, 'tools.json');
     if (existsSync(toolsPath)) {
       console.log(`[init] Skipping ${toolsPath} (already exists)`);
     } else {
@@ -179,7 +181,7 @@ function buildConfig(surface: 'sdk' | 'cli' | 'mcp'): object {
           sources: ['../src/cli.ts'],
         },
         cli: {
-          commands: './cli-commands.json',
+          commands: './.skill-optimizer/cli-commands.json',
         },
       },
       benchmark: commonBenchmark,
@@ -199,7 +201,7 @@ function buildConfig(surface: 'sdk' | 'cli' | 'mcp'): object {
         sources: ['../src/server.ts'],
       },
       mcp: {
-        tools: './tools.json',
+        tools: './.skill-optimizer/tools.json',
       },
     },
     benchmark: commonBenchmark,

--- a/src/benchmark/init.ts
+++ b/src/benchmark/init.ts
@@ -1,18 +1,6 @@
 import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-/**
- * Scaffold benchmark config and surface-specific files for a new project.
- * All files are written into a `skill-optimizer/` subdirectory so they
- * don't clutter the project root.
- *
- * - sdk: creates skill-optimizer.json only (code-first discovery via sources)
- * - cli: creates skill-optimizer.json + cli-commands.json manifest template
- * - mcp: creates skill-optimizer.json + tools.json manifest template
- *
- * Tasks are never scaffolded — task generation (benchmark.taskGeneration.enabled)
- * handles them automatically at run time.
- */
 export function initBenchmark(targetDir: string = process.cwd(), surface: 'sdk' | 'cli' | 'mcp' = 'sdk'): void {
   const configDir = resolve(targetDir, 'skill-optimizer');
   const generatedDir = resolve(configDir, '.skill-optimizer');
@@ -21,17 +9,13 @@ export function initBenchmark(targetDir: string = process.cwd(), surface: 'sdk' 
 
   const configPath = resolve(configDir, 'skill-optimizer.json');
 
-  // ── skill-optimizer.json ─────────────────────────────────────────────────
-  // Paths use "../" because this config lives one level below the project root.
   if (existsSync(configPath)) {
     console.log(`[init] Skipping ${configPath} (already exists)`);
   } else {
-    const config = buildConfig(surface);
-    writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+    writeFileSync(configPath, JSON.stringify(buildConfig(surface), null, 2) + '\n', 'utf-8');
     console.log(`[init] Created ${configPath}`);
   }
 
-  // ── Surface-specific companion files ─────────────────────────────────────
   if (surface === 'cli') {
     const commandsPath = resolve(generatedDir, 'cli-commands.json');
     if (existsSync(commandsPath)) {
@@ -99,7 +83,6 @@ export function initBenchmark(targetDir: string = process.cwd(), surface: 'sdk' 
     }
   }
 
-  // ── Next steps ────────────────────────────────────────────────────────────
   console.log('\n[init] Done! Next steps:');
   console.log('  1. Edit skill-optimizer/skill-optimizer.json:');
   console.log('       target.repoPath  → path to your repo');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,6 @@ import { runBenchmark } from './benchmark/runner.js';
 import { loadReport, compareReports, printComparison } from './benchmark/compare.js';
 import { printSummary, generateMarkdown } from './benchmark/reporter.js';
 import { printCoverage } from './benchmark/coverage.js';
-import { initBenchmark } from './benchmark/init.js';
 import { printOptimizeSummary, runOptimizeFromConfig } from './optimizer/main.js';
 import { DEFAULT_PROJECT_CONFIG_NAME, loadProjectConfig, parseModelRef } from './project/index.js';
 import { createDefaultPiTaskGenerator, generateTasksForProject, createDefaultPiCritic, discoverActionsOnly, resolveScope } from './tasks/index.js';
@@ -21,6 +20,9 @@ import type { Recommendation } from './verdict/recommendations.js';
 import { generateRecommendations } from './verdict/recommendations.js';
 import { renderVerdictConsole, renderVerdictMarkdown } from './verdict/render.js';
 import { importCommands } from './import/index.js';
+import { scaffoldInit } from './init/scaffold.js';
+import { buildDefaultAnswers, readAnswersFile } from './init/answers.js';
+import { runWizard } from './init/wizard.js';
 
 // ── Arg parsing helpers ───────────────────────────────────────────────────────
 
@@ -49,9 +51,11 @@ const BOOLEAN_FLAGS = new Set([
   '--no-cache',
   '--skip-generation',
   '--scrape',
+  '--yes',
 ]);
 
 const VALUE_FLAGS = new Set([
+  '--answers',
   '--baseline',
   '--config',
   '--current',
@@ -99,7 +103,9 @@ function printUsage(): void {
 Skill Optimizer CLI — Benchmark and optimize SDK/CLI/MCP guidance
 
 Usage:
-  skill-optimizer init <sdk|cli|mcp>            Scaffold config for the given surface type
+  skill-optimizer init [sdk|cli|mcp]            Interactive wizard — scaffold config for the given surface
+  skill-optimizer init [surface] --yes          Accept all defaults non-interactively
+  skill-optimizer init --answers <file.json>    Load wizard answers from a JSON file (CI mode)
   skill-optimizer import-commands [options]     Extract CLI commands from source or binary
   skill-optimizer generate-tasks [options]      Generate and freeze tasks from discovered surface
   skill-optimizer benchmark [options]           Run the benchmark
@@ -208,16 +214,23 @@ async function main(): Promise<void> {
 
   // ── Init mode ────────────────────────────────────────────────────────────────
   if (command === 'init') {
-    const surface = pos[1];
-    if (!surface || !['sdk', 'cli', 'mcp'].includes(surface)) {
-      console.error('Usage: skill-optimizer init <surface>');
-      console.error('');
-      console.error('  sdk  — TypeScript / Python / Rust library');
-      console.error('  cli  — command-line tool with subcommands');
-      console.error('  mcp  — MCP server with tools');
+    const surfaceArg = pos[1] as 'sdk' | 'cli' | 'mcp' | undefined;
+    if (surfaceArg && !['sdk', 'cli', 'mcp'].includes(surfaceArg)) {
+      console.error(`ERROR: Unknown surface '${surfaceArg}'. Must be: sdk | cli | mcp`);
       process.exit(1);
     }
-    initBenchmark(process.cwd(), surface as 'sdk' | 'cli' | 'mcp');
+    const answersFlag = getFlag(args, '--answers');
+    const useDefaults = hasFlag(args, '--yes');
+
+    if (answersFlag) {
+      const answers = readAnswersFile(resolve(process.cwd(), answersFlag));
+      await scaffoldInit(answers, process.cwd());
+    } else if (useDefaults) {
+      const answers = buildDefaultAnswers(surfaceArg ?? 'sdk', process.cwd());
+      await scaffoldInit(answers, process.cwd());
+    } else {
+      await runWizard(process.cwd(), surfaceArg);
+    }
     process.exit(0);
   }
 

--- a/src/init/answers.ts
+++ b/src/init/answers.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs';
+
+export interface WizardAnswers {
+  /** What kind of surface is being benchmarked */
+  surface: 'sdk' | 'cli' | 'mcp';
+  /** Absolute path to the target repo */
+  repoPath: string;
+  /** OpenRouter model IDs selected for benchmarking */
+  models: string[];
+  /** Max tasks to generate */
+  maxTasks: number;
+  /** Max optimize iterations */
+  maxIterations: number;
+  /** For cli/mcp: path to entry file or binary (relative to repoPath or absolute) */
+  entryFile?: string;
+  /** Optional project name (defaults to basename of repoPath) */
+  name?: string;
+}
+
+const DEFAULT_MODELS = [
+  'openrouter/anthropic/claude-sonnet-4-6',
+  'openrouter/google/gemini-2.0-flash-001',
+];
+
+export function buildDefaultAnswers(surface: 'sdk' | 'cli' | 'mcp' = 'sdk', repoPath?: string): WizardAnswers {
+  return {
+    surface,
+    repoPath: repoPath ?? process.cwd(),
+    models: DEFAULT_MODELS,
+    maxTasks: 20,
+    maxIterations: 5,
+  };
+}
+
+export function readAnswersFile(filePath: string): WizardAnswers {
+  const raw = JSON.parse(readFileSync(filePath, 'utf-8')) as Partial<WizardAnswers>;
+  if (!raw.surface || !['sdk', 'cli', 'mcp'].includes(raw.surface)) {
+    throw new Error(`answers file must have surface: sdk | cli | mcp (got: ${JSON.stringify(raw.surface)})`);
+  }
+  if (!raw.repoPath) {
+    throw new Error('answers file must have repoPath');
+  }
+  if (!raw.models || raw.models.length === 0) {
+    throw new Error('answers file must have at least one model');
+  }
+  return {
+    surface: raw.surface,
+    repoPath: raw.repoPath,
+    models: raw.models,
+    maxTasks: raw.maxTasks ?? 20,
+    maxIterations: raw.maxIterations ?? 5,
+    entryFile: raw.entryFile,
+    name: raw.name,
+  };
+}

--- a/src/init/answers.ts
+++ b/src/init/answers.ts
@@ -34,8 +34,8 @@ export function readAnswersFile(filePath: string): WizardAnswers {
   if (!raw.repoPath) {
     throw new Error('answers file must have repoPath');
   }
-  if (!raw.models || raw.models.length === 0) {
-    throw new Error('answers file must have at least one model');
+  if (!Array.isArray(raw.models) || raw.models.length === 0) {
+    throw new Error('answers file must have at least one model (as a JSON array)');
   }
   return {
     surface: raw.surface,

--- a/src/init/answers.ts
+++ b/src/init/answers.ts
@@ -1,19 +1,13 @@
 import { readFileSync } from 'node:fs';
 
 export interface WizardAnswers {
-  /** What kind of surface is being benchmarked */
   surface: 'sdk' | 'cli' | 'mcp';
-  /** Absolute path to the target repo */
   repoPath: string;
-  /** OpenRouter model IDs selected for benchmarking */
   models: string[];
-  /** Max tasks to generate */
   maxTasks: number;
-  /** Max optimize iterations */
   maxIterations: number;
   /** For cli/mcp: path to entry file or binary (relative to repoPath or absolute) */
   entryFile?: string;
-  /** Optional project name (defaults to basename of repoPath) */
   name?: string;
 }
 

--- a/src/init/scaffold.ts
+++ b/src/init/scaffold.ts
@@ -1,11 +1,14 @@
 import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
-import { resolve, basename } from 'node:path';
+import { resolve, relative, join, basename } from 'node:path';
 import type { WizardAnswers } from './answers.js';
 import { importCommands } from '../import/index.js';
 
-export function buildConfigFromAnswers(answers: WizardAnswers): object {
+export function buildConfigFromAnswers(answers: WizardAnswers, configDir: string): object {
   const { surface, repoPath, models, maxTasks, maxIterations, name } = answers;
   const projectName = name ?? basename(repoPath);
+
+  // Paths stored in the JSON are relative to configDir so the config is portable
+  const relRepo = relative(configDir, repoPath) || '.';
 
   const commonBenchmark = {
     apiKeyEnv: 'OPENROUTER_API_KEY',
@@ -22,7 +25,7 @@ export function buildConfigFromAnswers(answers: WizardAnswers): object {
       ? 'openrouter/anthropic/claude-sonnet-4-6'
       : models[0]!,
     apiKeyEnv: 'OPENROUTER_API_KEY',
-    allowedPaths: ['../SKILL.md'],
+    allowedPaths: [join(relRepo, 'SKILL.md')],
     validation: [],
     maxIterations,
   };
@@ -32,26 +35,26 @@ export function buildConfigFromAnswers(answers: WizardAnswers): object {
       name: projectName,
       target: {
         surface: 'sdk',
-        repoPath,
-        skill: resolve(repoPath, 'SKILL.md'),
-        discovery: { mode: 'auto', sources: [resolve(repoPath, 'src/index.ts')] },
+        repoPath: relRepo,
+        skill: join(relRepo, 'SKILL.md'),
+        discovery: { mode: 'auto', sources: [join(relRepo, 'src/index.ts')] },
       },
       benchmark: commonBenchmark,
       optimize: commonOptimize,
     };
   }
 
+  const defaultEntry = surface === 'cli' ? 'src/cli.ts' : 'src/server.ts';
+  const entryRelative = answers.entryFile ?? defaultEntry;
+
   if (surface === 'cli') {
     return {
       name: projectName,
       target: {
         surface: 'cli',
-        repoPath,
-        skill: resolve(repoPath, 'SKILL.md'),
-        discovery: {
-          mode: 'auto',
-          sources: [answers.entryFile ? resolve(repoPath, answers.entryFile) : resolve(repoPath, 'src/cli.ts')],
-        },
+        repoPath: relRepo,
+        skill: join(relRepo, 'SKILL.md'),
+        discovery: { mode: 'auto', sources: [join(relRepo, entryRelative)] },
         cli: { commands: './.skill-optimizer/cli-commands.json' },
       },
       benchmark: commonBenchmark,
@@ -64,12 +67,9 @@ export function buildConfigFromAnswers(answers: WizardAnswers): object {
     name: projectName,
     target: {
       surface: 'mcp',
-      repoPath,
-      skill: resolve(repoPath, 'SKILL.md'),
-      discovery: {
-        mode: 'auto',
-        sources: [answers.entryFile ? resolve(repoPath, answers.entryFile) : resolve(repoPath, 'src/server.ts')],
-      },
+      repoPath: relRepo,
+      skill: join(relRepo, 'SKILL.md'),
+      discovery: { mode: 'auto', sources: [join(relRepo, entryRelative)] },
       mcp: { tools: './.skill-optimizer/tools.json' },
     },
     benchmark: commonBenchmark,
@@ -87,7 +87,7 @@ export async function scaffoldInit(answers: WizardAnswers, cwd: string): Promise
   if (existsSync(configPath)) {
     console.log(`[init] Skipping ${configPath} (already exists)`);
   } else {
-    writeFileSync(configPath, JSON.stringify(buildConfigFromAnswers(answers), null, 2) + '\n', 'utf-8');
+    writeFileSync(configPath, JSON.stringify(buildConfigFromAnswers(answers, configDir), null, 2) + '\n', 'utf-8');
     console.log(`[init] Created ${configPath}`);
   }
 

--- a/src/init/scaffold.ts
+++ b/src/init/scaffold.ts
@@ -1,0 +1,200 @@
+import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { resolve, basename } from 'node:path';
+import type { WizardAnswers } from './answers.js';
+import { importCommands } from '../import/index.js';
+
+export function buildConfigFromAnswers(answers: WizardAnswers): object {
+  const { surface, repoPath, models, maxTasks, maxIterations, name } = answers;
+  const projectName = name ?? basename(repoPath);
+  const benchmarkModels = models.map(id => ({ id }));
+
+  const commonBenchmark = {
+    apiKeyEnv: 'OPENROUTER_API_KEY',
+    format: 'pi',
+    timeout: 240000,
+    taskGeneration: { enabled: true, maxTasks, outputDir: './.skill-optimizer' },
+    models: benchmarkModels,
+    output: { dir: '../benchmark-results' },
+    verdict: { perModelFloor: 0.6, targetWeightedAverage: 0.7 },
+  };
+
+  const optimizeModel = models.includes('openrouter/anthropic/claude-sonnet-4-6')
+    ? 'openrouter/anthropic/claude-sonnet-4-6'
+    : models[0]!;
+
+  const commonOptimize = {
+    model: optimizeModel,
+    apiKeyEnv: 'OPENROUTER_API_KEY',
+    allowedPaths: ['../SKILL.md'],
+    validation: [],
+    maxIterations,
+  };
+
+  if (surface === 'sdk') {
+    return {
+      name: projectName,
+      target: {
+        surface: 'sdk',
+        repoPath,
+        skill: resolve(repoPath, 'SKILL.md'),
+        discovery: { mode: 'auto', sources: [resolve(repoPath, 'src/index.ts')] },
+      },
+      benchmark: commonBenchmark,
+      optimize: commonOptimize,
+    };
+  }
+
+  if (surface === 'cli') {
+    const entrySource = answers.entryFile
+      ? resolve(repoPath, answers.entryFile)
+      : resolve(repoPath, 'src/cli.ts');
+    return {
+      name: projectName,
+      target: {
+        surface: 'cli',
+        repoPath,
+        skill: resolve(repoPath, 'SKILL.md'),
+        discovery: { mode: 'auto', sources: [entrySource] },
+        cli: { commands: './.skill-optimizer/cli-commands.json' },
+      },
+      benchmark: commonBenchmark,
+      optimize: commonOptimize,
+    };
+  }
+
+  // mcp
+  const entrySource = answers.entryFile
+    ? resolve(repoPath, answers.entryFile)
+    : resolve(repoPath, 'src/server.ts');
+  return {
+    name: projectName,
+    target: {
+      surface: 'mcp',
+      repoPath,
+      skill: resolve(repoPath, 'SKILL.md'),
+      discovery: { mode: 'auto', sources: [entrySource] },
+      mcp: { tools: './.skill-optimizer/tools.json' },
+    },
+    benchmark: commonBenchmark,
+    optimize: commonOptimize,
+  };
+}
+
+export async function scaffoldInit(answers: WizardAnswers, cwd: string): Promise<void> {
+  const configDir = resolve(cwd, 'skill-optimizer');
+  const generatedDir = resolve(configDir, '.skill-optimizer');
+  mkdirSync(configDir, { recursive: true });
+  mkdirSync(generatedDir, { recursive: true });
+
+  const configPath = resolve(configDir, 'skill-optimizer.json');
+  if (existsSync(configPath)) {
+    console.log(`[init] Skipping ${configPath} (already exists)`);
+  } else {
+    const config = buildConfigFromAnswers(answers);
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+    console.log(`[init] Created ${configPath}`);
+  }
+
+  if (answers.surface === 'cli') {
+    const commandsPath = resolve(generatedDir, 'cli-commands.json');
+    if (existsSync(commandsPath)) {
+      console.log(`[init] Skipping ${commandsPath} (already exists)`);
+    } else if (answers.entryFile) {
+      console.log(`[init] Running import-commands from ${answers.entryFile}...`);
+      try {
+        await importCommands({
+          from: answers.entryFile,
+          out: commandsPath,
+          scrape: false,
+          depth: 2,
+          cwd: answers.repoPath,
+        });
+      } catch (err) {
+        console.warn(`[init] Warning: import-commands failed: ${err instanceof Error ? err.message : err}`);
+        console.warn(`[init] Writing template cli-commands.json instead.`);
+        writeCliTemplate(commandsPath);
+      }
+    } else {
+      writeCliTemplate(commandsPath);
+    }
+  }
+
+  if (answers.surface === 'mcp') {
+    const toolsPath = resolve(generatedDir, 'tools.json');
+    if (!existsSync(toolsPath)) {
+      writeMcpTemplate(toolsPath);
+    }
+  }
+
+  printNextSteps(answers, configPath);
+}
+
+function writeCliTemplate(commandsPath: string): void {
+  const commands = [
+    {
+      command: 'example-create',
+      description: 'Create a new item',
+      options: [{ name: '--name', takesValue: true, description: 'Name for the item' }],
+    },
+    {
+      command: 'example-list',
+      description: 'List all items',
+      options: [{ name: '--format', takesValue: true, description: 'Output format: json | table (default: table)' }],
+    },
+  ];
+  writeFileSync(commandsPath, JSON.stringify(commands, null, 2) + '\n', 'utf-8');
+  console.log(`[init] Created ${commandsPath} (template — edit or run import-commands to replace)`);
+}
+
+function writeMcpTemplate(toolsPath: string): void {
+  const tools = [
+    {
+      type: 'function',
+      function: {
+        name: 'get_data',
+        description: 'Get data for a given item ID',
+        parameters: {
+          type: 'object',
+          properties: { item_id: { type: 'string', description: 'The item identifier' } },
+          required: ['item_id'],
+        },
+      },
+    },
+    {
+      type: 'function',
+      function: {
+        name: 'send_data',
+        description: 'Send data to a recipient',
+        parameters: {
+          type: 'object',
+          properties: {
+            value: { type: 'string', description: 'The data to send' },
+            recipient: { type: 'string', description: 'The recipient identifier' },
+          },
+          required: ['value', 'recipient'],
+        },
+      },
+    },
+  ];
+  writeFileSync(toolsPath, JSON.stringify(tools, null, 2) + '\n', 'utf-8');
+  console.log(`[init] Created ${toolsPath} (template — edit with your real tools)`);
+}
+
+function printNextSteps(answers: WizardAnswers, configPath: string): void {
+  console.log('\n[init] Done! Next steps:');
+  console.log(`  Config: ${configPath}`);
+  if (answers.surface === 'sdk') {
+    console.log('  1. Review target.discovery.sources in the config — points to your SDK entry file');
+  } else if (answers.surface === 'cli') {
+    if (answers.entryFile) {
+      console.log('  1. Review skill-optimizer/.skill-optimizer/cli-commands.json — auto-extracted from your CLI');
+    } else {
+      console.log('  1. Edit skill-optimizer/.skill-optimizer/cli-commands.json — replace template with real commands');
+      console.log('     Or run: skill-optimizer import-commands --from <entry-file>');
+    }
+  } else {
+    console.log('  1. Edit skill-optimizer/.skill-optimizer/tools.json — replace template with your real MCP tools');
+  }
+  console.log('  2. Add a SKILL.md to your repo root explaining the surface to the model');
+  console.log('  3. Run: skill-optimizer run --config ./skill-optimizer/skill-optimizer.json');
+}

--- a/src/init/scaffold.ts
+++ b/src/init/scaffold.ts
@@ -6,24 +6,21 @@ import { importCommands } from '../import/index.js';
 export function buildConfigFromAnswers(answers: WizardAnswers): object {
   const { surface, repoPath, models, maxTasks, maxIterations, name } = answers;
   const projectName = name ?? basename(repoPath);
-  const benchmarkModels = models.map(id => ({ id }));
 
   const commonBenchmark = {
     apiKeyEnv: 'OPENROUTER_API_KEY',
     format: 'pi',
     timeout: 240000,
     taskGeneration: { enabled: true, maxTasks, outputDir: './.skill-optimizer' },
-    models: benchmarkModels,
+    models: models.map(id => ({ id })),
     output: { dir: '../benchmark-results' },
     verdict: { perModelFloor: 0.6, targetWeightedAverage: 0.7 },
   };
 
-  const optimizeModel = models.includes('openrouter/anthropic/claude-sonnet-4-6')
-    ? 'openrouter/anthropic/claude-sonnet-4-6'
-    : models[0]!;
-
   const commonOptimize = {
-    model: optimizeModel,
+    model: models.includes('openrouter/anthropic/claude-sonnet-4-6')
+      ? 'openrouter/anthropic/claude-sonnet-4-6'
+      : models[0]!,
     apiKeyEnv: 'OPENROUTER_API_KEY',
     allowedPaths: ['../SKILL.md'],
     validation: [],
@@ -45,16 +42,16 @@ export function buildConfigFromAnswers(answers: WizardAnswers): object {
   }
 
   if (surface === 'cli') {
-    const entrySource = answers.entryFile
-      ? resolve(repoPath, answers.entryFile)
-      : resolve(repoPath, 'src/cli.ts');
     return {
       name: projectName,
       target: {
         surface: 'cli',
         repoPath,
         skill: resolve(repoPath, 'SKILL.md'),
-        discovery: { mode: 'auto', sources: [entrySource] },
+        discovery: {
+          mode: 'auto',
+          sources: [answers.entryFile ? resolve(repoPath, answers.entryFile) : resolve(repoPath, 'src/cli.ts')],
+        },
         cli: { commands: './.skill-optimizer/cli-commands.json' },
       },
       benchmark: commonBenchmark,
@@ -63,16 +60,16 @@ export function buildConfigFromAnswers(answers: WizardAnswers): object {
   }
 
   // mcp
-  const entrySource = answers.entryFile
-    ? resolve(repoPath, answers.entryFile)
-    : resolve(repoPath, 'src/server.ts');
   return {
     name: projectName,
     target: {
       surface: 'mcp',
       repoPath,
       skill: resolve(repoPath, 'SKILL.md'),
-      discovery: { mode: 'auto', sources: [entrySource] },
+      discovery: {
+        mode: 'auto',
+        sources: [answers.entryFile ? resolve(repoPath, answers.entryFile) : resolve(repoPath, 'src/server.ts')],
+      },
       mcp: { tools: './.skill-optimizer/tools.json' },
     },
     benchmark: commonBenchmark,
@@ -90,8 +87,7 @@ export async function scaffoldInit(answers: WizardAnswers, cwd: string): Promise
   if (existsSync(configPath)) {
     console.log(`[init] Skipping ${configPath} (already exists)`);
   } else {
-    const config = buildConfigFromAnswers(answers);
-    writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+    writeFileSync(configPath, JSON.stringify(buildConfigFromAnswers(answers), null, 2) + '\n', 'utf-8');
     console.log(`[init] Created ${configPath}`);
   }
 
@@ -121,7 +117,9 @@ export async function scaffoldInit(answers: WizardAnswers, cwd: string): Promise
 
   if (answers.surface === 'mcp') {
     const toolsPath = resolve(generatedDir, 'tools.json');
-    if (!existsSync(toolsPath)) {
+    if (existsSync(toolsPath)) {
+      console.log(`[init] Skipping ${toolsPath} (already exists)`);
+    } else {
       writeMcpTemplate(toolsPath);
     }
   }

--- a/src/init/wizard.ts
+++ b/src/init/wizard.ts
@@ -59,7 +59,7 @@ export async function runWizard(cwd: string, preseedSurface?: 'sdk' | 'cli' | 'm
     required: true,
     initialValues: ['openrouter/anthropic/claude-sonnet-4-6', 'openrouter/google/gemini-2.0-flash-001'],
   }) as string[]);
-  const models: string[] = [...selectedPresets];
+  const models: string[] = selectedPresets;
 
   // Optional custom model
   const customModel = cancelGuard(await p.text({
@@ -99,21 +99,14 @@ export async function runWizard(cwd: string, preseedSurface?: 'sdk' | 'cli' | 'm
   }) as string);
   const maxIterations = parseInt(maxIterationsRaw || '5', 10);
 
-  // 6. Entry file (cli / mcp)
+  // 6. Entry file (cli / mcp only)
   let entryFile: string | undefined;
-  if (surface === 'cli') {
-    const raw = cancelGuard(await p.text({
-      message: 'Path to CLI entry file or binary (relative to repo, leave blank to skip):',
-      placeholder: 'src/cli.ts',
-      validate: () => undefined,
-    }) as string);
-    entryFile = raw.trim() || undefined;
-  } else if (surface === 'mcp') {
-    const raw = cancelGuard(await p.text({
-      message: 'Path to MCP server entry file (relative to repo, leave blank to skip):',
-      placeholder: 'src/server.ts',
-      validate: () => undefined,
-    }) as string);
+  if (surface === 'cli' || surface === 'mcp') {
+    const message = surface === 'cli'
+      ? 'Path to CLI entry file or binary (relative to repo, leave blank to skip):'
+      : 'Path to MCP server entry file (relative to repo, leave blank to skip):';
+    const placeholder = surface === 'cli' ? 'src/cli.ts' : 'src/server.ts';
+    const raw = cancelGuard(await p.text({ message, placeholder }) as string);
     entryFile = raw.trim() || undefined;
   }
 

--- a/src/init/wizard.ts
+++ b/src/init/wizard.ts
@@ -1,0 +1,134 @@
+import * as p from '@clack/prompts';
+import { resolve } from 'node:path';
+import type { WizardAnswers } from './answers.js';
+import { scaffoldInit } from './scaffold.js';
+
+export const MODEL_PRESETS = [
+  { value: 'openrouter/anthropic/claude-sonnet-4-6', label: 'Claude Sonnet 4.6  · Anthropic', hint: 'recommended' },
+  { value: 'openrouter/anthropic/claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5   · Anthropic', hint: 'fast' },
+  { value: 'openrouter/openai/gpt-4o', label: 'GPT-4o             · OpenAI' },
+  { value: 'openrouter/openai/gpt-4o-mini', label: 'GPT-4o Mini        · OpenAI', hint: 'fast' },
+  { value: 'openrouter/google/gemini-2.5-pro-preview', label: 'Gemini 2.5 Pro     · Google' },
+  { value: 'openrouter/google/gemini-2.0-flash-001', label: 'Gemini 2.0 Flash   · Google', hint: 'fast' },
+  { value: 'openrouter/meta-llama/llama-3.3-70b-instruct', label: 'Llama 3.3 70B      · Meta', hint: 'open' },
+  { value: 'openrouter/mistralai/mistral-large-2411', label: 'Mistral Large      · Mistral' },
+  { value: 'openrouter/deepseek/deepseek-chat', label: 'DeepSeek Chat      · DeepSeek', hint: 'open' },
+  { value: 'openrouter/qwen/qwen-2.5-72b-instruct', label: 'Qwen 2.5 72B       · Alibaba', hint: 'open' },
+];
+
+function cancelGuard<T>(value: T | symbol): T {
+  if (p.isCancel(value)) {
+    p.cancel('Cancelled.');
+    process.exit(0);
+  }
+  return value as T;
+}
+
+export async function runWizard(cwd: string, preseedSurface?: 'sdk' | 'cli' | 'mcp'): Promise<void> {
+  p.intro('skill-optimizer init');
+
+  // 1. Surface
+  let surface: 'sdk' | 'cli' | 'mcp';
+  if (preseedSurface) {
+    surface = preseedSurface;
+    p.log.info(`Surface: ${surface}`);
+  } else {
+    surface = cancelGuard(await p.select({
+      message: 'What surface are you targeting?',
+      options: [
+        { value: 'sdk', label: 'sdk', hint: 'TypeScript / Python / Rust library' },
+        { value: 'cli', label: 'cli', hint: 'command-line tool with subcommands' },
+        { value: 'mcp', label: 'mcp', hint: 'MCP server with tools' },
+      ],
+    }) as 'sdk' | 'cli' | 'mcp');
+  }
+
+  // 2. Target repo path
+  const repoPathRaw = cancelGuard(await p.text({
+    message: 'Target repo path (absolute):',
+    defaultValue: cwd,
+    placeholder: cwd,
+    validate: (v) => (v !== undefined && v.trim().length === 0 ? 'Required — enter the absolute path to your project' : undefined),
+  }) as string);
+  const repoPath = resolve(repoPathRaw.trim() || cwd);
+
+  // 3. Models (multi-select)
+  const selectedPresets = cancelGuard(await p.multiselect({
+    message: 'Which models to benchmark? (space to toggle, enter to confirm)',
+    options: MODEL_PRESETS,
+    required: true,
+    initialValues: ['openrouter/anthropic/claude-sonnet-4-6', 'openrouter/google/gemini-2.0-flash-001'],
+  }) as string[]);
+  const models: string[] = [...selectedPresets];
+
+  // Optional custom model
+  const customModel = cancelGuard(await p.text({
+    message: 'Add a custom model ID? (leave blank to skip)',
+    placeholder: 'openrouter/provider/model-name',
+    validate: (v) => {
+      if (!v || !v.trim()) return undefined;
+      if (!v.startsWith('openrouter/')) return 'Must start with openrouter/';
+      return undefined;
+    },
+  }) as string);
+  if (customModel.trim()) models.push(customModel.trim());
+
+  // 4. Max tasks
+  const maxTasksRaw = cancelGuard(await p.text({
+    message: 'Max tasks to generate per benchmark run:',
+    defaultValue: '20',
+    placeholder: '20',
+    validate: (v) => {
+      const n = parseInt(v ?? '', 10);
+      if (isNaN(n) || n < 1) return 'Must be a positive integer';
+      return undefined;
+    },
+  }) as string);
+  const maxTasks = parseInt(maxTasksRaw || '20', 10);
+
+  // 5. Max iterations
+  const maxIterationsRaw = cancelGuard(await p.text({
+    message: 'Max optimize iterations:',
+    defaultValue: '5',
+    placeholder: '5',
+    validate: (v) => {
+      const n = parseInt(v ?? '', 10);
+      if (isNaN(n) || n < 1) return 'Must be a positive integer';
+      return undefined;
+    },
+  }) as string);
+  const maxIterations = parseInt(maxIterationsRaw || '5', 10);
+
+  // 6. Entry file (cli / mcp)
+  let entryFile: string | undefined;
+  if (surface === 'cli') {
+    const raw = cancelGuard(await p.text({
+      message: 'Path to CLI entry file or binary (relative to repo, leave blank to skip):',
+      placeholder: 'src/cli.ts',
+      validate: () => undefined,
+    }) as string);
+    entryFile = raw.trim() || undefined;
+  } else if (surface === 'mcp') {
+    const raw = cancelGuard(await p.text({
+      message: 'Path to MCP server entry file (relative to repo, leave blank to skip):',
+      placeholder: 'src/server.ts',
+      validate: () => undefined,
+    }) as string);
+    entryFile = raw.trim() || undefined;
+  }
+
+  const answers: WizardAnswers = { surface, repoPath, models, maxTasks, maxIterations, entryFile };
+
+  const spinner = p.spinner();
+  spinner.start('Scaffolding...');
+  try {
+    await scaffoldInit(answers, cwd);
+    spinner.stop('Done!');
+  } catch (err) {
+    spinner.stop('Error during scaffolding');
+    p.log.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
+  p.outro('Config written. Next: skill-optimizer run --config ./skill-optimizer/skill-optimizer.json');
+}

--- a/tests/smoke-code.ts
+++ b/tests/smoke-code.ts
@@ -319,7 +319,7 @@ await test('initBenchmark cli: creates cli-commands.json and sets target.cli.com
   try {
     initBenchmark(dir, 'cli');
     const configPath = join(dir, 'skill-optimizer', 'skill-optimizer.json');
-    const commandsPath = join(dir, 'skill-optimizer', 'cli-commands.json');
+    const commandsPath = join(dir, 'skill-optimizer', '.skill-optimizer', 'cli-commands.json');
     const config = JSON.parse(readFileSync(configPath, 'utf-8')) as {
       target: { surface: string; cli?: { commands?: string } };
       benchmark: { taskGeneration?: { enabled?: boolean }; tasks?: string };
@@ -339,7 +339,7 @@ await test('initBenchmark mcp: creates tools.json and sets target.mcp.tools', ()
   try {
     initBenchmark(dir, 'mcp');
     const configPath = join(dir, 'skill-optimizer', 'skill-optimizer.json');
-    const toolsPath = join(dir, 'skill-optimizer', 'tools.json');
+    const toolsPath = join(dir, 'skill-optimizer', '.skill-optimizer', 'tools.json');
     const config = JSON.parse(readFileSync(configPath, 'utf-8')) as {
       target: { surface: string; mcp?: { tools?: string } };
       benchmark: { taskGeneration?: { enabled?: boolean }; tasks?: string };

--- a/tests/smoke-init.ts
+++ b/tests/smoke-init.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { WizardAnswers } from '../src/init/answers.js';
 import { buildDefaultAnswers, readAnswersFile } from '../src/init/answers.js';
+import { scaffoldInit } from '../src/init/scaffold.js';
 
 // Type check
 const _a: WizardAnswers = {
@@ -56,6 +57,98 @@ assert.strictEqual(typeof _a.surface, 'string');
     let threw = false;
     try { readAnswersFile(bad); } catch { threw = true; }
     assert.ok(threw, 'readAnswersFile should throw on missing surface');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// scaffoldInit sdk
+{
+  const dir = mkdtempSync(join(tmpdir(), 'scaffold-sdk-'));
+  try {
+    await scaffoldInit({
+      surface: 'sdk',
+      repoPath: dir,
+      models: ['openrouter/openai/gpt-4o'],
+      maxTasks: 10,
+      maxIterations: 3,
+    }, dir);
+    const configPath = join(dir, 'skill-optimizer', 'skill-optimizer.json');
+    assert.ok(existsSync(configPath), 'sdk scaffold should create skill-optimizer.json');
+    const config = JSON.parse(readFileSync(configPath, 'utf-8')) as {
+      target: { surface: string; repoPath: string };
+      benchmark: { models: Array<{ id: string }>; taskGeneration: { maxTasks: number } };
+      optimize: { maxIterations: number };
+    };
+    assert.strictEqual(config.target.surface, 'sdk');
+    assert.strictEqual(config.benchmark.models[0]?.id, 'openrouter/openai/gpt-4o');
+    assert.strictEqual(config.benchmark.taskGeneration.maxTasks, 10);
+    assert.strictEqual(config.optimize.maxIterations, 3);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// scaffoldInit cli — no entryFile, writes template
+{
+  const dir = mkdtempSync(join(tmpdir(), 'scaffold-cli-'));
+  try {
+    await scaffoldInit({
+      surface: 'cli',
+      repoPath: dir,
+      models: ['openrouter/openai/gpt-4o'],
+      maxTasks: 15,
+      maxIterations: 2,
+    }, dir);
+    const configPath = join(dir, 'skill-optimizer', 'skill-optimizer.json');
+    const commandsPath = join(dir, 'skill-optimizer', '.skill-optimizer', 'cli-commands.json');
+    assert.ok(existsSync(configPath), 'cli scaffold should create skill-optimizer.json');
+    assert.ok(existsSync(commandsPath), 'cli scaffold should create .skill-optimizer/cli-commands.json');
+    const config = JSON.parse(readFileSync(configPath, 'utf-8')) as {
+      target: { surface: string; cli?: { commands?: string } };
+    };
+    assert.strictEqual(config.target.surface, 'cli');
+    assert.ok(config.target.cli?.commands?.includes('cli-commands.json'), 'config should reference cli-commands.json');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// scaffoldInit mcp — writes template tools.json
+{
+  const dir = mkdtempSync(join(tmpdir(), 'scaffold-mcp-'));
+  try {
+    await scaffoldInit({
+      surface: 'mcp',
+      repoPath: dir,
+      models: ['openrouter/openai/gpt-4o'],
+      maxTasks: 5,
+      maxIterations: 1,
+    }, dir);
+    const toolsPath = join(dir, 'skill-optimizer', '.skill-optimizer', 'tools.json');
+    assert.ok(existsSync(toolsPath), 'mcp scaffold should create .skill-optimizer/tools.json');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// --answers equivalent: readAnswersFile + scaffoldInit mcp
+{
+  const dir = mkdtempSync(join(tmpdir(), 'scaffold-answers-'));
+  try {
+    const answersObj = {
+      surface: 'mcp',
+      repoPath: dir,
+      models: ['openrouter/openai/gpt-4o'],
+      maxTasks: 5,
+      maxIterations: 1,
+    };
+    const answersFile = join(dir, 'answers.json');
+    writeFileSync(answersFile, JSON.stringify(answersObj), 'utf-8');
+    const answers = readAnswersFile(answersFile);
+    await scaffoldInit(answers, dir);
+    const toolsPath = join(dir, 'skill-optimizer', '.skill-optimizer', 'tools.json');
+    assert.ok(existsSync(toolsPath), 'mcp scaffold via readAnswersFile should create tools.json');
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/smoke-init.ts
+++ b/tests/smoke-init.ts
@@ -154,4 +154,28 @@ assert.strictEqual(typeof _a.surface, 'string');
   }
 }
 
+// --yes equivalent test (buildDefaultAnswers + scaffoldInit)
+{
+  const dir = mkdtempSync(join(tmpdir(), 'scaffold-yes-'));
+  try {
+    const answers = buildDefaultAnswers('sdk', dir);
+    await scaffoldInit(answers, dir);
+    const configPath = join(dir, 'skill-optimizer', 'skill-optimizer.json');
+    assert.ok(existsSync(configPath), '--yes sdk should create skill-optimizer.json');
+    const config = JSON.parse(readFileSync(configPath, 'utf-8')) as { target: { surface: string }; optimize: { maxIterations: number }; benchmark: { taskGeneration: { maxTasks: number } } };
+    assert.strictEqual(config.target.surface, 'sdk');
+    assert.strictEqual(config.optimize.maxIterations, 5);
+    assert.strictEqual(config.benchmark.taskGeneration.maxTasks, 20);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// MODEL_PRESETS should have 10 entries
+{
+  const { MODEL_PRESETS } = await import('../src/init/wizard.js');
+  assert.strictEqual(MODEL_PRESETS.length, 10, `Expected 10 presets, got ${MODEL_PRESETS.length}`);
+  assert.ok(MODEL_PRESETS.every(p => p.value.startsWith('openrouter/')), 'All presets should be openrouter/ IDs');
+}
+
 console.log('smoke-init: all tests passed');

--- a/tests/smoke-init.ts
+++ b/tests/smoke-init.ts
@@ -1,0 +1,64 @@
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { WizardAnswers } from '../src/init/answers.js';
+import { buildDefaultAnswers, readAnswersFile } from '../src/init/answers.js';
+
+// Type check
+const _a: WizardAnswers = {
+  surface: 'sdk',
+  repoPath: '/tmp/repo',
+  models: ['openrouter/openai/gpt-4o'],
+  maxTasks: 20,
+  maxIterations: 5,
+};
+assert.strictEqual(typeof _a.surface, 'string');
+
+// buildDefaultAnswers
+{
+  const defaults = buildDefaultAnswers('cli');
+  assert.strictEqual(defaults.surface, 'cli');
+  assert.ok(defaults.models.length >= 1, 'should have at least one default model');
+  assert.strictEqual(typeof defaults.maxTasks, 'number');
+  assert.strictEqual(typeof defaults.maxIterations, 'number');
+}
+
+// readAnswersFile
+{
+  const dir = mkdtempSync(join(tmpdir(), 'answers-test-'));
+  try {
+    const answers: WizardAnswers = {
+      surface: 'mcp',
+      repoPath: '/tmp/myrepo',
+      models: ['openrouter/openai/gpt-4o'],
+      maxTasks: 15,
+      maxIterations: 3,
+      entryFile: 'src/server.ts',
+    };
+    const file = join(dir, 'answers.json');
+    writeFileSync(file, JSON.stringify(answers), 'utf-8');
+    const loaded = readAnswersFile(file);
+    assert.strictEqual(loaded.surface, 'mcp');
+    assert.strictEqual(loaded.entryFile, 'src/server.ts');
+    assert.strictEqual(loaded.maxIterations, 3);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// readAnswersFile error: missing surface
+{
+  const dir = mkdtempSync(join(tmpdir(), 'answers-err-'));
+  try {
+    const bad = join(dir, 'bad.json');
+    writeFileSync(bad, JSON.stringify({ repoPath: '/tmp', models: ['openrouter/openai/gpt-4o'], maxTasks: 5, maxIterations: 1 }), 'utf-8');
+    let threw = false;
+    try { readAnswersFile(bad); } catch { threw = true; }
+    assert.ok(threw, 'readAnswersFile should throw on missing surface');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+console.log('smoke-init: all tests passed');


### PR DESCRIPTION
## Summary

- Replaces `skill-optimizer init <surface>` (positional-only) with a full `@clack/prompts` interactive wizard
- Wizard asks: surface → repo path → model multiselect (10 presets + custom entry) → max tasks → max iterations → entry file (cli/mcp)
- For CLI surface: automatically runs `import-commands` when entry file is given, populating `.skill-optimizer/cli-commands.json`
- Non-interactive escapes: `--yes` (defaults) and `--answers <file.json>` (CI mode)
- Generated artifacts move to `skill-optimizer/.skill-optimizer/` (gitignored) — `skill-optimizer.json` stays tracked
- Generated config uses relative paths so it's portable and committable

## New files

- `src/init/answers.ts` — `WizardAnswers` type, `buildDefaultAnswers()`, `readAnswersFile()` (with runtime array validation)
- `src/init/scaffold.ts` — `buildConfigFromAnswers()` (relative paths), `scaffoldInit()` (async, runs import-commands for cli)
- `src/init/wizard.ts` — `runWizard()` using `@clack/prompts` with `cancelGuard`, 10-model `MODEL_PRESETS`
- `tests/smoke-init.ts` — smoke tests for all three paths (answers, scaffold sdk/cli/mcp, MODEL_PRESETS count)

## Modified files

- `src/benchmark/init.ts` — companion files now go to `.skill-optimizer/` (gitignored); updated `buildConfig` path refs
- `src/cli.ts` — init handler dispatches wizard / `--yes` / `--answers`; adds `--yes` + `--answers` to flag sets
- `package.json` — `@clack/prompts` dep; `smoke-init` in test chain
- `README.md` — quickstart updated with wizard flow and `--answers` JSON format

## Test plan

- [x] `npx tsx tests/smoke-init.ts` — all tests pass
- [x] `npm run typecheck` — clean
- [x] `npm test` — smoke-init included, all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)