### PR TITLE
feat(phase-4): init --auto, typed error registry, auto-generated reference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ cd skill-optimizer
 npm install
 export OPENROUTER_API_KEY=sk-or-...
 
-# Interactive wizard — asks surface, repo path, models, task limits, entry file
-npx tsx src/cli.ts init
+# Auto-detect project type and pre-fill wizard
+npx tsx src/cli.ts init --auto
 
-# Or pre-fill the surface to skip the first question
+# Or specify the surface directly
 npx tsx src/cli.ts init cli       # or: init sdk, init mcp
 
 # Non-interactive: accept all defaults
@@ -74,97 +74,9 @@ npx tsx src/cli.ts run --config ./skill-optimizer/skill-optimizer.json
 
 ## Configuration reference
 
-All configuration lives in a single `skill-optimizer.json` file.
+See [docs/reference/config-schema.md](docs/reference/config-schema.md) for the full generated config reference — auto-updated at every build.
 
-### `target` fields
-
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `surface` | `"sdk" \| "cli" \| "mcp"` | required | Type of callable surface |
-| `repoPath` | `string` | `.` | Path to the target repo |
-| `skill` | `string \| { source: string; cache?: boolean }` | — | Path to SKILL.md |
-| `discovery.mode` | `"auto" \| "manifest"` | `"auto"` | How to discover actions |
-| `discovery.sources` | `string[]` | — | Source files for tree-sitter discovery |
-| `discovery.language` | `"typescript" \| "python" \| "rust"` | — | Language for code-first discovery |
-| `discovery.fallbackManifest` | `string` | — | Path to manifest JSON when code-first discovery is incomplete |
-| `sdk.language` | `"typescript" \| "python" \| "rust"` | — | SDK language |
-| `sdk.entrypoints` | `string[]` | — | SDK entry files |
-| `cli.commands` | `string` | — | Path to CLI commands manifest JSON |
-| `mcp.tools` | `string` | — | Path to MCP tools manifest JSON |
-
-### `benchmark` fields
-
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `format` | `"pi"` | `"pi"` | LLM transport format |
-| `apiKeyEnv` | `string` | `OPENROUTER_API_KEY` | Env var name for the API key |
-| `timeout` | `number` | `240000` | Ms per model call |
-| `models` | `Array<{ id: string; name: string; tier: "flagship"\|"mid"\|"low"; weight?: number }>` | required | Models to benchmark |
-| `taskGeneration.enabled` | `boolean` | `false` | Whether to generate tasks automatically |
-| `taskGeneration.maxTasks` | `number` | `10` | Max tasks to generate (must be >= scope size) |
-| `taskGeneration.seed` | `number` | `1` | RNG seed for reproducible generation |
-| `output.dir` | `string` | `benchmark-results/` | Where reports are saved |
-| `verdict.perModelFloor` | `number` | `0.6` | Minimum per-model pass fraction for a PASS verdict |
-| `verdict.targetWeightedAverage` | `number` | `0.7` | Minimum weighted average across all models for a PASS verdict |
-
-### `optimize` fields (all optional)
-
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `model` | `string` | — | Model for mutation (e.g. `openrouter/anthropic/claude-sonnet-4-6`) |
-| `apiKeyEnv` | `string` | — | Env var for the optimizer's API key |
-| `thinkingLevel` | `"off"\|"minimal"\|"low"\|"medium"\|"high"\|"xhigh"` | `"medium"` | Reasoning depth for mutation calls |
-| `allowedPaths` | `string[]` | — | Paths the optimizer may edit (safety boundary) |
-| `validation` | `string[]` | — | Shell commands to run to validate each mutation |
-| `requireCleanGit` | `boolean` | `true` | Require clean git state before starting |
-| `maxIterations` | `number` | `5` | Maximum optimization iterations |
-| `minImprovement` | `number` | `0.02` | Minimum weighted-average gain per accepted iteration |
-| `reportContextMaxBytes` | `number` | `16000` | Byte budget for mutation context |
-
-### Annotated example config
-
-```json
-{
-  "name": "my-mcp-project",
-  "target": {
-    "surface": "mcp",
-    "repoPath": ".",
-    "skill": "./SKILL.md",
-    "discovery": {
-      "mode": "auto",
-      "sources": ["./src/server.ts"]
-    }
-  },
-  "benchmark": {
-    "format": "pi",
-    "apiKeyEnv": "OPENROUTER_API_KEY",
-    "models": [
-      { "id": "openrouter/anthropic/claude-sonnet-4-6", "name": "Claude Sonnet", "tier": "flagship", "weight": 2 },
-      { "id": "openrouter/openai/gpt-4o-mini",          "name": "GPT-4o mini",   "tier": "mid",      "weight": 1 }
-    ],
-    "taskGeneration": {
-      "enabled": true,
-      "maxTasks": 20,
-      "seed": 1
-    },
-    "output": { "dir": "./benchmark-results" },
-    "verdict": {
-      "perModelFloor": 0.6,
-      "targetWeightedAverage": 0.7
-    }
-  },
-  "optimize": {
-    "model": "openrouter/anthropic/claude-sonnet-4-6",
-    "apiKeyEnv": "OPENROUTER_API_KEY",
-    "thinkingLevel": "medium",
-    "allowedPaths": ["SKILL.md"],
-    "requireCleanGit": true,
-    "maxIterations": 5,
-    "minImprovement": 0.02,
-    "reportContextMaxBytes": 16000
-  }
-}
-```
+See [docs/reference/errors.md](docs/reference/errors.md) for all error codes, descriptions, and fix instructions.
 
 ## Interpreting the verdict
 

--- a/README.md
+++ b/README.md
@@ -12,17 +12,38 @@ cd skill-optimizer
 npm install
 export OPENROUTER_API_KEY=sk-or-...
 
-# Scaffold config for your surface type (sdk | cli | mcp)
-npx tsx src/cli.ts init cli
+# Interactive wizard — asks surface, repo path, models, task limits, entry file
+npx tsx src/cli.ts init
+
+# Or pre-fill the surface to skip the first question
+npx tsx src/cli.ts init cli       # or: init sdk, init mcp
+
+# Non-interactive: accept all defaults
+npx tsx src/cli.ts init cli --yes
+
+# CI mode: load answers from a JSON file
+npx tsx src/cli.ts init --answers answers.json
 ```
 
-`init cli` creates a `skill-optimizer/` directory with:
-- `skill-optimizer.json` — the main config (task generation enabled by default)
-- `cli-commands.json` — command manifest template (used as fallback if code-first discovery finds nothing)
+`init` creates a `skill-optimizer/` directory with:
+- `skill-optimizer.json` — the main config (commit this)
+- `skill-optimizer/.skill-optimizer/` — generated artifacts (gitignored)
+  - `cli-commands.json` — CLI surface: auto-extracted via `import-commands`, or template
+  - `tools.json` — MCP surface: template to edit with your real tools
 
-`init sdk` creates `skill-optimizer.json` only. `init mcp` creates `skill-optimizer.json` + `tools.json`.
+**`answers.json` format for CI/`--answers` mode:**
+```json
+{
+  "surface": "cli",
+  "repoPath": "/absolute/path/to/your-repo",
+  "models": ["openrouter/anthropic/claude-sonnet-4-6", "openrouter/openai/gpt-4o"],
+  "maxTasks": 20,
+  "maxIterations": 5,
+  "entryFile": "src/cli.ts"
+}
+```
 
-Open `skill-optimizer/skill-optimizer.json` and fill in these fields:
+Open `skill-optimizer/skill-optimizer.json` and review these fields:
 
 | Field | What it does | Set it to |
 |-------|-------------|-----------|

--- a/docs/reference/config-schema.md
+++ b/docs/reference/config-schema.md
@@ -1,0 +1,44 @@
+<!-- AUTO-GENERATED — do not edit. Run `npm run gen-docs` to regenerate. -->
+
+
+# Config Schema Reference
+
+All configuration lives in a single `skill-optimizer.json` file.
+Paths in the config are relative to the config file location.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `name` | `string` | — | Human-readable project name |
+| `target.surface` | `"sdk" | "cli" | "mcp"` | — | Type of callable surface |
+| `target.repoPath` | `string` | — | Path to the target repo (default ".") |
+| `target.skill` | `string | object` | — | Path to SKILL.md or { source, cache } object |
+| `target.discovery.mode` | `"auto" | "manifest"` | — | "auto" = code-first tree-sitter; "manifest" = use provided file only |
+| `target.discovery.sources` | `string[]` | — | Source files to scan for callable methods/commands/tools |
+| `target.discovery.fallbackManifest` | `string` | — | Path to manifest JSON when code-first discovery is incomplete |
+| `target.discovery.language` | `"typescript" | "python" | "rust"` | — | Language for code-first discovery |
+| `target.sdk.language` | `"typescript" | "python" | "rust"` | — | SDK language |
+| `target.sdk.entrypoints` | `string[]` | — | SDK entry files for discovery |
+| `target.cli.commands` | `string` | — | Path to CLI commands manifest JSON (CliCommandDefinition[]) |
+| `target.mcp.tools` | `string` | — | Path to MCP tools manifest JSON (OpenAI function tool definitions) |
+| `target.scope.include` | `string[]` | — | Glob patterns for actions to include (default ["*"]) |
+| `target.scope.exclude` | `string[]` | — | Glob patterns for actions to exclude (default []) |
+| `benchmark.format` | `"pi" | "openai" | "anthropic"` | — | LLM transport format: pi, openai, or anthropic |
+| `benchmark.apiKeyEnv` | `string` | — | Env var name for the API key (default OPENROUTER_API_KEY) |
+| `benchmark.timeout` | `integer` | — | Milliseconds per model call (default 240000) |
+| `benchmark.models` | `object[]` | — | Models to benchmark — at least one required |
+| `benchmark.taskGeneration.enabled` | `boolean` | — | Whether to generate tasks automatically (default false) |
+| `benchmark.taskGeneration.maxTasks` | `integer` | — | Max tasks to generate — must be >= in-scope action count (default 10) |
+| `benchmark.taskGeneration.seed` | `integer` | — | RNG seed for reproducible generation (default 1) |
+| `benchmark.taskGeneration.outputDir` | `string` | — | Where to write generated task artifacts (default ".skill-optimizer") |
+| `benchmark.output.dir` | `string` | — | Directory where reports are saved (default "benchmark-results/") |
+| `benchmark.verdict.perModelFloor` | `number` | — | Minimum per-model pass fraction for PASS verdict (default 0.6) |
+| `benchmark.verdict.targetWeightedAverage` | `number` | — | Minimum weighted average across all models for PASS (default 0.7) |
+| `optimize.model` | `string` | — | Model for mutation, e.g. openrouter/anthropic/claude-sonnet-4-6 |
+| `optimize.apiKeyEnv` | `string` | — | Env var for the optimizer API key |
+| `optimize.thinkingLevel` | `"off" | "minimal" | "low" | "medium" | "high" | "xhigh"` | — | Reasoning depth for mutation calls (default "medium") |
+| `optimize.allowedPaths` | `string[]` | — | Paths the optimizer may edit — safety boundary |
+| `optimize.validation` | `string[]` | — | Shell commands to run to validate each mutation |
+| `optimize.requireCleanGit` | `boolean` | — | Require clean git state before starting (default true) |
+| `optimize.maxIterations` | `integer` | — | Maximum optimization iterations (default 5) |
+| `optimize.minImprovement` | `number` | — | Minimum weighted-average gain per accepted iteration (default 0.02) |
+| `optimize.reportContextMaxBytes` | `integer` | — | Byte budget for mutation context (default 16000) |

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -1,0 +1,232 @@
+<!-- AUTO-GENERATED — do not edit. Run `npm run gen-docs` to regenerate. -->
+
+
+# Error Reference
+
+Every `skill-optimizer` error has a code, a short message, and a fix list.
+The catch-all `E_UNEXPECTED` appears if an error slips past the known list.
+
+## Summary
+
+| Code | Description | Quick fix |
+|---|---|---|
+| `E_INVALID_SURFACE` | Invalid surface value | Set target.surface to one of: sdk, cli, mcp |
+| `E_MODELS_EMPTY` | benchmark.models is empty or missing | Add at least one model to benchmark.models, e.g.: |
+| `E_MODEL_ID_FORMAT` | Model ID is missing the openrouter/ prefix | Prefix all model IDs with openrouter/, e.g. openrouter/anthropic/claude-sonnet-4-6 |
+| `E_VERDICT_OUT_OF_RANGE` | Verdict threshold is out of range | Set benchmark.verdict.perModelFloor and targetWeightedAverage to values between 0.0 and 1.0 |
+| `E_MAX_ITERATIONS_ZERO` | optimize.maxIterations must be a positive integer | Set optimize.maxIterations to a positive integer, e.g. 5 |
+| `E_INVALID_FORMAT` | Invalid benchmark.format value | Set benchmark.format to one of: pi, openai, anthropic |
+| `E_REPO_NOT_FOUND` | target.repoPath does not exist or is not a directory | Fix target.repoPath in your skill-optimizer.json to point at an existing directory |
+| `E_MISSING_SKILL` | target.skill file not found | Create a SKILL.md at the path specified in target.skill |
+| `E_SOURCES_NOT_FOUND` | One or more target.discovery.sources files do not exist | Check that all paths in target.discovery.sources exist in your repo |
+| `E_CLI_MANIFEST_NOT_FOUND` | target.cli.commands manifest file not found | Run: skill-optimizer import-commands --from <entry-file> to auto-extract |
+| `E_MCP_MANIFEST_NOT_FOUND` | target.mcp.tools manifest file not found | Create the tools.json file at the path specified in target.mcp.tools |
+| `E_ALLOWED_PATHS_ESCAPE` | optimize.allowedPaths contains a path outside target.repoPath | All paths in optimize.allowedPaths must be inside target.repoPath |
+| `E_OUTPUT_DIR_NOT_WRITABLE` | benchmark.output.dir is not writable | Check directory permissions for the path set in benchmark.output.dir |
+| `E_MISSING_API_KEY` | API key environment variable is not set | Export your OpenRouter API key before running: export OPENROUTER_API_KEY=sk-or-... |
+| `E_LEGACY_CONFIG` | Found skill-benchmark.json instead of skill-optimizer.json | Rename skill-benchmark.json to skill-optimizer.json |
+| `E_DISCOVERY_EMPTY` | Discovery found zero callable actions | Check that target.discovery.sources points at the right entry file |
+| `E_MAXTASKS_TOO_LOW` | benchmark.taskGeneration.maxTasks is less than the in-scope action count | Raise benchmark.taskGeneration.maxTasks to at least the number of in-scope actions |
+| `E_COVERAGE_EXHAUSTED` | Task generation could not cover all in-scope actions after 2 retry passes | Add guidance for the uncovered actions to your SKILL.md |
+| `E_DIRTY_GIT` | Target repo has uncommitted changes | Commit or stash changes in target.repoPath before running the optimizer |
+| `E_GIT_CHECKPOINT_FAILED` | Git checkpoint creation failed | Check disk space and git permissions in target.repoPath |
+| `E_VALIDATION_FAILED` | Configured validation command exited non-zero | Fix the issue flagged by the validation command before retrying |
+| `E_INIT_AUTO_LOW_CONFIDENCE` | init --auto --yes requires high confidence detection | Run init interactively to review and confirm detection: skill-optimizer init --auto |
+| `E_UNEXPECTED` | An unexpected error occurred | Check the full error message and stack trace above for details |
+
+## Details
+
+### `E_INVALID_SURFACE`
+
+**Invalid surface value**
+
+**How to fix:**
+- Set target.surface to one of: sdk, cli, mcp
+- sdk = TypeScript/Python/Rust library, cli = command-line tool, mcp = MCP server
+
+### `E_MODELS_EMPTY`
+
+**benchmark.models is empty or missing**
+
+**How to fix:**
+- Add at least one model to benchmark.models, e.g.:
+-   { "id": "openrouter/anthropic/claude-sonnet-4-6", "name": "Claude Sonnet", "tier": "flagship" }
+
+### `E_MODEL_ID_FORMAT`
+
+**Model ID is missing the openrouter/ prefix**
+
+**How to fix:**
+- Prefix all model IDs with openrouter/, e.g. openrouter/anthropic/claude-sonnet-4-6
+- Browse available models at https://openrouter.ai/models
+
+### `E_VERDICT_OUT_OF_RANGE`
+
+**Verdict threshold is out of range**
+
+**How to fix:**
+- Set benchmark.verdict.perModelFloor and targetWeightedAverage to values between 0.0 and 1.0
+- Typical values: perModelFloor=0.6, targetWeightedAverage=0.7
+
+### `E_MAX_ITERATIONS_ZERO`
+
+**optimize.maxIterations must be a positive integer**
+
+**How to fix:**
+- Set optimize.maxIterations to a positive integer, e.g. 5
+
+### `E_INVALID_FORMAT`
+
+**Invalid benchmark.format value**
+
+**How to fix:**
+- Set benchmark.format to one of: pi, openai, anthropic
+
+### `E_REPO_NOT_FOUND`
+
+**target.repoPath does not exist or is not a directory**
+
+**How to fix:**
+- Fix target.repoPath in your skill-optimizer.json to point at an existing directory
+- Paths in the config are relative to the config file location
+
+### `E_MISSING_SKILL`
+
+**target.skill file not found**
+
+**How to fix:**
+- Create a SKILL.md at the path specified in target.skill
+- Or update target.skill in your config to point at an existing file
+
+### `E_SOURCES_NOT_FOUND`
+
+**One or more target.discovery.sources files do not exist**
+
+**How to fix:**
+- Check that all paths in target.discovery.sources exist in your repo
+- Paths are relative to target.repoPath
+- For CLI: point at your main entry file (e.g. src/cli.ts)
+- For MCP: point at your server entry file (e.g. src/server.ts)
+
+### `E_CLI_MANIFEST_NOT_FOUND`
+
+**target.cli.commands manifest file not found**
+
+**How to fix:**
+- Run: skill-optimizer import-commands --from <entry-file> to auto-extract
+- Or create the file manually and populate it with your CLI commands
+- Format: Array of { command, description, options[] }
+
+### `E_MCP_MANIFEST_NOT_FOUND`
+
+**target.mcp.tools manifest file not found**
+
+**How to fix:**
+- Create the tools.json file at the path specified in target.mcp.tools
+- Format: Array of OpenAI function tool definitions { type: "function", function: { name, description, parameters } }
+
+### `E_ALLOWED_PATHS_ESCAPE`
+
+**optimize.allowedPaths contains a path outside target.repoPath**
+
+**How to fix:**
+- All paths in optimize.allowedPaths must be inside target.repoPath
+- This is a safety boundary — the optimizer will only edit files within this list
+
+### `E_OUTPUT_DIR_NOT_WRITABLE`
+
+**benchmark.output.dir is not writable**
+
+**How to fix:**
+- Check directory permissions for the path set in benchmark.output.dir
+- Or change benchmark.output.dir to a path you have write access to
+
+### `E_MISSING_API_KEY`
+
+**API key environment variable is not set**
+
+**How to fix:**
+- Export your OpenRouter API key before running: export OPENROUTER_API_KEY=sk-or-...
+- Or add it to a .env file alongside your skill-optimizer.json
+- Get a key at https://openrouter.ai/keys
+
+### `E_LEGACY_CONFIG`
+
+**Found skill-benchmark.json instead of skill-optimizer.json**
+
+**How to fix:**
+- Rename skill-benchmark.json to skill-optimizer.json
+- See CHANGELOG.md for any field renames between versions
+
+### `E_DISCOVERY_EMPTY`
+
+**Discovery found zero callable actions**
+
+**How to fix:**
+- Check that target.discovery.sources points at the right entry file
+- For SDK: should be your public API entry (e.g. src/index.ts)
+- For CLI: should be the file that registers all subcommands
+- For MCP: should be the file that registers all tools
+- Add a fallback manifest: target.discovery.fallbackManifest or target.cli.commands / target.mcp.tools
+
+### `E_MAXTASKS_TOO_LOW`
+
+**benchmark.taskGeneration.maxTasks is less than the in-scope action count**
+
+**How to fix:**
+- Raise benchmark.taskGeneration.maxTasks to at least the number of in-scope actions
+- Run: skill-optimizer --dry-run --config ./skill-optimizer.json to see the action count
+- Or narrow the scope with target.scope.exclude to reduce the action count
+
+### `E_COVERAGE_EXHAUSTED`
+
+**Task generation could not cover all in-scope actions after 2 retry passes**
+
+**How to fix:**
+- Add guidance for the uncovered actions to your SKILL.md
+- The error message above names the specific uncovered actions
+- Or exclude them with target.scope.exclude if they should not be benchmarked
+
+### `E_DIRTY_GIT`
+
+**Target repo has uncommitted changes**
+
+**How to fix:**
+- Commit or stash changes in target.repoPath before running the optimizer
+- Run: git -C <repoPath> stash
+- Or: git -C <repoPath> add -A && git -C <repoPath> commit -m "wip: before optimizer run"
+
+### `E_GIT_CHECKPOINT_FAILED`
+
+**Git checkpoint creation failed**
+
+**How to fix:**
+- Check disk space and git permissions in target.repoPath
+- Make sure the directory is a valid git repository
+- Run: git -C <repoPath> status to verify git state
+
+### `E_VALIDATION_FAILED`
+
+**Configured validation command exited non-zero**
+
+**How to fix:**
+- Fix the issue flagged by the validation command before retrying
+- The failing command is listed in optimize.validation in your config
+- Run the validation command manually to see the full error output
+
+### `E_INIT_AUTO_LOW_CONFIDENCE`
+
+**init --auto --yes requires high confidence detection**
+
+**How to fix:**
+- Run init interactively to review and confirm detection: skill-optimizer init --auto
+- Or supply a pre-filled answers file: skill-optimizer init --answers answers.json
+- See README for the answers.json format
+
+### `E_UNEXPECTED`
+
+**An unexpected error occurred**
+
+**How to fix:**
+- Check the full error message and stack trace above for details
+- File an issue at https://github.com/bucurdavid/skill-optimizer/issues with the full output

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@clack/prompts": "^1.2.0",
         "@mariozechner/pi-agent-core": "^0.66.1",
         "@mariozechner/pi-ai": "^0.66.1",
         "@mariozechner/pi-coding-agent": "^0.66.1",
@@ -778,6 +779,28 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.2.0.tgz",
+      "integrity": "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-wrap-ansi": "^0.1.3",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.2.0.tgz",
+      "integrity": "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.2.0",
+        "fast-string-width": "^1.1.0",
+        "fast-wrap-ansi": "^0.1.3",
+        "sisteransi": "^1.0.5"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2802,6 +2825,21 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-1.2.1.tgz",
+      "integrity": "sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-1.1.0.tgz",
+      "integrity": "sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^1.2.0"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -2817,6 +2855,15 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.1.6.tgz",
+      "integrity": "sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^1.1.0"
+      }
     },
     "node_modules/fast-xml-builder": {
       "version": "1.1.4",
@@ -3680,6 +3727,12 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,9 @@
         "@mariozechner/pi-coding-agent": "^0.66.1",
         "dotenv": "^17.4.1",
         "tree-sitter-wasms": "^0.1.13",
-        "web-tree-sitter": "^0.24.7"
+        "web-tree-sitter": "^0.24.7",
+        "zod": "^4.3.6",
+        "zod-to-json-schema": "^3.25.2"
       },
       "bin": {
         "skill-optimizer": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,9 @@
     "@mariozechner/pi-coding-agent": "^0.66.1",
     "dotenv": "^17.4.1",
     "tree-sitter-wasms": "^0.1.13",
-    "web-tree-sitter": "^0.24.7"
+    "web-tree-sitter": "^0.24.7",
+    "zod": "^4.3.6",
+    "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {
     "@types/node": "^22.12.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "test": "tsx tests/smoke-code.ts && tsx tests/smoke-sdk-python.ts && tsx tests/smoke-sdk-rust.ts && tsx tests/smoke-cli.ts && tsx tests/smoke-cli-entry.ts && tsx tests/smoke-mcp.ts && tsx tests/smoke-llm.ts && tsx tests/smoke-discovery-sdk.ts && tsx tests/smoke-discovery-cli.ts && tsx tests/smoke-discovery-mcp.ts && tsx tests/smoke-generation.ts && tsx tests/smoke-optimize.ts && tsx tests/smoke-mock-repos.ts && tsx tests/smoke-release.ts && tsx tests/smoke-scoring.ts && tsx tests/smoke-scope.ts && tsx tests/smoke-coverage.ts && tsx tests/smoke-feedback.ts && tsx tests/smoke-verdict.ts && tsx tests/smoke-dry-run.ts && tsx tests/smoke-errors.ts && tsx tests/smoke-e2e.ts && tsx tests/smoke-import.ts"
   },
   "dependencies": {
+    "@clack/prompts": "^1.2.0",
     "@mariozechner/pi-agent-core": "^0.66.1",
     "@mariozechner/pi-ai": "^0.66.1",
     "@mariozechner/pi-coding-agent": "^0.66.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "materialize:mock": "tsx src/optimizer/materialize-mock-repo.ts",
     "build": "tsc",
     "typecheck": "tsc --noEmit",
-    "test": "tsx tests/smoke-code.ts && tsx tests/smoke-sdk-python.ts && tsx tests/smoke-sdk-rust.ts && tsx tests/smoke-cli.ts && tsx tests/smoke-cli-entry.ts && tsx tests/smoke-mcp.ts && tsx tests/smoke-llm.ts && tsx tests/smoke-discovery-sdk.ts && tsx tests/smoke-discovery-cli.ts && tsx tests/smoke-discovery-mcp.ts && tsx tests/smoke-generation.ts && tsx tests/smoke-optimize.ts && tsx tests/smoke-mock-repos.ts && tsx tests/smoke-release.ts && tsx tests/smoke-scoring.ts && tsx tests/smoke-scope.ts && tsx tests/smoke-coverage.ts && tsx tests/smoke-feedback.ts && tsx tests/smoke-verdict.ts && tsx tests/smoke-dry-run.ts && tsx tests/smoke-errors.ts && tsx tests/smoke-e2e.ts"
+    "test": "tsx tests/smoke-code.ts && tsx tests/smoke-sdk-python.ts && tsx tests/smoke-sdk-rust.ts && tsx tests/smoke-cli.ts && tsx tests/smoke-cli-entry.ts && tsx tests/smoke-mcp.ts && tsx tests/smoke-llm.ts && tsx tests/smoke-discovery-sdk.ts && tsx tests/smoke-discovery-cli.ts && tsx tests/smoke-discovery-mcp.ts && tsx tests/smoke-generation.ts && tsx tests/smoke-optimize.ts && tsx tests/smoke-mock-repos.ts && tsx tests/smoke-release.ts && tsx tests/smoke-scoring.ts && tsx tests/smoke-scope.ts && tsx tests/smoke-coverage.ts && tsx tests/smoke-feedback.ts && tsx tests/smoke-verdict.ts && tsx tests/smoke-dry-run.ts && tsx tests/smoke-errors.ts && tsx tests/smoke-e2e.ts && tsx tests/smoke-import.ts"
   },
   "dependencies": {
     "@mariozechner/pi-agent-core": "^0.66.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "dev": "tsx src/cli.ts",
     "optimize": "tsx src/cli.ts optimize",
     "materialize:mock": "tsx src/optimizer/materialize-mock-repo.ts",
-    "build": "tsc",
+    "gen-docs": "tsx scripts/gen-docs.ts",
+    "build": "tsc && npm run gen-docs",
     "typecheck": "tsc --noEmit",
     "test": "tsx tests/smoke-code.ts && tsx tests/smoke-sdk-python.ts && tsx tests/smoke-sdk-rust.ts && tsx tests/smoke-cli.ts && tsx tests/smoke-cli-entry.ts && tsx tests/smoke-mcp.ts && tsx tests/smoke-llm.ts && tsx tests/smoke-discovery-sdk.ts && tsx tests/smoke-discovery-cli.ts && tsx tests/smoke-discovery-mcp.ts && tsx tests/smoke-generation.ts && tsx tests/smoke-optimize.ts && tsx tests/smoke-mock-repos.ts && tsx tests/smoke-release.ts && tsx tests/smoke-scoring.ts && tsx tests/smoke-scope.ts && tsx tests/smoke-coverage.ts && tsx tests/smoke-feedback.ts && tsx tests/smoke-verdict.ts && tsx tests/smoke-dry-run.ts && tsx tests/smoke-errors.ts && tsx tests/smoke-e2e.ts && tsx tests/smoke-import.ts && tsx tests/smoke-init.ts"
   },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "materialize:mock": "tsx src/optimizer/materialize-mock-repo.ts",
     "build": "tsc",
     "typecheck": "tsc --noEmit",
-    "test": "tsx tests/smoke-code.ts && tsx tests/smoke-sdk-python.ts && tsx tests/smoke-sdk-rust.ts && tsx tests/smoke-cli.ts && tsx tests/smoke-cli-entry.ts && tsx tests/smoke-mcp.ts && tsx tests/smoke-llm.ts && tsx tests/smoke-discovery-sdk.ts && tsx tests/smoke-discovery-cli.ts && tsx tests/smoke-discovery-mcp.ts && tsx tests/smoke-generation.ts && tsx tests/smoke-optimize.ts && tsx tests/smoke-mock-repos.ts && tsx tests/smoke-release.ts && tsx tests/smoke-scoring.ts && tsx tests/smoke-scope.ts && tsx tests/smoke-coverage.ts && tsx tests/smoke-feedback.ts && tsx tests/smoke-verdict.ts && tsx tests/smoke-dry-run.ts && tsx tests/smoke-errors.ts && tsx tests/smoke-e2e.ts && tsx tests/smoke-import.ts"
+    "test": "tsx tests/smoke-code.ts && tsx tests/smoke-sdk-python.ts && tsx tests/smoke-sdk-rust.ts && tsx tests/smoke-cli.ts && tsx tests/smoke-cli-entry.ts && tsx tests/smoke-mcp.ts && tsx tests/smoke-llm.ts && tsx tests/smoke-discovery-sdk.ts && tsx tests/smoke-discovery-cli.ts && tsx tests/smoke-discovery-mcp.ts && tsx tests/smoke-generation.ts && tsx tests/smoke-optimize.ts && tsx tests/smoke-mock-repos.ts && tsx tests/smoke-release.ts && tsx tests/smoke-scoring.ts && tsx tests/smoke-scope.ts && tsx tests/smoke-coverage.ts && tsx tests/smoke-feedback.ts && tsx tests/smoke-verdict.ts && tsx tests/smoke-dry-run.ts && tsx tests/smoke-errors.ts && tsx tests/smoke-e2e.ts && tsx tests/smoke-import.ts && tsx tests/smoke-init.ts"
   },
   "dependencies": {
     "@clack/prompts": "^1.2.0",

--- a/scripts/gen-docs.ts
+++ b/scripts/gen-docs.ts
@@ -34,8 +34,9 @@ function generateErrorsMd(): string {
   ];
 
   for (const def of entries) {
+    const msg = def.message.replace(/\|/g, '\\|');
     const quickFix = (def.fix[0] ?? '').replace(/\|/g, '\\|');
-    lines.push(`| \`${def.code}\` | ${def.message} | ${quickFix} |`);
+    lines.push(`| \`${def.code}\` | ${msg} | ${quickFix} |`);
   }
 
   lines.push('', '## Details', '');

--- a/scripts/gen-docs.ts
+++ b/scripts/gen-docs.ts
@@ -1,0 +1,164 @@
+#!/usr/bin/env tsx
+// scripts/gen-docs.ts — auto-generates docs/reference/ from code artifacts.
+// Run via: npm run gen-docs
+// Hooked into: npm run build
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import { ERRORS } from '../src/errors.js';
+import { ProjectConfigSchema } from '../src/project/schema.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const refDir = resolve(__dirname, '../docs/reference');
+mkdirSync(refDir, { recursive: true });
+
+const GENERATED_HEADER = '<!-- AUTO-GENERATED — do not edit. Run `npm run gen-docs` to regenerate. -->\n\n';
+
+// ── errors.md ─────────────────────────────────────────────────────────────────
+
+function generateErrorsMd(): string {
+  const entries = Object.values(ERRORS);
+  const lines: string[] = [
+    GENERATED_HEADER,
+    '# Error Reference',
+    '',
+    'Every `skill-optimizer` error has a code, a short message, and a fix list.',
+    'The catch-all `E_UNEXPECTED` appears if an error slips past the known list.',
+    '',
+    '## Summary',
+    '',
+    '| Code | Description | Quick fix |',
+    '|---|---|---|',
+  ];
+
+  for (const def of entries) {
+    const quickFix = (def.fix[0] ?? '').replace(/\|/g, '\\|');
+    lines.push(`| \`${def.code}\` | ${def.message} | ${quickFix} |`);
+  }
+
+  lines.push('', '## Details', '');
+
+  for (const def of entries) {
+    lines.push(`### \`${def.code}\``);
+    lines.push('');
+    lines.push(`**${def.message}**`);
+    lines.push('');
+    lines.push('**How to fix:**');
+    for (const step of def.fix) {
+      lines.push(`- ${step}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+// ── config-schema.md ──────────────────────────────────────────────────────────
+
+interface JsonSchemaNode {
+  type?: string;
+  description?: string;
+  default?: unknown;
+  enum?: unknown[];
+  properties?: Record<string, JsonSchemaNode>;
+  items?: JsonSchemaNode;
+  anyOf?: JsonSchemaNode[];
+  $ref?: string;
+  $defs?: Record<string, JsonSchemaNode>;
+  definitions?: Record<string, JsonSchemaNode>;
+}
+
+function typeLabel(node: JsonSchemaNode): string {
+  if (node.enum) return node.enum.map(v => `"${v}"`).join(' | ');
+  if (node.anyOf) return node.anyOf.map(typeLabel).filter(Boolean).join(' | ');
+  if (node.type === 'array') {
+    const itemLabel = node.items ? typeLabel(node.items) : 'any';
+    return `${itemLabel}[]`;
+  }
+  return node.type ?? '';
+}
+
+function flattenSchema(
+  node: JsonSchemaNode,
+  prefix: string,
+  rows: Array<{ path: string; type: string; default: string; description: string }>,
+  defs: Record<string, JsonSchemaNode>,
+): void {
+  if (!node.properties) return;
+
+  for (const [key, child] of Object.entries(node.properties)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    let resolved = child;
+
+    // Resolve $ref
+    if (child.$ref) {
+      const refKey = child.$ref.replace(/^#\/\$defs\//, '').replace(/^#\/definitions\//, '');
+      resolved = defs[refKey] ?? child;
+    }
+
+    // If it has nested properties, recurse without adding a row for the parent
+    if (resolved.properties) {
+      flattenSchema(resolved, path, rows, defs);
+    } else {
+      rows.push({
+        path,
+        type: typeLabel(resolved),
+        default: resolved.default !== undefined ? JSON.stringify(resolved.default) : '—',
+        description: resolved.description ?? '',
+      });
+    }
+  }
+}
+
+function generateConfigSchemaMd(): string {
+  const jsonSchema = zodToJsonSchema(ProjectConfigSchema, {
+    name: 'ProjectConfig',
+    $refStrategy: 'none',
+  }) as JsonSchemaNode;
+
+  const defs: Record<string, JsonSchemaNode> = {
+    ...(jsonSchema.$defs ?? {}),
+    ...(jsonSchema.definitions ?? {}),
+  };
+
+  // Resolve a top-level $ref if the named schema strategy wrapped everything in one
+  let root = jsonSchema;
+  if (jsonSchema.$ref && !jsonSchema.properties) {
+    const refKey = jsonSchema.$ref.replace(/^#\/\$defs\//, '').replace(/^#\/definitions\//, '');
+    root = defs[refKey] ?? jsonSchema;
+  }
+
+  const rows: Array<{ path: string; type: string; default: string; description: string }> = [];
+  flattenSchema(root, '', rows, defs);
+
+  const lines: string[] = [
+    GENERATED_HEADER,
+    '# Config Schema Reference',
+    '',
+    'All configuration lives in a single `skill-optimizer.json` file.',
+    'Paths in the config are relative to the config file location.',
+    '',
+    '| Field | Type | Default | Description |',
+    '|---|---|---|---|',
+  ];
+
+  for (const row of rows) {
+    const desc = row.description.replace(/\|/g, '\\|');
+    lines.push(`| \`${row.path}\` | \`${row.type}\` | ${row.default} | ${desc} |`);
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+// ── Write files ────────────────────────────────────────────────────────────────
+
+const errorsPath = resolve(refDir, 'errors.md');
+writeFileSync(errorsPath, generateErrorsMd(), 'utf-8');
+console.log(`[gen-docs] Written: ${errorsPath}`);
+
+const schemaPath = resolve(refDir, 'config-schema.md');
+writeFileSync(schemaPath, generateConfigSchemaMd(), 'utf-8');
+console.log(`[gen-docs] Written: ${schemaPath}`);

--- a/scripts/gen-docs.ts
+++ b/scripts/gen-docs.ts
@@ -81,6 +81,12 @@ function typeLabel(node: JsonSchemaNode): string {
   return node.type ?? '';
 }
 
+function resolveRef(node: JsonSchemaNode, defs: Record<string, JsonSchemaNode>): JsonSchemaNode {
+  if (!node.$ref) return node;
+  const refKey = node.$ref.replace(/^#\/\$defs\//, '').replace(/^#\/definitions\//, '');
+  return defs[refKey] ?? node;
+}
+
 function flattenSchema(
   node: JsonSchemaNode,
   prefix: string,
@@ -91,13 +97,7 @@ function flattenSchema(
 
   for (const [key, child] of Object.entries(node.properties)) {
     const path = prefix ? `${prefix}.${key}` : key;
-    let resolved = child;
-
-    // Resolve $ref
-    if (child.$ref) {
-      const refKey = child.$ref.replace(/^#\/\$defs\//, '').replace(/^#\/definitions\//, '');
-      resolved = defs[refKey] ?? child;
-    }
+    const resolved = resolveRef(child, defs);
 
     // If it has nested properties, recurse without adding a row for the parent
     if (resolved.properties) {
@@ -125,11 +125,7 @@ function generateConfigSchemaMd(): string {
   };
 
   // Resolve a top-level $ref if the named schema strategy wrapped everything in one
-  let root = jsonSchema;
-  if (jsonSchema.$ref && !jsonSchema.properties) {
-    const refKey = jsonSchema.$ref.replace(/^#\/\$defs\//, '').replace(/^#\/definitions\//, '');
-    root = defs[refKey] ?? jsonSchema;
-  }
+  const root = jsonSchema.properties ? jsonSchema : resolveRef(jsonSchema, defs);
 
   const rows: Array<{ path: string; type: string; default: string; description: string }> = [];
   flattenSchema(root, '', rows, defs);

--- a/src/benchmark/init.ts
+++ b/src/benchmark/init.ts
@@ -15,7 +15,9 @@ import { resolve } from 'node:path';
  */
 export function initBenchmark(targetDir: string = process.cwd(), surface: 'sdk' | 'cli' | 'mcp' = 'sdk'): void {
   const configDir = resolve(targetDir, 'skill-optimizer');
+  const generatedDir = resolve(configDir, '.skill-optimizer');
   mkdirSync(configDir, { recursive: true });
+  mkdirSync(generatedDir, { recursive: true });
 
   const configPath = resolve(configDir, 'skill-optimizer.json');
 
@@ -31,7 +33,7 @@ export function initBenchmark(targetDir: string = process.cwd(), surface: 'sdk' 
 
   // ── Surface-specific companion files ─────────────────────────────────────
   if (surface === 'cli') {
-    const commandsPath = resolve(configDir, 'cli-commands.json');
+    const commandsPath = resolve(generatedDir, 'cli-commands.json');
     if (existsSync(commandsPath)) {
       console.log(`[init] Skipping ${commandsPath} (already exists)`);
     } else {
@@ -57,7 +59,7 @@ export function initBenchmark(targetDir: string = process.cwd(), surface: 'sdk' 
   }
 
   if (surface === 'mcp') {
-    const toolsPath = resolve(configDir, 'tools.json');
+    const toolsPath = resolve(generatedDir, 'tools.json');
     if (existsSync(toolsPath)) {
       console.log(`[init] Skipping ${toolsPath} (already exists)`);
     } else {
@@ -179,7 +181,7 @@ function buildConfig(surface: 'sdk' | 'cli' | 'mcp'): object {
           sources: ['../src/cli.ts'],
         },
         cli: {
-          commands: './cli-commands.json',
+          commands: './.skill-optimizer/cli-commands.json',
         },
       },
       benchmark: commonBenchmark,
@@ -199,7 +201,7 @@ function buildConfig(surface: 'sdk' | 'cli' | 'mcp'): object {
         sources: ['../src/server.ts'],
       },
       mcp: {
-        tools: './tools.json',
+        tools: './.skill-optimizer/tools.json',
       },
     },
     benchmark: commonBenchmark,

--- a/src/benchmark/init.ts
+++ b/src/benchmark/init.ts
@@ -1,18 +1,6 @@
 import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-/**
- * Scaffold benchmark config and surface-specific files for a new project.
- * All files are written into a `skill-optimizer/` subdirectory so they
- * don't clutter the project root.
- *
- * - sdk: creates skill-optimizer.json only (code-first discovery via sources)
- * - cli: creates skill-optimizer.json + cli-commands.json manifest template
- * - mcp: creates skill-optimizer.json + tools.json manifest template
- *
- * Tasks are never scaffolded — task generation (benchmark.taskGeneration.enabled)
- * handles them automatically at run time.
- */
 export function initBenchmark(targetDir: string = process.cwd(), surface: 'sdk' | 'cli' | 'mcp' = 'sdk'): void {
   const configDir = resolve(targetDir, 'skill-optimizer');
   const generatedDir = resolve(configDir, '.skill-optimizer');
@@ -21,17 +9,13 @@ export function initBenchmark(targetDir: string = process.cwd(), surface: 'sdk' 
 
   const configPath = resolve(configDir, 'skill-optimizer.json');
 
-  // ── skill-optimizer.json ─────────────────────────────────────────────────
-  // Paths use "../" because this config lives one level below the project root.
   if (existsSync(configPath)) {
     console.log(`[init] Skipping ${configPath} (already exists)`);
   } else {
-    const config = buildConfig(surface);
-    writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+    writeFileSync(configPath, JSON.stringify(buildConfig(surface), null, 2) + '\n', 'utf-8');
     console.log(`[init] Created ${configPath}`);
   }
 
-  // ── Surface-specific companion files ─────────────────────────────────────
   if (surface === 'cli') {
     const commandsPath = resolve(generatedDir, 'cli-commands.json');
     if (existsSync(commandsPath)) {
@@ -99,7 +83,6 @@ export function initBenchmark(targetDir: string = process.cwd(), surface: 'sdk' 
     }
   }
 
-  // ── Next steps ────────────────────────────────────────────────────────────
   console.log('\n[init] Done! Next steps:');
   console.log('  1. Edit skill-optimizer/skill-optimizer.json:');
   console.log('       target.repoPath  → path to your repo');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,9 @@ import { renderVerdictConsole, renderVerdictMarkdown } from './verdict/render.js
 import { importCommands } from './import/index.js';
 import { scaffoldInit } from './init/scaffold.js';
 import { buildDefaultAnswers, readAnswersFile } from './init/answers.js';
+import type { WizardAnswers } from './init/answers.js';
 import { runWizard } from './init/wizard.js';
+import { detectProject, detectedToPreseed, printDetectionSummary } from './init/detect-project.js';
 import { ERRORS, SkillOptimizerError, printError } from './errors.js';
 
 // ── Arg parsing helpers ───────────────────────────────────────────────────────
@@ -106,6 +108,8 @@ Skill Optimizer CLI — Benchmark and optimize SDK/CLI/MCP guidance
 
 Usage:
   skill-optimizer init [sdk|cli|mcp]            Interactive wizard — scaffold config for the given surface
+  skill-optimizer init --auto                   Auto-detect project type and pre-fill wizard
+  skill-optimizer init --auto --yes             Auto-detect and scaffold non-interactively (high confidence only)
   skill-optimizer init [surface] --yes          Accept all defaults non-interactively
   skill-optimizer init --answers <file.json>    Load wizard answers from a JSON file (CI mode)
   skill-optimizer import-commands [options]     Extract CLI commands from source or binary
@@ -223,6 +227,27 @@ async function main(): Promise<void> {
     }
     const answersFlag = getFlag(args, '--answers');
     const useDefaults = hasFlag(args, '--yes');
+    const useAuto = hasFlag(args, '--auto');
+
+    if (useAuto) {
+      const detected = detectProject(process.cwd());
+      printDetectionSummary(detected);
+      if (useDefaults) {
+        if (detected.confidence !== 'high') {
+          printError(new SkillOptimizerError(ERRORS.E_INIT_AUTO_LOW_CONFIDENCE,
+            `detected confidence is ${detected.confidence}`));
+          process.exit(1);
+        }
+        const answers: WizardAnswers = {
+          ...buildDefaultAnswers(detected.surface, detected.repoPath),
+          ...detectedToPreseed(detected),
+        };
+        await scaffoldInit(answers, process.cwd());
+      } else {
+        await runWizard(process.cwd(), detectedToPreseed(detected));
+      }
+      process.exit(0);
+    }
 
     if (answersFlag) {
       const answers = readAnswersFile(resolve(process.cwd(), answersFlag));
@@ -231,7 +256,7 @@ async function main(): Promise<void> {
       const answers = buildDefaultAnswers(surfaceArg ?? 'sdk', process.cwd());
       await scaffoldInit(answers, process.cwd());
     } else {
-      await runWizard(process.cwd(), surfaceArg);
+      await runWizard(process.cwd(), surfaceArg ? { surface: surfaceArg } : undefined);
     }
     process.exit(0);
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ import { createDefaultPiTaskGenerator, generateTasksForProject, createDefaultPiC
 import type { Recommendation } from './verdict/recommendations.js';
 import { generateRecommendations } from './verdict/recommendations.js';
 import { renderVerdictConsole, renderVerdictMarkdown } from './verdict/render.js';
+import { importCommands } from './import/index.js';
 
 // ── Arg parsing helpers ───────────────────────────────────────────────────────
 
@@ -47,14 +48,18 @@ const BOOLEAN_FLAGS = new Set([
   '--dry-run',
   '--no-cache',
   '--skip-generation',
+  '--scrape',
 ]);
 
 const VALUE_FLAGS = new Set([
   '--baseline',
   '--config',
   '--current',
+  '--depth',
+  '--from',
   '--max-iterations',
   '--model',
+  '--out',
   '--task',
   '--tier',
 ]);
@@ -95,6 +100,7 @@ Skill Optimizer CLI — Benchmark and optimize SDK/CLI/MCP guidance
 
 Usage:
   skill-optimizer init <sdk|cli|mcp>            Scaffold config for the given surface type
+  skill-optimizer import-commands [options]     Extract CLI commands from source or binary
   skill-optimizer generate-tasks [options]      Generate and freeze tasks from discovered surface
   skill-optimizer benchmark [options]           Run the benchmark
   skill-optimizer run [options]                 Run the benchmark
@@ -120,6 +126,12 @@ Optimize options:
 Generate-tasks options:
   --config <path>                               Config file (default: skill-optimizer.json)
 
+Import-commands options:
+  --from <path>                                 Entry file or binary name (required)
+  --out <path>                                  Output path (default: skill-optimizer/cli-commands.json)
+  --scrape                                      Force --help scraping regardless of file type
+  --depth <n>                                   Max subcommand depth for --help scraping (default: 2)
+
 Compare options:
   --baseline <path>                             Path to baseline report.json
   --current <path>                              Path to current report.json
@@ -128,6 +140,8 @@ Examples:
   skill-optimizer init cli
   skill-optimizer init sdk
   skill-optimizer init mcp
+  skill-optimizer import-commands --from ./src/cli.ts
+  skill-optimizer import-commands --from fast-cli --scrape
   skill-optimizer --dry-run --config ./skill-optimizer.json
   skill-optimizer benchmark --config ./skill-optimizer.json
   skill-optimizer run
@@ -204,6 +218,26 @@ async function main(): Promise<void> {
       process.exit(1);
     }
     initBenchmark(process.cwd(), surface as 'sdk' | 'cli' | 'mcp');
+    process.exit(0);
+  }
+
+  // ── Import-commands mode ─────────────────────────────────────────────────────
+  if (command === 'import-commands') {
+    const fromFlag = getFlag(args, '--from');
+    if (!fromFlag) {
+      console.error('ERROR: --from <path> is required for import-commands.');
+      console.error('  Example: skill-optimizer import-commands --from ./src/cli.ts');
+      process.exit(1);
+    }
+    const outFlag = getFlag(args, '--out') ?? 'skill-optimizer/cli-commands.json';
+    const depthRaw = getFlag(args, '--depth');
+    await importCommands({
+      from: fromFlag,
+      out: outFlag,
+      scrape: hasFlag(args, '--scrape'),
+      depth: depthRaw ? parseInt(depthRaw, 10) : 2,
+      cwd: process.cwd(),
+    });
     process.exit(0);
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,20 @@ import { runWizard } from './init/wizard.js';
 import { detectProject, detectedToPreseed, printDetectionSummary } from './init/detect-project.js';
 import { ERRORS, SkillOptimizerError, printError } from './errors.js';
 
+// ── Error handling ────────────────────────────────────────────────────────────
+
+/** Print an error and exit. SkillOptimizerErrors render their fix list; others
+ * are wrapped in E_UNEXPECTED and include the stack trace. */
+function fatalError(err: unknown): never {
+  if (err instanceof SkillOptimizerError) {
+    printError(err);
+  } else {
+    printError(new SkillOptimizerError(ERRORS.E_UNEXPECTED, err instanceof Error ? err.message : String(err)));
+    if (err instanceof Error && err.stack) console.error(err.stack);
+  }
+  process.exit(1);
+}
+
 // ── Arg parsing helpers ───────────────────────────────────────────────────────
 
 /** Return the value of a named flag, e.g. --tier flagship → 'flagship' */
@@ -354,13 +368,7 @@ async function main(): Promise<void> {
       }
       process.exit(bestReport.verdict?.result === 'FAIL' ? 1 : 0);
     } catch (err) {
-      if (err instanceof SkillOptimizerError) {
-        printError(err);
-      } else {
-        printError(new SkillOptimizerError(ERRORS.E_UNEXPECTED, err instanceof Error ? err.message : String(err)));
-        if (err instanceof Error && err.stack) console.error(err.stack);
-      }
-      process.exit(1);
+      fatalError(err);
     }
   }
 
@@ -461,13 +469,7 @@ async function main(): Promise<void> {
       generatedCoverage = generation.coverage;
     }
   } catch (err) {
-    if (err instanceof SkillOptimizerError) {
-      printError(err);
-    } else {
-      printError(new SkillOptimizerError(ERRORS.E_UNEXPECTED, err instanceof Error ? err.message : String(err)));
-      if (err instanceof Error && err.stack) console.error(err.stack);
-    }
-    process.exit(1);
+    fatalError(err);
   }
 
   let report;
@@ -478,13 +480,7 @@ async function main(): Promise<void> {
       scopeCoverage: generatedCoverage,
     });
   } catch (err) {
-    if (err instanceof SkillOptimizerError) {
-      printError(err);
-    } else {
-      printError(new SkillOptimizerError(ERRORS.E_UNEXPECTED, err instanceof Error ? err.message : String(err)));
-      if (err instanceof Error && err.stack) console.error(err.stack);
-    }
-    process.exit(1);
+    fatalError(err);
   }
 
   // Print console summary

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,7 @@ import { importCommands } from './import/index.js';
 import { scaffoldInit } from './init/scaffold.js';
 import { buildDefaultAnswers, readAnswersFile } from './init/answers.js';
 import { runWizard } from './init/wizard.js';
+import { ERRORS, SkillOptimizerError, printError } from './errors.js';
 
 // ── Arg parsing helpers ───────────────────────────────────────────────────────
 
@@ -47,6 +48,7 @@ function hasFlag(args: string[], flag: string): boolean {
 const BOOLEAN_FLAGS = new Set([
   '--help',
   '-h',
+  '--auto',
   '--dry-run',
   '--no-cache',
   '--skip-generation',
@@ -327,9 +329,11 @@ async function main(): Promise<void> {
       }
       process.exit(bestReport.verdict?.result === 'FAIL' ? 1 : 0);
     } catch (err) {
-      console.error(`\nFATAL: Optimize failed: ${err instanceof Error ? err.message : err}`);
-      if (err instanceof Error && err.stack) {
-        console.error(err.stack);
+      if (err instanceof SkillOptimizerError) {
+        printError(err);
+      } else {
+        printError(new SkillOptimizerError(ERRORS.E_UNEXPECTED, err instanceof Error ? err.message : String(err)));
+        if (err instanceof Error && err.stack) console.error(err.stack);
       }
       process.exit(1);
     }
@@ -432,9 +436,11 @@ async function main(): Promise<void> {
       generatedCoverage = generation.coverage;
     }
   } catch (err) {
-    console.error(`\nFATAL: Benchmark setup failed: ${err instanceof Error ? err.message : err}`);
-    if (err instanceof Error && err.stack) {
-      console.error(err.stack);
+    if (err instanceof SkillOptimizerError) {
+      printError(err);
+    } else {
+      printError(new SkillOptimizerError(ERRORS.E_UNEXPECTED, err instanceof Error ? err.message : String(err)));
+      if (err instanceof Error && err.stack) console.error(err.stack);
     }
     process.exit(1);
   }
@@ -447,9 +453,11 @@ async function main(): Promise<void> {
       scopeCoverage: generatedCoverage,
     });
   } catch (err) {
-    console.error(`\nFATAL: Benchmark failed: ${err instanceof Error ? err.message : err}`);
-    if (err instanceof Error && err.stack) {
-      console.error(err.stack);
+    if (err instanceof SkillOptimizerError) {
+      printError(err);
+    } else {
+      printError(new SkillOptimizerError(ERRORS.E_UNEXPECTED, err instanceof Error ? err.message : String(err)));
+      if (err instanceof Error && err.stack) console.error(err.stack);
     }
     process.exit(1);
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -244,8 +244,16 @@ async function main(): Promise<void> {
     const useAuto = hasFlag(args, '--auto');
 
     if (useAuto) {
-      const detected = detectProject(process.cwd());
+      let detected;
+      try {
+        detected = detectProject(process.cwd());
+      } catch (err) {
+        fatalError(err);
+      }
       printDetectionSummary(detected);
+      if (surfaceArg && surfaceArg !== detected.surface) {
+        console.log(`Note: explicit surface '${surfaceArg}' overridden by auto-detected '${detected.surface}'.`);
+      }
       if (useDefaults) {
         if (detected.confidence !== 'high') {
           printError(new SkillOptimizerError(ERRORS.E_INIT_AUTO_LOW_CONFIDENCE,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,6 @@ import { runBenchmark } from './benchmark/runner.js';
 import { loadReport, compareReports, printComparison } from './benchmark/compare.js';
 import { printSummary, generateMarkdown } from './benchmark/reporter.js';
 import { printCoverage } from './benchmark/coverage.js';
-import { initBenchmark } from './benchmark/init.js';
 import { printOptimizeSummary, runOptimizeFromConfig } from './optimizer/main.js';
 import { DEFAULT_PROJECT_CONFIG_NAME, loadProjectConfig, parseModelRef } from './project/index.js';
 import { createDefaultPiTaskGenerator, generateTasksForProject, createDefaultPiCritic, discoverActionsOnly, resolveScope } from './tasks/index.js';
@@ -21,6 +20,9 @@ import type { Recommendation } from './verdict/recommendations.js';
 import { generateRecommendations } from './verdict/recommendations.js';
 import { renderVerdictConsole, renderVerdictMarkdown } from './verdict/render.js';
 import { importCommands } from './import/index.js';
+import { scaffoldInit } from './init/scaffold.js';
+import { buildDefaultAnswers, readAnswersFile } from './init/answers.js';
+import { runWizard } from './init/wizard.js';
 
 // ── Arg parsing helpers ───────────────────────────────────────────────────────
 
@@ -49,9 +51,11 @@ const BOOLEAN_FLAGS = new Set([
   '--no-cache',
   '--skip-generation',
   '--scrape',
+  '--yes',
 ]);
 
 const VALUE_FLAGS = new Set([
+  '--answers',
   '--baseline',
   '--config',
   '--current',
@@ -99,7 +103,9 @@ function printUsage(): void {
 Skill Optimizer CLI — Benchmark and optimize SDK/CLI/MCP guidance
 
 Usage:
-  skill-optimizer init <sdk|cli|mcp>            Scaffold config for the given surface type
+  skill-optimizer init [sdk|cli|mcp]            Interactive wizard — scaffold config for the given surface
+  skill-optimizer init [surface] --yes          Accept all defaults non-interactively
+  skill-optimizer init --answers <file.json>    Load wizard answers from a JSON file (CI mode)
   skill-optimizer import-commands [options]     Extract CLI commands from source or binary
   skill-optimizer generate-tasks [options]      Generate and freeze tasks from discovered surface
   skill-optimizer benchmark [options]           Run the benchmark
@@ -208,16 +214,23 @@ async function main(): Promise<void> {
 
   // ── Init mode ────────────────────────────────────────────────────────────────
   if (command === 'init') {
-    const surface = pos[1];
-    if (!surface || !['sdk', 'cli', 'mcp'].includes(surface)) {
-      console.error('Usage: skill-optimizer init <surface>');
-      console.error('');
-      console.error('  sdk  — TypeScript / Python / Rust library');
-      console.error('  cli  — command-line tool with subcommands');
-      console.error('  mcp  — MCP server with tools');
+    const surfaceArg = pos[1] as 'sdk' | 'cli' | 'mcp' | undefined;
+    if (surfaceArg && !['sdk', 'cli', 'mcp'].includes(surfaceArg)) {
+      console.error(`ERROR: Unknown surface '${surfaceArg}'. Must be: sdk | cli | mcp`);
       process.exit(1);
     }
-    initBenchmark(process.cwd(), surface as 'sdk' | 'cli' | 'mcp');
+    const answersFlag = getFlag(args, '--answers');
+    const useDefaults = hasFlag(args, '--yes');
+
+    if (answersFlag) {
+      const answers = readAnswersFile(resolve(process.cwd(), answersFlag));
+      await scaffoldInit(answers, process.cwd());
+    } else if (useDefaults) {
+      const answers = buildDefaultAnswers(surfaceArg ?? 'sdk', process.cwd());
+      await scaffoldInit(answers, process.cwd());
+    } else {
+      await runWizard(process.cwd(), surfaceArg);
+    }
     process.exit(0);
   }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -67,7 +67,7 @@ export const ERRORS = {
     code: 'E_INVALID_FORMAT',
     message: 'Invalid benchmark.format value',
     fix: [
-      'Only "pi" is supported for benchmark.format in the current version',
+      'Set benchmark.format to one of: pi, openai, anthropic',
     ],
   },
   // ── Path resolution ────────────────────────────────────────────────────────

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,229 @@
+// src/errors.ts
+export interface ErrorDef {
+  code: string;
+  message: string;
+  fix: string[];
+}
+
+export class SkillOptimizerError extends Error {
+  constructor(public readonly def: ErrorDef, public readonly detail?: string) {
+    super(detail ? `${def.message}: ${detail}` : def.message);
+    this.name = def.code;
+  }
+}
+
+export function printError(err: SkillOptimizerError): void {
+  console.error(`\nError [${err.def.code}]: ${err.message}`);
+  if (err.def.fix.length > 0) {
+    console.error('How to fix:');
+    for (const step of err.def.fix) {
+      console.error(`  • ${step}`);
+    }
+  }
+}
+
+export const ERRORS = {
+  // ── Config validation ──────────────────────────────────────────────────────
+  E_INVALID_SURFACE: {
+    code: 'E_INVALID_SURFACE',
+    message: 'Invalid surface value',
+    fix: [
+      'Set target.surface to one of: sdk, cli, mcp',
+      'sdk = TypeScript/Python/Rust library, cli = command-line tool, mcp = MCP server',
+    ],
+  },
+  E_MODELS_EMPTY: {
+    code: 'E_MODELS_EMPTY',
+    message: 'benchmark.models is empty or missing',
+    fix: [
+      'Add at least one model to benchmark.models, e.g.:',
+      '  { "id": "openrouter/anthropic/claude-sonnet-4-6", "name": "Claude Sonnet", "tier": "flagship" }',
+    ],
+  },
+  E_MODEL_ID_FORMAT: {
+    code: 'E_MODEL_ID_FORMAT',
+    message: 'Model ID is missing the openrouter/ prefix',
+    fix: [
+      'Prefix all model IDs with openrouter/, e.g. openrouter/anthropic/claude-sonnet-4-6',
+      'Browse available models at https://openrouter.ai/models',
+    ],
+  },
+  E_VERDICT_OUT_OF_RANGE: {
+    code: 'E_VERDICT_OUT_OF_RANGE',
+    message: 'Verdict threshold is out of range',
+    fix: [
+      'Set benchmark.verdict.perModelFloor and targetWeightedAverage to values between 0.0 and 1.0',
+      'Typical values: perModelFloor=0.6, targetWeightedAverage=0.7',
+    ],
+  },
+  E_MAX_ITERATIONS_ZERO: {
+    code: 'E_MAX_ITERATIONS_ZERO',
+    message: 'optimize.maxIterations must be a positive integer',
+    fix: [
+      'Set optimize.maxIterations to a positive integer, e.g. 5',
+    ],
+  },
+  E_INVALID_FORMAT: {
+    code: 'E_INVALID_FORMAT',
+    message: 'Invalid benchmark.format value',
+    fix: [
+      'Only "pi" is supported for benchmark.format in the current version',
+    ],
+  },
+  // ── Path resolution ────────────────────────────────────────────────────────
+  E_REPO_NOT_FOUND: {
+    code: 'E_REPO_NOT_FOUND',
+    message: 'target.repoPath does not exist or is not a directory',
+    fix: [
+      'Fix target.repoPath in your skill-optimizer.json to point at an existing directory',
+      'Paths in the config are relative to the config file location',
+    ],
+  },
+  E_MISSING_SKILL: {
+    code: 'E_MISSING_SKILL',
+    message: 'target.skill file not found',
+    fix: [
+      'Create a SKILL.md at the path specified in target.skill',
+      'Or update target.skill in your config to point at an existing file',
+    ],
+  },
+  E_SOURCES_NOT_FOUND: {
+    code: 'E_SOURCES_NOT_FOUND',
+    message: 'One or more target.discovery.sources files do not exist',
+    fix: [
+      'Check that all paths in target.discovery.sources exist in your repo',
+      'Paths are relative to target.repoPath',
+      'For CLI: point at your main entry file (e.g. src/cli.ts)',
+      'For MCP: point at your server entry file (e.g. src/server.ts)',
+    ],
+  },
+  E_CLI_MANIFEST_NOT_FOUND: {
+    code: 'E_CLI_MANIFEST_NOT_FOUND',
+    message: 'target.cli.commands manifest file not found',
+    fix: [
+      'Run: skill-optimizer import-commands --from <entry-file> to auto-extract',
+      'Or create the file manually and populate it with your CLI commands',
+      'Format: Array of { command, description, options[] }',
+    ],
+  },
+  E_MCP_MANIFEST_NOT_FOUND: {
+    code: 'E_MCP_MANIFEST_NOT_FOUND',
+    message: 'target.mcp.tools manifest file not found',
+    fix: [
+      'Create the tools.json file at the path specified in target.mcp.tools',
+      'Format: Array of OpenAI function tool definitions { type: "function", function: { name, description, parameters } }',
+    ],
+  },
+  E_ALLOWED_PATHS_ESCAPE: {
+    code: 'E_ALLOWED_PATHS_ESCAPE',
+    message: 'optimize.allowedPaths contains a path outside target.repoPath',
+    fix: [
+      'All paths in optimize.allowedPaths must be inside target.repoPath',
+      'This is a safety boundary — the optimizer will only edit files within this list',
+    ],
+  },
+  E_OUTPUT_DIR_NOT_WRITABLE: {
+    code: 'E_OUTPUT_DIR_NOT_WRITABLE',
+    message: 'benchmark.output.dir is not writable',
+    fix: [
+      'Check directory permissions for the path set in benchmark.output.dir',
+      'Or change benchmark.output.dir to a path you have write access to',
+    ],
+  },
+  // ── Environment ────────────────────────────────────────────────────────────
+  E_MISSING_API_KEY: {
+    code: 'E_MISSING_API_KEY',
+    message: 'API key environment variable is not set',
+    fix: [
+      'Export your OpenRouter API key before running: export OPENROUTER_API_KEY=sk-or-...',
+      'Or add it to a .env file alongside your skill-optimizer.json',
+      'Get a key at https://openrouter.ai/keys',
+    ],
+  },
+  E_LEGACY_CONFIG: {
+    code: 'E_LEGACY_CONFIG',
+    message: 'Found skill-benchmark.json instead of skill-optimizer.json',
+    fix: [
+      'Rename skill-benchmark.json to skill-optimizer.json',
+      'See CHANGELOG.md for any field renames between versions',
+    ],
+  },
+  // ── Discovery ─────────────────────────────────────────────────────────────
+  E_DISCOVERY_EMPTY: {
+    code: 'E_DISCOVERY_EMPTY',
+    message: 'Discovery found zero callable actions',
+    fix: [
+      'Check that target.discovery.sources points at the right entry file',
+      'For SDK: should be your public API entry (e.g. src/index.ts)',
+      'For CLI: should be the file that registers all subcommands',
+      'For MCP: should be the file that registers all tools',
+      'Add a fallback manifest: target.discovery.fallbackManifest or target.cli.commands / target.mcp.tools',
+    ],
+  },
+  // ── Task generation ────────────────────────────────────────────────────────
+  E_MAXTASKS_TOO_LOW: {
+    code: 'E_MAXTASKS_TOO_LOW',
+    message: 'benchmark.taskGeneration.maxTasks is less than the in-scope action count',
+    fix: [
+      'Raise benchmark.taskGeneration.maxTasks to at least the number of in-scope actions',
+      'Run: skill-optimizer --dry-run --config ./skill-optimizer.json to see the action count',
+      'Or narrow the scope with target.scope.exclude to reduce the action count',
+    ],
+  },
+  E_COVERAGE_EXHAUSTED: {
+    code: 'E_COVERAGE_EXHAUSTED',
+    message: 'Task generation could not cover all in-scope actions after 2 retry passes',
+    fix: [
+      'Add guidance for the uncovered actions to your SKILL.md',
+      'The error message above names the specific uncovered actions',
+      'Or exclude them with target.scope.exclude if they should not be benchmarked',
+    ],
+  },
+  // ── Optimizer runtime ──────────────────────────────────────────────────────
+  E_DIRTY_GIT: {
+    code: 'E_DIRTY_GIT',
+    message: 'Target repo has uncommitted changes',
+    fix: [
+      'Commit or stash changes in target.repoPath before running the optimizer',
+      'Run: git -C <repoPath> stash',
+      'Or: git -C <repoPath> add -A && git -C <repoPath> commit -m "wip: before optimizer run"',
+    ],
+  },
+  E_GIT_CHECKPOINT_FAILED: {
+    code: 'E_GIT_CHECKPOINT_FAILED',
+    message: 'Git checkpoint creation failed',
+    fix: [
+      'Check disk space and git permissions in target.repoPath',
+      'Make sure the directory is a valid git repository',
+      'Run: git -C <repoPath> status to verify git state',
+    ],
+  },
+  E_VALIDATION_FAILED: {
+    code: 'E_VALIDATION_FAILED',
+    message: 'Configured validation command exited non-zero',
+    fix: [
+      'Fix the issue flagged by the validation command before retrying',
+      'The failing command is listed in optimize.validation in your config',
+      'Run the validation command manually to see the full error output',
+    ],
+  },
+  // ── Init ──────────────────────────────────────────────────────────────────
+  E_INIT_AUTO_LOW_CONFIDENCE: {
+    code: 'E_INIT_AUTO_LOW_CONFIDENCE',
+    message: 'init --auto --yes requires high confidence detection',
+    fix: [
+      'Run init interactively to review and confirm detection: skill-optimizer init --auto',
+      'Or supply a pre-filled answers file: skill-optimizer init --answers answers.json',
+      'See README for the answers.json format',
+    ],
+  },
+  // ── Catch-all ─────────────────────────────────────────────────────────────
+  E_UNEXPECTED: {
+    code: 'E_UNEXPECTED',
+    message: 'An unexpected error occurred',
+    fix: [
+      'Check the full error message and stack trace above for details',
+      'File an issue at https://github.com/bucurdavid/skill-optimizer/issues with the full output',
+    ],
+  },
+} as const satisfies Record<string, ErrorDef>;

--- a/src/import/detect.ts
+++ b/src/import/detect.ts
@@ -1,0 +1,58 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { extname, resolve, basename } from 'node:path';
+import type { DetectionResult } from './types.js';
+
+function inferBinaryHint(fromPath: string, cwd: string): string | undefined {
+  const pkgPath = resolve(cwd, 'package.json');
+  if (existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as Record<string, unknown>;
+      const bin = pkg['bin'];
+      if (typeof bin === 'string') return bin;
+      if (typeof bin === 'object' && bin !== null) {
+        const keys = Object.keys(bin as object);
+        if (keys.length > 0) return keys[0];
+      }
+    } catch { /* ignore */ }
+  }
+
+  const pyprojPath = resolve(cwd, 'pyproject.toml');
+  if (existsSync(pyprojPath)) {
+    const content = readFileSync(pyprojPath, 'utf-8');
+    const m = content.match(/\[project\.scripts\][\s\S]*?\n(\S+)\s*=/);
+    if (m) return m[1];
+  }
+
+  return basename(fromPath).replace(/\.[^.]+$/, '') || undefined;
+}
+
+export function detectFramework(fromPath: string, cwd: string): DetectionResult {
+  const abs = resolve(cwd, fromPath);
+  const ext = extname(abs).toLowerCase();
+  const binaryHint = inferBinaryHint(fromPath, cwd);
+
+  if (ext === '.py') {
+    if (!existsSync(abs)) return { kind: 'unknown', binaryHint };
+    const content = readFileSync(abs, 'utf-8');
+    if (/import typer|from typer/.test(content)) return { kind: 'typer', binaryHint };
+    if (/import click|from click/.test(content)) return { kind: 'click', binaryHint };
+    if (/import argparse|from argparse/.test(content)) return { kind: 'argparse', binaryHint };
+    return { kind: 'unknown', binaryHint };
+  }
+
+  if (ext === '.rs' || basename(abs) === 'Cargo.toml') {
+    return { kind: 'clap', binaryHint };
+  }
+
+  if (['.ts', '.tsx', '.js', '.mjs', '.cjs'].includes(ext)) {
+    if (!existsSync(abs)) return { kind: 'unknown', binaryHint };
+    const content = readFileSync(abs, 'utf-8');
+    if (/from ['"]commander['"]|require\(['"]commander['"]\)/.test(content)) return { kind: 'commander', binaryHint };
+    if (/from ['"]yargs['"]|require\(['"]yargs['"]\)/.test(content)) return { kind: 'yargs', binaryHint };
+    if (/\{\s*command\s*:/.test(content)) return { kind: 'optique', binaryHint };
+    return { kind: 'unknown', binaryHint };
+  }
+
+  // No recognized extension — treat fromPath as a binary name
+  return { kind: 'unknown', binaryHint: fromPath };
+}

--- a/src/import/extractors/help-scraper.ts
+++ b/src/import/extractors/help-scraper.ts
@@ -21,8 +21,8 @@ export function parseHelpOutput(text: string, prefix: string[]): CliCommandDefin
   const OPTIONS_HEADER = /^(Options|Flags|Global Options):\s*$/i;
   // Match a subcommand line: leading whitespace, non-dash first char, name token, optional description
   const CMD_LINE = /^\s+(\S+)\s*(.*)/;
-  // Match an option line: leading whitespace, dash-starting flag
-  const OPT_LINE = /^\s+(-\S+(?:,\s*--\S+)?)\s+(.*)/;
+  // Match an option line: "-x[, --long-form]" or "--long-form"
+  const OPT_LINE = /^\s+(-[a-zA-Z](?:,\s*--\S+)?|--\S+)\s*(.*)/;
 
   for (const line of lines) {
     const trimmed = line.trim();
@@ -76,14 +76,11 @@ export function parseHelpOutput(text: string, prefix: string[]): CliCommandDefin
     }
   }
 
-  // If we have options and prefix is non-empty, attach them to the command
-  // whose name matches prefix.join(' ')
+  // Options on a subcommand page belong to the parent command (prefix.join(' ')).
+  // Return a synthetic parent entry so scrapeHelp can merge options onto it.
   if (prefix.length > 0 && optionsBuf.length > 0) {
     const parentName = prefix.join(' ');
-    const parentCmd = commands.find((c) => c.command === parentName);
-    if (parentCmd) {
-      parentCmd.options = optionsBuf;
-    }
+    commands.push({ command: parentName, options: optionsBuf });
   }
 
   return commands;
@@ -125,13 +122,16 @@ export async function scrapeHelp(
     const discovered = parseHelpOutput(stdout, prefix);
 
     for (const cmd of discovered) {
-      if (!seen.has(cmd.command)) {
+      const existing = all.find((c) => c.command === cmd.command);
+      if (existing) {
+        // Merge options onto an already-discovered parent command
+        if (cmd.options && cmd.options.length > 0) {
+          existing.options = cmd.options;
+        }
+      } else {
         seen.add(cmd.command);
         all.push(cmd);
-
-        // Only recurse if we haven't reached max depth
         if (prefix.length < depth) {
-          // The next prefix is the parts of this command name
           queue.push(cmd.command.split(' '));
         }
       }

--- a/src/import/extractors/help-scraper.ts
+++ b/src/import/extractors/help-scraper.ts
@@ -70,7 +70,7 @@ export function parseHelpOutput(text: string, prefix: string[]): CliCommandDefin
         optionsBuf.push({
           name: flagStr,
           description: desc || undefined,
-          ...(takesValue ? { takesValue: true } : {}),
+          takesValue,
         });
       }
     }

--- a/src/import/extractors/help-scraper.ts
+++ b/src/import/extractors/help-scraper.ts
@@ -1,0 +1,142 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { CliCommandDefinition, CliCommandOptionDefinition } from '../types.js';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Pure parser: given the text output of `<binary> [prefix...] --help`,
+ * returns the subcommands and their options found in that output.
+ */
+export function parseHelpOutput(text: string, prefix: string[]): CliCommandDefinition[] {
+  const lines = text.split('\n');
+
+  let inCommands = false;
+  let inOptions = false;
+
+  const commands: CliCommandDefinition[] = [];
+  const optionsBuf: CliCommandOptionDefinition[] = [];
+
+  const COMMANDS_HEADER = /^(Commands|Subcommands):\s*$/;
+  const OPTIONS_HEADER = /^(Options|Flags|Global Options):\s*$/;
+  // Match a subcommand line: leading whitespace, non-dash first char, name token, optional description
+  const CMD_LINE = /^\s+(\S+)\s*(.*)/;
+  // Match an option line: leading whitespace, dash-starting flag
+  const OPT_LINE = /^\s+(-\S+(?:,\s*--\S+)?)\s+(.*)/;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Blank line resets section state
+    if (trimmed === '') {
+      inCommands = false;
+      inOptions = false;
+      continue;
+    }
+
+    // Detect section headers
+    if (COMMANDS_HEADER.test(trimmed)) {
+      inCommands = true;
+      inOptions = false;
+      continue;
+    }
+    if (OPTIONS_HEADER.test(trimmed)) {
+      inOptions = true;
+      inCommands = false;
+      continue;
+    }
+
+    if (inCommands) {
+      const m = CMD_LINE.exec(line);
+      if (m) {
+        const rawName = m[1]!;
+        // Skip if it looks like a flag line
+        if (rawName.startsWith('-')) continue;
+        // Strip positional hints like <name> or [name] from the token
+        const name = rawName.replace(/[<[].*/g, '').trim();
+        if (!name) continue;
+        const description = m[2]!.trim();
+
+        const commandStr = prefix.length > 0 ? [...prefix, name].join(' ') : name;
+        commands.push({ command: commandStr, description: description || undefined });
+      }
+    } else if (inOptions) {
+      const m = OPT_LINE.exec(line);
+      if (m) {
+        const flagStr = m[1]!.trim();
+        const desc = m[2]!.trim();
+        // takesValue if the flag string contains <word> or [word]
+        const takesValue = /<\w+>|\[\w+\]/.test(flagStr);
+        optionsBuf.push({
+          name: flagStr,
+          description: desc || undefined,
+          ...(takesValue ? { takesValue: true } : {}),
+        });
+      }
+    }
+  }
+
+  // If we have options and prefix is non-empty, attach them to the command
+  // whose name matches prefix.join(' ')
+  if (prefix.length > 0 && optionsBuf.length > 0) {
+    const parentName = prefix.join(' ');
+    const parentCmd = commands.find((c) => c.command === parentName);
+    if (parentCmd) {
+      parentCmd.options = optionsBuf;
+    }
+  }
+
+  return commands;
+}
+
+/**
+ * BFS scraper: runs `binary [prefix...] --help` for each discovered subcommand
+ * up to `opts.depth` levels deep.
+ */
+export async function scrapeHelp(
+  binary: string,
+  opts: { depth: number; cwd?: string },
+): Promise<CliCommandDefinition[]> {
+  const { depth, cwd } = opts;
+  const all: CliCommandDefinition[] = [];
+  const seen = new Set<string>();
+
+  // BFS queue of prefix arrays
+  const queue: string[][] = [[]];
+
+  while (queue.length > 0) {
+    const prefix = queue.shift()!;
+    const args = [...prefix, '--help'];
+
+    let stdout = '';
+    try {
+      const result = await execFileAsync(binary, args, {
+        cwd,
+        encoding: 'utf-8',
+        timeout: 5000,
+      });
+      stdout = result.stdout;
+    } catch (err: unknown) {
+      // Some CLIs exit non-zero for --help or print to stderr
+      const e = err as { stdout?: string; stderr?: string };
+      stdout = e.stdout ?? e.stderr ?? '';
+    }
+
+    const discovered = parseHelpOutput(stdout, prefix);
+
+    for (const cmd of discovered) {
+      if (!seen.has(cmd.command)) {
+        seen.add(cmd.command);
+        all.push(cmd);
+
+        // Only recurse if we haven't reached max depth
+        if (prefix.length < depth) {
+          // The next prefix is the parts of this command name
+          queue.push(cmd.command.split(' '));
+        }
+      }
+    }
+  }
+
+  return all;
+}

--- a/src/import/extractors/help-scraper.ts
+++ b/src/import/extractors/help-scraper.ts
@@ -17,8 +17,8 @@ export function parseHelpOutput(text: string, prefix: string[]): CliCommandDefin
   const commands: CliCommandDefinition[] = [];
   const optionsBuf: CliCommandOptionDefinition[] = [];
 
-  const COMMANDS_HEADER = /^(Commands|Subcommands):\s*$/;
-  const OPTIONS_HEADER = /^(Options|Flags|Global Options):\s*$/;
+  const COMMANDS_HEADER = /^(Commands|Subcommands):\s*$/i;
+  const OPTIONS_HEADER = /^(Options|Flags|Global Options):\s*$/i;
   // Match a subcommand line: leading whitespace, non-dash first char, name token, optional description
   const CMD_LINE = /^\s+(\S+)\s*(.*)/;
   // Match an option line: leading whitespace, dash-starting flag

--- a/src/import/extractors/py-argparse.ts
+++ b/src/import/extractors/py-argparse.ts
@@ -2,6 +2,21 @@ import { readFileSync } from 'node:fs';
 import { getSdkParser } from '../../benchmark/extractors/sdk/parser.js';
 import type { CliCommandDefinition, CliCommandOptionDefinition } from '../types.js';
 
+/** Extract the content of a paren-balanced block starting at `start` (the opening paren). */
+function extractParenBlock(source: string, start: number): string {
+  let depth = 0;
+  let i = start;
+  while (i < source.length) {
+    if (source[i] === '(') depth++;
+    else if (source[i] === ')') {
+      depth--;
+      if (depth === 0) return source.slice(start, i + 1);
+    }
+    i++;
+  }
+  return source.slice(start);
+}
+
 export async function extractArgparse(filePath: string): Promise<CliCommandDefinition[]> {
   const source = readFileSync(filePath, 'utf-8');
   // Use tree-sitter just to validate it parses (will throw on syntax error)
@@ -21,42 +36,47 @@ export async function extractArgparse(filePath: string): Promise<CliCommandDefin
   // Find parser variables and commands
   const commands: CliCommandDefinition[] = [];
   const parserVarToCmd = new Map<string, CliCommandDefinition>();
-  // Escape the subparsers variable name for use in regex
   const escapedSub = subparsersVar.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-  for (const line of lines) {
-    const m = line.match(
-      new RegExp(`(\\w+)\\s*=\\s*${escapedSub}\\.add_parser\\s*\\(\\s*['"]([^'"]+)['"](?:\\s*,\\s*help\\s*=\\s*['"]([^'"]+)['"])?`)
-    );
-    if (!m) continue;
+  // Scan full source for add_parser calls (handles multi-line calls)
+  const addParserRe = new RegExp(`(\\w+)\\s*=\\s*${escapedSub}\\.add_parser\\s*\\(`, 'g');
+  let m: RegExpExecArray | null;
+  while ((m = addParserRe.exec(source)) !== null) {
     const parserVar = m[1]!;
-    const commandName = m[2]!;
-    const helpText = m[3];
-    const def: CliCommandDefinition = { command: commandName, description: helpText };
+    const blockStart = m.index + m[0].length - 1; // position of '('
+    const block = extractParenBlock(source, blockStart);
+    const nameMatch = block.match(/^\(\s*['"]([^'"]+)['"]/);
+    if (!nameMatch) continue;
+    const commandName = nameMatch[1]!;
+    const helpMatch = block.match(/help\s*=\s*['"]([^'"]+)['"]/);
+    const def: CliCommandDefinition = { command: commandName, description: helpMatch?.[1] };
     commands.push(def);
     parserVarToCmd.set(parserVar, def);
   }
 
-  // Find add_argument calls for each parser variable
+  // Find add_argument calls for each parser variable — use paren-block extraction
+  // so multi-line calls and arbitrary kwarg ordering are handled correctly.
   for (const [parserVar, def] of parserVarToCmd) {
     const escapedVar = parserVar.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const argRegex = new RegExp(
-      `${escapedVar}\\.add_argument\\s*\\(\\s*['"](-[^'"]+)['"](?:\\s*,\\s*help\\s*=\\s*['"]([^'"]+)['"])?`,
-      'g'
-    );
+    const addArgRe = new RegExp(`${escapedVar}\\.add_argument\\s*\\(`, 'g');
     let argMatch: RegExpExecArray | null;
-    while ((argMatch = argRegex.exec(source)) !== null) {
-      const flagName = argMatch[1]!;
-      if (!flagName.startsWith('-')) continue; // skip positionals
-      const helpText2 = argMatch[2];
-      // Find the full line to check for store_true
-      const lineStart = source.lastIndexOf('\n', argMatch.index) + 1;
-      const lineEnd = source.indexOf('\n', argMatch.index);
-      const fullLine = source.slice(lineStart, lineEnd === -1 ? undefined : lineEnd);
-      const isStoreTrue = /action\s*=\s*['"]store_true['"]/.test(fullLine);
+    while ((argMatch = addArgRe.exec(source)) !== null) {
+      const blockStart = argMatch.index + argMatch[0].length - 1;
+      const block = extractParenBlock(source, blockStart);
+
+      // First string arg — must start with '-' to be a flag (not a positional)
+      const flagMatch = block.match(/^\(\s*['"](-[^'"]+)['"]/);
+      if (!flagMatch) continue;
+      const flagName = flagMatch[1]!;
+
+      // help= anywhere in the block
+      const helpMatch = block.match(/help\s*=\s*['"]([^'"]+)['"]/);
+      // action='store_true' anywhere in the block (handles multi-line)
+      const isStoreTrue = /action\s*=\s*['"]store_true['"]/.test(block);
+
       const opt: CliCommandOptionDefinition = {
         name: flagName,
-        description: helpText2,
+        description: helpMatch?.[1],
         takesValue: !isStoreTrue,
       };
       if (!def.options) def.options = [];

--- a/src/import/extractors/py-argparse.ts
+++ b/src/import/extractors/py-argparse.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from 'node:fs';
+import { getSdkParser } from '../../benchmark/extractors/sdk/parser.js';
+import type { CliCommandDefinition, CliCommandOptionDefinition } from '../types.js';
+
+export async function extractArgparse(filePath: string): Promise<CliCommandDefinition[]> {
+  const source = readFileSync(filePath, 'utf-8');
+  // Use tree-sitter just to validate it parses (will throw on syntax error)
+  const parser = await getSdkParser('python');
+  parser.parse(source); // validate only
+
+  const lines = source.split('\n');
+
+  // Find subparsers variable
+  let subparsersVar: string | null = null;
+  for (const line of lines) {
+    const m = line.match(/(\w+)\s*=\s*\w+\.add_subparsers\s*\(/);
+    if (m) { subparsersVar = m[1]!; break; }
+  }
+  if (!subparsersVar) return [];
+
+  // Find parser variables and commands
+  const commands: CliCommandDefinition[] = [];
+  const parserVarToCmd = new Map<string, CliCommandDefinition>();
+  // Escape the subparsers variable name for use in regex
+  const escapedSub = subparsersVar.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+  for (const line of lines) {
+    const m = line.match(
+      new RegExp(`(\\w+)\\s*=\\s*${escapedSub}\\.add_parser\\s*\\(\\s*['"]([^'"]+)['"](?:\\s*,\\s*help\\s*=\\s*['"]([^'"]+)['"])?`)
+    );
+    if (!m) continue;
+    const parserVar = m[1]!;
+    const commandName = m[2]!;
+    const helpText = m[3];
+    const def: CliCommandDefinition = { command: commandName, description: helpText };
+    commands.push(def);
+    parserVarToCmd.set(parserVar, def);
+  }
+
+  // Find add_argument calls for each parser variable
+  for (const [parserVar, def] of parserVarToCmd) {
+    const escapedVar = parserVar.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const argRegex = new RegExp(
+      `${escapedVar}\\.add_argument\\s*\\(\\s*['"](-[^'"]+)['"](?:\\s*,\\s*help\\s*=\\s*['"]([^'"]+)['"])?`,
+      'g'
+    );
+    let argMatch: RegExpExecArray | null;
+    while ((argMatch = argRegex.exec(source)) !== null) {
+      const flagName = argMatch[1]!;
+      if (!flagName.startsWith('-')) continue; // skip positionals
+      const helpText2 = argMatch[2];
+      // Find the full line to check for store_true
+      const lineStart = source.lastIndexOf('\n', argMatch.index) + 1;
+      const lineEnd = source.indexOf('\n', argMatch.index);
+      const fullLine = source.slice(lineStart, lineEnd === -1 ? undefined : lineEnd);
+      const isStoreTrue = /action\s*=\s*['"]store_true['"]/.test(fullLine);
+      const opt: CliCommandOptionDefinition = {
+        name: flagName,
+        description: helpText2,
+        takesValue: !isStoreTrue,
+      };
+      if (!def.options) def.options = [];
+      if (!def.options.find(o => o.name === flagName)) {
+        def.options.push(opt);
+      }
+    }
+  }
+
+  return commands;
+}

--- a/src/import/extractors/py-click.ts
+++ b/src/import/extractors/py-click.ts
@@ -1,0 +1,112 @@
+import { readFileSync } from 'node:fs';
+import type Parser from 'web-tree-sitter';
+import { getSdkParser } from '../../benchmark/extractors/sdk/parser.js';
+import type { CliCommandDefinition, CliCommandOptionDefinition } from '../types.js';
+
+function stripDocstring(raw: string): string {
+  const m = raw.match(/^['"]{1,3}([\s\S]*?)['"]{1,3}$/);
+  if (m) return m[1]!.trim();
+  return raw.trim();
+}
+
+function getDocstring(funcDef: Parser.SyntaxNode): string | undefined {
+  // Find the 'block' child of the function definition
+  let block: Parser.SyntaxNode | null = null;
+  for (const child of funcDef.children) {
+    if (child.type === 'block') {
+      block = child;
+      break;
+    }
+  }
+  if (!block) return undefined;
+
+  // First child of block that is expression_statement containing a string
+  for (const child of block.children) {
+    if (child.type === 'expression_statement') {
+      for (const inner of child.children) {
+        if (inner.type === 'string') {
+          return stripDocstring(inner.text);
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
+function walkTree(node: Parser.SyntaxNode, source: string): CliCommandDefinition[] {
+  const results: CliCommandDefinition[] = [];
+
+  if (node.type === 'decorated_definition') {
+    const decorators: Parser.SyntaxNode[] = [];
+    let funcDef: Parser.SyntaxNode | null = null;
+
+    for (const child of node.children) {
+      if (child.type === 'decorator') {
+        decorators.push(child);
+      } else if (child.type === 'function_definition') {
+        funcDef = child;
+      }
+    }
+
+    if (funcDef) {
+      // Check if any decorator is a command decorator (but not group)
+      let isCommand = false;
+      const options: CliCommandOptionDefinition[] = [];
+
+      for (const dec of decorators) {
+        const decoratorText = source.slice(dec.startIndex, dec.endIndex);
+        const isCommandDec =
+          /\.command\s*\(\s*\)/.test(decoratorText) ||
+          /^@click\.command\s*\(/.test(decoratorText);
+        const isOptionDec = /\.option\s*\(/.test(decoratorText);
+
+        if (isCommandDec) {
+          isCommand = true;
+        } else if (isOptionDec) {
+          const flagMatch = decoratorText.match(/\.option\s*\(\s*['"]([^'"]+)['"]/);
+          const helpMatch = decoratorText.match(/help\s*=\s*['"]([^'"]+)['"]/);
+          const isFlag = /is_flag\s*=\s*True/.test(decoratorText);
+
+          if (flagMatch) {
+            options.push({
+              name: flagMatch[1]!,
+              description: helpMatch ? helpMatch[1] : undefined,
+              takesValue: !isFlag,
+            });
+          }
+        }
+      }
+
+      if (isCommand) {
+        const nameNode = funcDef.childForFieldName('name');
+        const rawName = nameNode ? nameNode.text : '';
+        const commandName = rawName.replace(/_/g, '-');
+        const description = getDocstring(funcDef);
+
+        const def: CliCommandDefinition = { command: commandName };
+        if (description !== undefined) def.description = description;
+        if (options.length > 0) def.options = options;
+
+        results.push(def);
+      }
+    }
+  }
+
+  // Recurse into children
+  for (const child of node.children) {
+    const childResults = walkTree(child, source);
+    for (const r of childResults) results.push(r);
+  }
+
+  return results;
+}
+
+/**
+ * Extract click command definitions from a Python source file using tree-sitter.
+ */
+export async function extractClick(filePath: string): Promise<CliCommandDefinition[]> {
+  const source = readFileSync(filePath, 'utf-8');
+  const parser = await getSdkParser('python');
+  const tree = parser.parse(source);
+  return walkTree(tree.rootNode, source);
+}

--- a/src/import/extractors/py-click.ts
+++ b/src/import/extractors/py-click.ts
@@ -94,8 +94,7 @@ function walkTree(node: Parser.SyntaxNode, source: string): CliCommandDefinition
 
   // Recurse into children
   for (const child of node.children) {
-    const childResults = walkTree(child, source);
-    for (const r of childResults) results.push(r);
+    results.push(...walkTree(child, source));
   }
 
   return results;

--- a/src/import/extractors/rs-clap.ts
+++ b/src/import/extractors/rs-clap.ts
@@ -1,0 +1,82 @@
+import { readFileSync } from 'node:fs';
+import { getSdkParser } from '../../benchmark/extractors/sdk/parser.js';
+import type { CliCommandDefinition, CliCommandOptionDefinition } from '../types.js';
+
+function extractParenBlock(source: string, start: number): string {
+  let depth = 0;
+  let i = start;
+  while (i < source.length) {
+    if (source[i] === '(') depth++;
+    else if (source[i] === ')') {
+      depth--;
+      if (depth === 0) return source.slice(start, i + 1);
+    }
+    i++;
+  }
+  return source.slice(start);
+}
+
+/**
+ * Extract clap command definitions from a Rust source file using tree-sitter for validation,
+ * then text-based analysis for extraction.
+ */
+export async function extractClap(filePath: string): Promise<CliCommandDefinition[]> {
+  const source = readFileSync(filePath, 'utf-8');
+  const parser = await getSdkParser('rust');
+  parser.parse(source); // validate only
+
+  const commands: CliCommandDefinition[] = [];
+  const subcommandSearchStr = '.subcommand(';
+  let searchStart = 0;
+
+  while (true) {
+    const subIdx = source.indexOf(subcommandSearchStr, searchStart);
+    if (subIdx === -1) break;
+
+    // Extract the block starting at the '(' of .subcommand(
+    const blockStart = subIdx + subcommandSearchStr.length - 1; // position of '('
+    const block = extractParenBlock(source, blockStart);
+
+    // Find Command::new("name") in this block
+    const nameMatch = block.match(/Command\s*::\s*new\s*\(\s*"([^"]+)"\s*\)/);
+    if (!nameMatch) { searchStart = subIdx + 1; continue; }
+    const commandName = nameMatch[1]!;
+
+    // Find .about("description")
+    const aboutMatch = block.match(/\.about\s*\(\s*"([^"]+)"\s*\)/);
+    const description = aboutMatch ? aboutMatch[1] : undefined;
+
+    // Find options by scanning for .arg( calls in the block and extracting each arg's paren block
+    const options: CliCommandOptionDefinition[] = [];
+    const argSearchStr = '.arg(';
+    let argSearchStart = 0;
+    while (true) {
+      const argIdx = block.indexOf(argSearchStr, argSearchStart);
+      if (argIdx === -1) break;
+
+      // Extract the arg block starting at the '(' of .arg(
+      const argBlockStart = argIdx + argSearchStr.length - 1;
+      const argBlock = extractParenBlock(block, argBlockStart);
+
+      // Find .long("flag") within this arg block
+      const longMatch = argBlock.match(/\.long\s*\(\s*"([^"]+)"\s*\)/);
+      if (longMatch) {
+        const longFlag = '--' + longMatch[1];
+        const helpMatch = argBlock.match(/\.help\s*\(\s*"([^"]+)"\s*\)/);
+        const isBool = /SetTrue|SetFalse|store_true/.test(argBlock);
+        options.push({
+          name: longFlag,
+          description: helpMatch ? helpMatch[1] : undefined,
+          takesValue: !isBool,
+        });
+      }
+
+      argSearchStart = argIdx + 1;
+    }
+
+    commands.push({ command: commandName, description, options: options.length > 0 ? options : undefined });
+    searchStart = subIdx + 1;
+  }
+
+  return commands;
+}

--- a/src/import/extractors/ts-commander.ts
+++ b/src/import/extractors/ts-commander.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from 'node:fs';
+
+import ts from 'typescript';
+
+import type { CliCommandDefinition } from '../types.js';
+
+function getScriptKind(filePath: string): ts.ScriptKind {
+  if (filePath.endsWith('.tsx')) return ts.ScriptKind.TSX;
+  if (filePath.endsWith('.js')) return ts.ScriptKind.JS;
+  return ts.ScriptKind.TS;
+}
+
+function walkChainUp(node: ts.Node, def: CliCommandDefinition): void {
+  // node.parent is the PropertyAccessExpression (the `.command`/`.description`/etc access)
+  // node.parent.parent is the next CallExpression in the chain
+  const propAccess = node.parent;
+  if (!propAccess || !ts.isPropertyAccessExpression(propAccess)) return;
+  const nextCall = propAccess.parent;
+  if (!nextCall || !ts.isCallExpression(nextCall)) return;
+
+  const method = propAccess.name.text;
+  if (method === 'description' && nextCall.arguments[0] !== undefined && ts.isStringLiteral(nextCall.arguments[0])) {
+    def.description = nextCall.arguments[0].text;
+  } else if (method === 'option' && nextCall.arguments[0] !== undefined && ts.isStringLiteral(nextCall.arguments[0])) {
+    const flagStr = nextCall.arguments[0].text;
+    const desc =
+      nextCall.arguments[1] !== undefined && ts.isStringLiteral(nextCall.arguments[1])
+        ? nextCall.arguments[1].text
+        : undefined;
+    const takesValue = /<\w+>|\[\w+\]/.test(flagStr);
+    if (!def.options) def.options = [];
+    def.options.push({ name: flagStr, description: desc, takesValue });
+  }
+  // Continue walking up the chain
+  walkChainUp(nextCall, def);
+}
+
+/**
+ * Extract commander.js command definitions from a TypeScript/JavaScript source file
+ * using the TypeScript Compiler API.
+ */
+export function extractCommander(filePath: string): CliCommandDefinition[] {
+  const source = readFileSync(filePath, 'utf-8');
+  const scriptKind = getScriptKind(filePath);
+  const sourceFile = ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, true, scriptKind);
+
+  const commands: CliCommandDefinition[] = [];
+
+  function visit(node: ts.Node): void {
+    if (ts.isCallExpression(node)) {
+      const expr = node.expression;
+      if (
+        ts.isPropertyAccessExpression(expr) &&
+        expr.name.text === 'command' &&
+        node.arguments[0] !== undefined &&
+        ts.isStringLiteral(node.arguments[0])
+      ) {
+        const rawName = node.arguments[0].text;
+        // Strip positional placeholders: 'delete <id>' → 'delete'
+        const commandName = rawName.split(' ')[0]!;
+
+        const def: CliCommandDefinition = { command: commandName };
+        walkChainUp(node, def);
+        commands.push(def);
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+
+  return commands;
+}

--- a/src/import/extractors/ts-yargs.ts
+++ b/src/import/extractors/ts-yargs.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from 'node:fs';
+import { extname } from 'node:path';
+import ts from 'typescript';
+import type { CliCommandDefinition, CliCommandOptionDefinition } from '../types.js';
+
+function scriptKind(filePath: string): ts.ScriptKind {
+  const ext = extname(filePath).toLowerCase();
+  if (ext === '.tsx') return ts.ScriptKind.TSX;
+  if (ext === '.js' || ext === '.mjs' || ext === '.cjs') return ts.ScriptKind.JS;
+  return ts.ScriptKind.TS;
+}
+
+function extractOptionsFromBuilder(builder: ts.Expression): CliCommandOptionDefinition[] {
+  const options: CliCommandOptionDefinition[] = [];
+
+  function visitForOptions(node: ts.Node): void {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === 'option' &&
+      node.arguments.length >= 1 &&
+      ts.isStringLiteral(node.arguments[0]!)
+    ) {
+      const optName = `--${node.arguments[0].text}`;
+      let desc: string | undefined;
+      let takesValue = false;
+
+      const config = node.arguments[1];
+      if (config && ts.isObjectLiteralExpression(config)) {
+        for (const prop of config.properties) {
+          if (!ts.isPropertyAssignment(prop)) continue;
+          const key = ts.isIdentifier(prop.name) ? prop.name.text : null;
+          if (key === 'describe' && ts.isStringLiteral(prop.initializer)) {
+            desc = prop.initializer.text;
+          }
+          if (key === 'type' && ts.isStringLiteral(prop.initializer)) {
+            const t = prop.initializer.text;
+            takesValue = t === 'string' || t === 'array' || t === 'number';
+          }
+        }
+      }
+
+      options.push({ name: optName, description: desc, takesValue });
+    }
+    ts.forEachChild(node, visitForOptions);
+  }
+
+  visitForOptions(builder);
+  return options;
+}
+
+export function extractYargs(filePath: string): CliCommandDefinition[] {
+  const source = readFileSync(filePath, 'utf-8');
+  const sf = ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, true, scriptKind(filePath));
+  const commands: CliCommandDefinition[] = [];
+
+  function visit(node: ts.Node): void {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === 'command' &&
+      node.arguments.length >= 2 &&
+      ts.isStringLiteral(node.arguments[0]!) &&
+      ts.isStringLiteral(node.arguments[1]!)
+    ) {
+      const commandName = node.arguments[0].text.split(' ')[0]!;
+      const description = node.arguments[1].text;
+      const def: CliCommandDefinition = { command: commandName, description };
+
+      const builder = node.arguments[2];
+      if (builder) {
+        const opts = extractOptionsFromBuilder(builder);
+        if (opts.length > 0) def.options = opts;
+      }
+
+      commands.push(def);
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sf);
+  return commands;
+}

--- a/src/import/index.ts
+++ b/src/import/index.ts
@@ -1,0 +1,87 @@
+import { existsSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import type { ImportOptions } from './types.js';
+import type { CliCommandDefinition } from './types.js';
+import { detectFramework } from './detect.js';
+import { extractCommander } from './extractors/ts-commander.js';
+import { extractYargs } from './extractors/ts-yargs.js';
+import { extractClick } from './extractors/py-click.js';
+import { extractArgparse } from './extractors/py-argparse.js';
+import { extractClap } from './extractors/rs-clap.js';
+import { scrapeHelp } from './extractors/help-scraper.js';
+import { discoverCliSurfaceFromSources } from '../discovery/cli.js';
+import { promptOverwrite, writeOutput } from './output.js';
+
+export async function importCommands(opts: ImportOptions): Promise<void> {
+  const { from, out, scrape, depth, cwd } = opts;
+  const absFrom = resolve(cwd, from);
+  const absOut = resolve(cwd, out);
+
+  const detection = scrape ? { kind: 'unknown' as const, binaryHint: from } : detectFramework(from, cwd);
+  console.log(`\nskill-optimizer import-commands — detecting framework from ${from}`);
+  if (detection.kind !== 'unknown') {
+    console.log(`  Detected: ${detection.kind}`);
+  }
+
+  let commands: CliCommandDefinition[] = [];
+  if (!scrape) {
+    console.log('  Extracting commands...');
+    try {
+      if (detection.kind === 'commander') {
+        commands = extractCommander(absFrom);
+      } else if (detection.kind === 'yargs') {
+        commands = extractYargs(absFrom);
+      } else if (detection.kind === 'optique') {
+        const snapshot = discoverCliSurfaceFromSources([absFrom]);
+        commands = snapshot.actions.map(a => ({
+          command: a.name,
+          description: a.description,
+          options: a.args.map(arg => ({
+            name: arg.name,
+            description: arg.description,
+            takesValue: arg.type === 'string',
+          })),
+        }));
+      } else if (detection.kind === 'click' || detection.kind === 'typer') {
+        commands = await extractClick(absFrom);
+      } else if (detection.kind === 'argparse') {
+        commands = await extractArgparse(absFrom);
+      } else if (detection.kind === 'clap') {
+        commands = await extractClap(absFrom);
+      }
+    } catch (err) {
+      console.error(`  Warning: static extraction failed: ${err instanceof Error ? err.message : err}`);
+      commands = [];
+    }
+  }
+
+  if (commands.length === 0 && detection.binaryHint) {
+    console.log('  Static extraction yielded 0 commands — falling back to --help scraping...');
+    try {
+      commands = await scrapeHelp(detection.binaryHint, { depth, cwd });
+    } catch (err) {
+      console.error(`  Warning: --help scraping failed: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+
+  if (commands.length === 0) {
+    console.error('\n  ERROR: No commands found after all strategies.');
+    console.error('  Try: skill-optimizer import-commands --from <binary> --scrape');
+    process.exit(1);
+  }
+
+  console.log(`  Found ${commands.length} commands`);
+
+  if (existsSync(absOut)) {
+    const overwrite = await promptOverwrite(absOut);
+    if (!overwrite) {
+      console.log('\n  Aborted. Output file unchanged.');
+      process.exit(0);
+    }
+  }
+
+  mkdirSync(dirname(absOut), { recursive: true });
+  await writeOutput(commands, absOut);
+  console.log(`\n  Wrote ${commands.length} commands to ${out}`);
+  console.log(`  Done. Review the file and run 'skill-optimizer doctor' to validate.\n`);
+}

--- a/src/import/index.ts
+++ b/src/import/index.ts
@@ -1,7 +1,6 @@
 import { existsSync, mkdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
-import type { ImportOptions } from './types.js';
-import type { CliCommandDefinition } from './types.js';
+import type { ImportOptions, CliCommandDefinition } from './types.js';
 import { detectFramework } from './detect.js';
 import { extractCommander } from './extractors/ts-commander.js';
 import { extractYargs } from './extractors/ts-yargs.js';

--- a/src/import/index.ts
+++ b/src/import/index.ts
@@ -80,7 +80,7 @@ export async function importCommands(opts: ImportOptions): Promise<void> {
   }
 
   mkdirSync(dirname(absOut), { recursive: true });
-  await writeOutput(commands, absOut);
+  writeOutput(commands, absOut);
   console.log(`\n  Wrote ${commands.length} commands to ${out}`);
   console.log(`  Done. Review the file and run 'skill-optimizer doctor' to validate.\n`);
 }

--- a/src/import/output.ts
+++ b/src/import/output.ts
@@ -16,6 +16,6 @@ export async function promptOverwrite(outPath: string): Promise<boolean> {
   });
 }
 
-export async function writeOutput(commands: CliCommandDefinition[], outPath: string): Promise<void> {
+export function writeOutput(commands: CliCommandDefinition[], outPath: string): void {
   writeFileSync(outPath, JSON.stringify(commands, null, 2) + '\n', 'utf-8');
 }

--- a/src/import/output.ts
+++ b/src/import/output.ts
@@ -3,8 +3,12 @@ import { createInterface } from 'node:readline';
 import type { CliCommandDefinition } from './types.js';
 
 export async function promptOverwrite(outPath: string): Promise<boolean> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const rl = createInterface({ input: process.stdin, output: process.stdout });
+    rl.on('error', (err) => {
+      rl.close();
+      reject(err);
+    });
     rl.question(`  Output: ${outPath} already exists.\n  Overwrite? [y/N] `, (answer) => {
       rl.close();
       resolve(answer.trim().toLowerCase() === 'y');

--- a/src/import/output.ts
+++ b/src/import/output.ts
@@ -1,0 +1,17 @@
+import { writeFileSync } from 'node:fs';
+import { createInterface } from 'node:readline';
+import type { CliCommandDefinition } from './types.js';
+
+export async function promptOverwrite(outPath: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(`  Output: ${outPath} already exists.\n  Overwrite? [y/N] `, (answer) => {
+      rl.close();
+      resolve(answer.trim().toLowerCase() === 'y');
+    });
+  });
+}
+
+export async function writeOutput(commands: CliCommandDefinition[], outPath: string): Promise<void> {
+  writeFileSync(outPath, JSON.stringify(commands, null, 2) + '\n', 'utf-8');
+}

--- a/src/import/types.ts
+++ b/src/import/types.ts
@@ -1,0 +1,24 @@
+export type { CliCommandDefinition, CliCommandOptionDefinition } from '../benchmark/types.js';
+
+export type FrameworkKind =
+  | 'commander'
+  | 'yargs'
+  | 'optique'
+  | 'click'
+  | 'typer'
+  | 'argparse'
+  | 'clap'
+  | 'unknown';
+
+export interface DetectionResult {
+  kind: FrameworkKind;
+  binaryHint?: string;
+}
+
+export interface ImportOptions {
+  from: string;
+  out: string;
+  scrape: boolean;
+  depth: number;
+  cwd: string;
+}

--- a/src/init/answers.ts
+++ b/src/init/answers.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs';
+
+export interface WizardAnswers {
+  /** What kind of surface is being benchmarked */
+  surface: 'sdk' | 'cli' | 'mcp';
+  /** Absolute path to the target repo */
+  repoPath: string;
+  /** OpenRouter model IDs selected for benchmarking */
+  models: string[];
+  /** Max tasks to generate */
+  maxTasks: number;
+  /** Max optimize iterations */
+  maxIterations: number;
+  /** For cli/mcp: path to entry file or binary (relative to repoPath or absolute) */
+  entryFile?: string;
+  /** Optional project name (defaults to basename of repoPath) */
+  name?: string;
+}
+
+const DEFAULT_MODELS = [
+  'openrouter/anthropic/claude-sonnet-4-6',
+  'openrouter/google/gemini-2.0-flash-001',
+];
+
+export function buildDefaultAnswers(surface: 'sdk' | 'cli' | 'mcp' = 'sdk', repoPath?: string): WizardAnswers {
+  return {
+    surface,
+    repoPath: repoPath ?? process.cwd(),
+    models: DEFAULT_MODELS,
+    maxTasks: 20,
+    maxIterations: 5,
+  };
+}
+
+export function readAnswersFile(filePath: string): WizardAnswers {
+  const raw = JSON.parse(readFileSync(filePath, 'utf-8')) as Partial<WizardAnswers>;
+  if (!raw.surface || !['sdk', 'cli', 'mcp'].includes(raw.surface)) {
+    throw new Error(`answers file must have surface: sdk | cli | mcp (got: ${JSON.stringify(raw.surface)})`);
+  }
+  if (!raw.repoPath) {
+    throw new Error('answers file must have repoPath');
+  }
+  if (!raw.models || raw.models.length === 0) {
+    throw new Error('answers file must have at least one model');
+  }
+  return {
+    surface: raw.surface,
+    repoPath: raw.repoPath,
+    models: raw.models,
+    maxTasks: raw.maxTasks ?? 20,
+    maxIterations: raw.maxIterations ?? 5,
+    entryFile: raw.entryFile,
+    name: raw.name,
+  };
+}

--- a/src/init/answers.ts
+++ b/src/init/answers.ts
@@ -34,8 +34,8 @@ export function readAnswersFile(filePath: string): WizardAnswers {
   if (!raw.repoPath) {
     throw new Error('answers file must have repoPath');
   }
-  if (!raw.models || raw.models.length === 0) {
-    throw new Error('answers file must have at least one model');
+  if (!Array.isArray(raw.models) || raw.models.length === 0) {
+    throw new Error('answers file must have at least one model (as a JSON array)');
   }
   return {
     surface: raw.surface,

--- a/src/init/answers.ts
+++ b/src/init/answers.ts
@@ -1,19 +1,13 @@
 import { readFileSync } from 'node:fs';
 
 export interface WizardAnswers {
-  /** What kind of surface is being benchmarked */
   surface: 'sdk' | 'cli' | 'mcp';
-  /** Absolute path to the target repo */
   repoPath: string;
-  /** OpenRouter model IDs selected for benchmarking */
   models: string[];
-  /** Max tasks to generate */
   maxTasks: number;
-  /** Max optimize iterations */
   maxIterations: number;
   /** For cli/mcp: path to entry file or binary (relative to repoPath or absolute) */
   entryFile?: string;
-  /** Optional project name (defaults to basename of repoPath) */
   name?: string;
 }
 

--- a/src/init/detect-project.ts
+++ b/src/init/detect-project.ts
@@ -1,0 +1,130 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join, basename } from 'node:path';
+
+export interface DetectedProject {
+  surface: 'sdk' | 'cli' | 'mcp';
+  name: string;
+  repoPath: string;
+  /** Relative to repoPath */
+  entryFile: string;
+  /** Relative to repoPath, if found */
+  skillFile?: string;
+  confidence: 'high' | 'medium' | 'low';
+  /** Human-readable list of signals that drove detection */
+  signals: string[];
+}
+
+export function detectProject(dir: string): DetectedProject {
+  const signals: string[] = [];
+  let surface: 'sdk' | 'cli' | 'mcp' = 'sdk';
+  let name = basename(dir);
+  let entryFile = 'src/index.ts';
+  let confidence: 'high' | 'medium' | 'low' = 'low';
+
+  // ── package.json ──────────────────────────────────────────────────────────
+  const pkgPath = join(dir, 'package.json');
+  if (existsSync(pkgPath)) {
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as {
+      name?: string;
+      bin?: Record<string, string> | string;
+      main?: string;
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+
+    if (pkg.name) name = pkg.name;
+
+    const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
+
+    // MCP: @modelcontextprotocol/sdk in deps
+    if (allDeps['@modelcontextprotocol/sdk']) {
+      surface = 'mcp';
+      confidence = 'high';
+      signals.push('package.json: @modelcontextprotocol/sdk dependency');
+      entryFile = existsSync(join(dir, 'src', 'server.ts'))
+        ? 'src/server.ts'
+        : 'src/index.ts';
+    } else if (pkg.bin && Object.keys(pkg.bin as Record<string, string>).length > 0) {
+      surface = 'cli';
+      confidence = 'high';
+      signals.push('package.json: bin field');
+      const binValues = typeof pkg.bin === 'string'
+        ? [pkg.bin]
+        : Object.values(pkg.bin as Record<string, string>);
+      const firstBin = binValues[0] ?? '';
+      const srcGuess = firstBin.replace(/dist\//, 'src/').replace(/\.js$/, '.ts');
+      entryFile = existsSync(join(dir, srcGuess)) ? srcGuess : 'src/cli.ts';
+    } else {
+      surface = 'sdk';
+      confidence = 'medium';
+      signals.push('package.json: no bin field (SDK assumed)');
+      const mainGuess = pkg.main?.replace(/dist\//, 'src/').replace(/\.js$/, '.ts');
+      entryFile = mainGuess && existsSync(join(dir, mainGuess))
+        ? mainGuess
+        : 'src/index.ts';
+    }
+  }
+
+  // ── pyproject.toml ────────────────────────────────────────────────────────
+  const pyprojectPath = join(dir, 'pyproject.toml');
+  if (existsSync(pyprojectPath) && confidence === 'low') {
+    const content = readFileSync(pyprojectPath, 'utf-8');
+
+    const nameMatch = content.match(/^\s*name\s*=\s*"([^"]+)"/m);
+    if (nameMatch) name = nameMatch[1]!;
+
+    if (/^\s*mcp\s*[=\[>]/m.test(content) || content.includes('"mcp"')) {
+      surface = 'mcp';
+      confidence = 'high';
+      signals.push('pyproject.toml: mcp dependency');
+      entryFile = existsSync(join(dir, 'server.py')) ? 'server.py' : 'main.py';
+    } else if (/\[project\.scripts\]/m.test(content)) {
+      surface = 'cli';
+      confidence = 'high';
+      signals.push('pyproject.toml: [project.scripts] section');
+      const scriptMatch = content.match(/\[project\.scripts\][^\[]*\n\s*\S+\s*=\s*"([^:]+):/m);
+      entryFile = scriptMatch ? scriptMatch[1]!.replace(/\./g, '/') + '.py' : 'main.py';
+    } else {
+      surface = 'sdk';
+      confidence = 'medium';
+      signals.push('pyproject.toml: no [project.scripts] (SDK assumed)');
+      entryFile = 'src/__init__.py';
+    }
+  }
+
+  // ── Cargo.toml ────────────────────────────────────────────────────────────
+  const cargoPath = join(dir, 'Cargo.toml');
+  if (existsSync(cargoPath) && confidence === 'low') {
+    const content = readFileSync(cargoPath, 'utf-8');
+
+    const nameMatch = content.match(/^\s*name\s*=\s*"([^"]+)"/m);
+    if (nameMatch) name = nameMatch[1]!;
+
+    if (/^\[\[bin\]\]/m.test(content)) {
+      surface = 'cli';
+      confidence = 'high';
+      signals.push('Cargo.toml: [[bin]] section');
+      entryFile = 'src/main.rs';
+    } else if (/^\[lib\]/m.test(content)) {
+      surface = 'sdk';
+      confidence = 'high';
+      signals.push('Cargo.toml: [lib] section');
+      entryFile = 'src/lib.rs';
+    } else {
+      surface = existsSync(join(dir, 'src', 'main.rs')) ? 'cli' : 'sdk';
+      confidence = 'medium';
+      signals.push('Cargo.toml: inferred from src/main.rs existence');
+      entryFile = surface === 'cli' ? 'src/main.rs' : 'src/lib.rs';
+    }
+  }
+
+  if (signals.length === 0) {
+    signals.push('No manifest found — defaulting to sdk');
+  }
+
+  // ── Skill file ────────────────────────────────────────────────────────────
+  const skillCandidates = ['SKILL.md', 'docs/SKILL.md', 'README.md'];
+  const skillFile = skillCandidates.find(f => existsSync(join(dir, f)));
+
+  return { surface, name, repoPath: dir, entryFile, skillFile, confidence, signals };
+}

--- a/src/init/detect-project.ts
+++ b/src/init/detect-project.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join, basename } from 'node:path';
+import type { WizardAnswers } from './answers.js';
 
 export interface DetectedProject {
   surface: 'sdk' | 'cli' | 'mcp';
@@ -127,4 +128,26 @@ export function detectProject(dir: string): DetectedProject {
   const skillFile = skillCandidates.find(f => existsSync(join(dir, f)));
 
   return { surface, name, repoPath: dir, entryFile, skillFile, confidence, signals };
+}
+
+export function detectedToPreseed(detected: DetectedProject): Partial<WizardAnswers> {
+  return {
+    surface: detected.surface,
+    repoPath: detected.repoPath,
+    entryFile: detected.entryFile,
+    name: detected.name,
+  };
+}
+
+export function printDetectionSummary(detected: DetectedProject): void {
+  const confidenceLabel =
+    detected.confidence === 'high' ? 'high confidence' :
+    detected.confidence === 'medium' ? 'medium confidence' :
+    'low confidence — review carefully';
+  console.log(`\nDetected: ${detected.surface} (${confidenceLabel})`);
+  console.log(`  Name:    ${detected.name}`);
+  console.log(`  Entry:   ${detected.entryFile}`);
+  if (detected.skillFile) console.log(`  Skill:   ${detected.skillFile}`);
+  console.log(`  Signals: ${detected.signals.join('; ')}`);
+  console.log('');
 }

--- a/src/init/detect-project.ts
+++ b/src/init/detect-project.ts
@@ -45,14 +45,11 @@ export function detectProject(dir: string): DetectedProject {
       entryFile = existsSync(join(dir, 'src', 'server.ts'))
         ? 'src/server.ts'
         : 'src/index.ts';
-    } else if (pkg.bin && Object.keys(pkg.bin as Record<string, string>).length > 0) {
+    } else if (pkg.bin && (typeof pkg.bin === 'string' || Object.keys(pkg.bin).length > 0)) {
       surface = 'cli';
       confidence = 'high';
       signals.push('package.json: bin field');
-      const binValues = typeof pkg.bin === 'string'
-        ? [pkg.bin]
-        : Object.values(pkg.bin as Record<string, string>);
-      const firstBin = binValues[0] ?? '';
+      const firstBin = typeof pkg.bin === 'string' ? pkg.bin : Object.values(pkg.bin)[0] ?? '';
       const srcGuess = firstBin.replace(/dist\//, 'src/').replace(/\.js$/, '.ts');
       entryFile = existsSync(join(dir, srcGuess)) ? srcGuess : 'src/cli.ts';
     } else {
@@ -139,12 +136,16 @@ export function detectedToPreseed(detected: DetectedProject): Partial<WizardAnsw
   };
 }
 
+function confidenceLabel(confidence: DetectedProject['confidence']): string {
+  switch (confidence) {
+    case 'high': return 'high confidence';
+    case 'medium': return 'medium confidence';
+    case 'low': return 'low confidence — review carefully';
+  }
+}
+
 export function printDetectionSummary(detected: DetectedProject): void {
-  const confidenceLabel =
-    detected.confidence === 'high' ? 'high confidence' :
-    detected.confidence === 'medium' ? 'medium confidence' :
-    'low confidence — review carefully';
-  console.log(`\nDetected: ${detected.surface} (${confidenceLabel})`);
+  console.log(`\nDetected: ${detected.surface} (${confidenceLabel(detected.confidence)})`);
   console.log(`  Name:    ${detected.name}`);
   console.log(`  Entry:   ${detected.entryFile}`);
   if (detected.skillFile) console.log(`  Skill:   ${detected.skillFile}`);

--- a/src/init/detect-project.ts
+++ b/src/init/detect-project.ts
@@ -108,11 +108,16 @@ export function detectProject(dir: string): DetectedProject {
       confidence = 'high';
       signals.push('Cargo.toml: [lib] section');
       entryFile = 'src/lib.rs';
-    } else {
-      surface = existsSync(join(dir, 'src', 'main.rs')) ? 'cli' : 'sdk';
+    } else if (existsSync(join(dir, 'src', 'main.rs'))) {
+      surface = 'cli';
       confidence = 'medium';
-      signals.push('Cargo.toml: inferred from src/main.rs existence');
-      entryFile = surface === 'cli' ? 'src/main.rs' : 'src/lib.rs';
+      signals.push('Cargo.toml: inferred cli from src/main.rs existence');
+      entryFile = 'src/main.rs';
+    } else {
+      surface = 'sdk';
+      confidence = 'medium';
+      signals.push('Cargo.toml: no [[bin]] or [lib] found, no src/main.rs — defaulting to sdk');
+      entryFile = 'src/lib.rs';
     }
   }
 

--- a/src/init/scaffold.ts
+++ b/src/init/scaffold.ts
@@ -1,11 +1,14 @@
 import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
-import { resolve, basename } from 'node:path';
+import { resolve, relative, join, basename } from 'node:path';
 import type { WizardAnswers } from './answers.js';
 import { importCommands } from '../import/index.js';
 
-export function buildConfigFromAnswers(answers: WizardAnswers): object {
+export function buildConfigFromAnswers(answers: WizardAnswers, configDir: string): object {
   const { surface, repoPath, models, maxTasks, maxIterations, name } = answers;
   const projectName = name ?? basename(repoPath);
+
+  // Paths stored in the JSON are relative to configDir so the config is portable
+  const relRepo = relative(configDir, repoPath) || '.';
 
   const commonBenchmark = {
     apiKeyEnv: 'OPENROUTER_API_KEY',
@@ -22,7 +25,7 @@ export function buildConfigFromAnswers(answers: WizardAnswers): object {
       ? 'openrouter/anthropic/claude-sonnet-4-6'
       : models[0]!,
     apiKeyEnv: 'OPENROUTER_API_KEY',
-    allowedPaths: ['../SKILL.md'],
+    allowedPaths: [join(relRepo, 'SKILL.md')],
     validation: [],
     maxIterations,
   };
@@ -32,26 +35,26 @@ export function buildConfigFromAnswers(answers: WizardAnswers): object {
       name: projectName,
       target: {
         surface: 'sdk',
-        repoPath,
-        skill: resolve(repoPath, 'SKILL.md'),
-        discovery: { mode: 'auto', sources: [resolve(repoPath, 'src/index.ts')] },
+        repoPath: relRepo,
+        skill: join(relRepo, 'SKILL.md'),
+        discovery: { mode: 'auto', sources: [join(relRepo, 'src/index.ts')] },
       },
       benchmark: commonBenchmark,
       optimize: commonOptimize,
     };
   }
 
+  const defaultEntry = surface === 'cli' ? 'src/cli.ts' : 'src/server.ts';
+  const entryRelative = answers.entryFile ?? defaultEntry;
+
   if (surface === 'cli') {
     return {
       name: projectName,
       target: {
         surface: 'cli',
-        repoPath,
-        skill: resolve(repoPath, 'SKILL.md'),
-        discovery: {
-          mode: 'auto',
-          sources: [answers.entryFile ? resolve(repoPath, answers.entryFile) : resolve(repoPath, 'src/cli.ts')],
-        },
+        repoPath: relRepo,
+        skill: join(relRepo, 'SKILL.md'),
+        discovery: { mode: 'auto', sources: [join(relRepo, entryRelative)] },
         cli: { commands: './.skill-optimizer/cli-commands.json' },
       },
       benchmark: commonBenchmark,
@@ -64,12 +67,9 @@ export function buildConfigFromAnswers(answers: WizardAnswers): object {
     name: projectName,
     target: {
       surface: 'mcp',
-      repoPath,
-      skill: resolve(repoPath, 'SKILL.md'),
-      discovery: {
-        mode: 'auto',
-        sources: [answers.entryFile ? resolve(repoPath, answers.entryFile) : resolve(repoPath, 'src/server.ts')],
-      },
+      repoPath: relRepo,
+      skill: join(relRepo, 'SKILL.md'),
+      discovery: { mode: 'auto', sources: [join(relRepo, entryRelative)] },
       mcp: { tools: './.skill-optimizer/tools.json' },
     },
     benchmark: commonBenchmark,
@@ -87,7 +87,7 @@ export async function scaffoldInit(answers: WizardAnswers, cwd: string): Promise
   if (existsSync(configPath)) {
     console.log(`[init] Skipping ${configPath} (already exists)`);
   } else {
-    writeFileSync(configPath, JSON.stringify(buildConfigFromAnswers(answers), null, 2) + '\n', 'utf-8');
+    writeFileSync(configPath, JSON.stringify(buildConfigFromAnswers(answers, configDir), null, 2) + '\n', 'utf-8');
     console.log(`[init] Created ${configPath}`);
   }
 

--- a/src/init/scaffold.ts
+++ b/src/init/scaffold.ts
@@ -1,0 +1,200 @@
+import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { resolve, basename } from 'node:path';
+import type { WizardAnswers } from './answers.js';
+import { importCommands } from '../import/index.js';
+
+export function buildConfigFromAnswers(answers: WizardAnswers): object {
+  const { surface, repoPath, models, maxTasks, maxIterations, name } = answers;
+  const projectName = name ?? basename(repoPath);
+  const benchmarkModels = models.map(id => ({ id }));
+
+  const commonBenchmark = {
+    apiKeyEnv: 'OPENROUTER_API_KEY',
+    format: 'pi',
+    timeout: 240000,
+    taskGeneration: { enabled: true, maxTasks, outputDir: './.skill-optimizer' },
+    models: benchmarkModels,
+    output: { dir: '../benchmark-results' },
+    verdict: { perModelFloor: 0.6, targetWeightedAverage: 0.7 },
+  };
+
+  const optimizeModel = models.includes('openrouter/anthropic/claude-sonnet-4-6')
+    ? 'openrouter/anthropic/claude-sonnet-4-6'
+    : models[0]!;
+
+  const commonOptimize = {
+    model: optimizeModel,
+    apiKeyEnv: 'OPENROUTER_API_KEY',
+    allowedPaths: ['../SKILL.md'],
+    validation: [],
+    maxIterations,
+  };
+
+  if (surface === 'sdk') {
+    return {
+      name: projectName,
+      target: {
+        surface: 'sdk',
+        repoPath,
+        skill: resolve(repoPath, 'SKILL.md'),
+        discovery: { mode: 'auto', sources: [resolve(repoPath, 'src/index.ts')] },
+      },
+      benchmark: commonBenchmark,
+      optimize: commonOptimize,
+    };
+  }
+
+  if (surface === 'cli') {
+    const entrySource = answers.entryFile
+      ? resolve(repoPath, answers.entryFile)
+      : resolve(repoPath, 'src/cli.ts');
+    return {
+      name: projectName,
+      target: {
+        surface: 'cli',
+        repoPath,
+        skill: resolve(repoPath, 'SKILL.md'),
+        discovery: { mode: 'auto', sources: [entrySource] },
+        cli: { commands: './.skill-optimizer/cli-commands.json' },
+      },
+      benchmark: commonBenchmark,
+      optimize: commonOptimize,
+    };
+  }
+
+  // mcp
+  const entrySource = answers.entryFile
+    ? resolve(repoPath, answers.entryFile)
+    : resolve(repoPath, 'src/server.ts');
+  return {
+    name: projectName,
+    target: {
+      surface: 'mcp',
+      repoPath,
+      skill: resolve(repoPath, 'SKILL.md'),
+      discovery: { mode: 'auto', sources: [entrySource] },
+      mcp: { tools: './.skill-optimizer/tools.json' },
+    },
+    benchmark: commonBenchmark,
+    optimize: commonOptimize,
+  };
+}
+
+export async function scaffoldInit(answers: WizardAnswers, cwd: string): Promise<void> {
+  const configDir = resolve(cwd, 'skill-optimizer');
+  const generatedDir = resolve(configDir, '.skill-optimizer');
+  mkdirSync(configDir, { recursive: true });
+  mkdirSync(generatedDir, { recursive: true });
+
+  const configPath = resolve(configDir, 'skill-optimizer.json');
+  if (existsSync(configPath)) {
+    console.log(`[init] Skipping ${configPath} (already exists)`);
+  } else {
+    const config = buildConfigFromAnswers(answers);
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+    console.log(`[init] Created ${configPath}`);
+  }
+
+  if (answers.surface === 'cli') {
+    const commandsPath = resolve(generatedDir, 'cli-commands.json');
+    if (existsSync(commandsPath)) {
+      console.log(`[init] Skipping ${commandsPath} (already exists)`);
+    } else if (answers.entryFile) {
+      console.log(`[init] Running import-commands from ${answers.entryFile}...`);
+      try {
+        await importCommands({
+          from: answers.entryFile,
+          out: commandsPath,
+          scrape: false,
+          depth: 2,
+          cwd: answers.repoPath,
+        });
+      } catch (err) {
+        console.warn(`[init] Warning: import-commands failed: ${err instanceof Error ? err.message : err}`);
+        console.warn(`[init] Writing template cli-commands.json instead.`);
+        writeCliTemplate(commandsPath);
+      }
+    } else {
+      writeCliTemplate(commandsPath);
+    }
+  }
+
+  if (answers.surface === 'mcp') {
+    const toolsPath = resolve(generatedDir, 'tools.json');
+    if (!existsSync(toolsPath)) {
+      writeMcpTemplate(toolsPath);
+    }
+  }
+
+  printNextSteps(answers, configPath);
+}
+
+function writeCliTemplate(commandsPath: string): void {
+  const commands = [
+    {
+      command: 'example-create',
+      description: 'Create a new item',
+      options: [{ name: '--name', takesValue: true, description: 'Name for the item' }],
+    },
+    {
+      command: 'example-list',
+      description: 'List all items',
+      options: [{ name: '--format', takesValue: true, description: 'Output format: json | table (default: table)' }],
+    },
+  ];
+  writeFileSync(commandsPath, JSON.stringify(commands, null, 2) + '\n', 'utf-8');
+  console.log(`[init] Created ${commandsPath} (template — edit or run import-commands to replace)`);
+}
+
+function writeMcpTemplate(toolsPath: string): void {
+  const tools = [
+    {
+      type: 'function',
+      function: {
+        name: 'get_data',
+        description: 'Get data for a given item ID',
+        parameters: {
+          type: 'object',
+          properties: { item_id: { type: 'string', description: 'The item identifier' } },
+          required: ['item_id'],
+        },
+      },
+    },
+    {
+      type: 'function',
+      function: {
+        name: 'send_data',
+        description: 'Send data to a recipient',
+        parameters: {
+          type: 'object',
+          properties: {
+            value: { type: 'string', description: 'The data to send' },
+            recipient: { type: 'string', description: 'The recipient identifier' },
+          },
+          required: ['value', 'recipient'],
+        },
+      },
+    },
+  ];
+  writeFileSync(toolsPath, JSON.stringify(tools, null, 2) + '\n', 'utf-8');
+  console.log(`[init] Created ${toolsPath} (template — edit with your real tools)`);
+}
+
+function printNextSteps(answers: WizardAnswers, configPath: string): void {
+  console.log('\n[init] Done! Next steps:');
+  console.log(`  Config: ${configPath}`);
+  if (answers.surface === 'sdk') {
+    console.log('  1. Review target.discovery.sources in the config — points to your SDK entry file');
+  } else if (answers.surface === 'cli') {
+    if (answers.entryFile) {
+      console.log('  1. Review skill-optimizer/.skill-optimizer/cli-commands.json — auto-extracted from your CLI');
+    } else {
+      console.log('  1. Edit skill-optimizer/.skill-optimizer/cli-commands.json — replace template with real commands');
+      console.log('     Or run: skill-optimizer import-commands --from <entry-file>');
+    }
+  } else {
+    console.log('  1. Edit skill-optimizer/.skill-optimizer/tools.json — replace template with your real MCP tools');
+  }
+  console.log('  2. Add a SKILL.md to your repo root explaining the surface to the model');
+  console.log('  3. Run: skill-optimizer run --config ./skill-optimizer/skill-optimizer.json');
+}

--- a/src/init/scaffold.ts
+++ b/src/init/scaffold.ts
@@ -6,24 +6,21 @@ import { importCommands } from '../import/index.js';
 export function buildConfigFromAnswers(answers: WizardAnswers): object {
   const { surface, repoPath, models, maxTasks, maxIterations, name } = answers;
   const projectName = name ?? basename(repoPath);
-  const benchmarkModels = models.map(id => ({ id }));
 
   const commonBenchmark = {
     apiKeyEnv: 'OPENROUTER_API_KEY',
     format: 'pi',
     timeout: 240000,
     taskGeneration: { enabled: true, maxTasks, outputDir: './.skill-optimizer' },
-    models: benchmarkModels,
+    models: models.map(id => ({ id })),
     output: { dir: '../benchmark-results' },
     verdict: { perModelFloor: 0.6, targetWeightedAverage: 0.7 },
   };
 
-  const optimizeModel = models.includes('openrouter/anthropic/claude-sonnet-4-6')
-    ? 'openrouter/anthropic/claude-sonnet-4-6'
-    : models[0]!;
-
   const commonOptimize = {
-    model: optimizeModel,
+    model: models.includes('openrouter/anthropic/claude-sonnet-4-6')
+      ? 'openrouter/anthropic/claude-sonnet-4-6'
+      : models[0]!,
     apiKeyEnv: 'OPENROUTER_API_KEY',
     allowedPaths: ['../SKILL.md'],
     validation: [],
@@ -45,16 +42,16 @@ export function buildConfigFromAnswers(answers: WizardAnswers): object {
   }
 
   if (surface === 'cli') {
-    const entrySource = answers.entryFile
-      ? resolve(repoPath, answers.entryFile)
-      : resolve(repoPath, 'src/cli.ts');
     return {
       name: projectName,
       target: {
         surface: 'cli',
         repoPath,
         skill: resolve(repoPath, 'SKILL.md'),
-        discovery: { mode: 'auto', sources: [entrySource] },
+        discovery: {
+          mode: 'auto',
+          sources: [answers.entryFile ? resolve(repoPath, answers.entryFile) : resolve(repoPath, 'src/cli.ts')],
+        },
         cli: { commands: './.skill-optimizer/cli-commands.json' },
       },
       benchmark: commonBenchmark,
@@ -63,16 +60,16 @@ export function buildConfigFromAnswers(answers: WizardAnswers): object {
   }
 
   // mcp
-  const entrySource = answers.entryFile
-    ? resolve(repoPath, answers.entryFile)
-    : resolve(repoPath, 'src/server.ts');
   return {
     name: projectName,
     target: {
       surface: 'mcp',
       repoPath,
       skill: resolve(repoPath, 'SKILL.md'),
-      discovery: { mode: 'auto', sources: [entrySource] },
+      discovery: {
+        mode: 'auto',
+        sources: [answers.entryFile ? resolve(repoPath, answers.entryFile) : resolve(repoPath, 'src/server.ts')],
+      },
       mcp: { tools: './.skill-optimizer/tools.json' },
     },
     benchmark: commonBenchmark,
@@ -90,8 +87,7 @@ export async function scaffoldInit(answers: WizardAnswers, cwd: string): Promise
   if (existsSync(configPath)) {
     console.log(`[init] Skipping ${configPath} (already exists)`);
   } else {
-    const config = buildConfigFromAnswers(answers);
-    writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+    writeFileSync(configPath, JSON.stringify(buildConfigFromAnswers(answers), null, 2) + '\n', 'utf-8');
     console.log(`[init] Created ${configPath}`);
   }
 
@@ -121,7 +117,9 @@ export async function scaffoldInit(answers: WizardAnswers, cwd: string): Promise
 
   if (answers.surface === 'mcp') {
     const toolsPath = resolve(generatedDir, 'tools.json');
-    if (!existsSync(toolsPath)) {
+    if (existsSync(toolsPath)) {
+      console.log(`[init] Skipping ${toolsPath} (already exists)`);
+    } else {
       writeMcpTemplate(toolsPath);
     }
   }

--- a/src/init/wizard.ts
+++ b/src/init/wizard.ts
@@ -24,13 +24,13 @@ function cancelGuard<T>(value: T | symbol): T {
   return value as T;
 }
 
-export async function runWizard(cwd: string, preseedSurface?: 'sdk' | 'cli' | 'mcp'): Promise<void> {
+export async function runWizard(cwd: string, preseed?: Partial<WizardAnswers>): Promise<void> {
   p.intro('skill-optimizer init');
 
   // 1. Surface
   let surface: 'sdk' | 'cli' | 'mcp';
-  if (preseedSurface) {
-    surface = preseedSurface;
+  if (preseed?.surface) {
+    surface = preseed.surface;
     p.log.info(`Surface: ${surface}`);
   } else {
     surface = cancelGuard(await p.select({
@@ -46,11 +46,11 @@ export async function runWizard(cwd: string, preseedSurface?: 'sdk' | 'cli' | 'm
   // 2. Target repo path
   const repoPathRaw = cancelGuard(await p.text({
     message: 'Target repo path (absolute):',
-    defaultValue: cwd,
-    placeholder: cwd,
+    defaultValue: preseed?.repoPath ?? cwd,
+    placeholder: preseed?.repoPath ?? cwd,
     validate: (v) => (v !== undefined && v.trim().length === 0 ? 'Required — enter the absolute path to your project' : undefined),
   }) as string);
-  const repoPath = resolve(repoPathRaw.trim() || cwd);
+  const repoPath = resolve(repoPathRaw.trim() || preseed?.repoPath || cwd);
 
   // 3. Models (multi-select)
   const selectedPresets = cancelGuard(await p.multiselect({
@@ -106,11 +106,11 @@ export async function runWizard(cwd: string, preseedSurface?: 'sdk' | 'cli' | 'm
       ? 'Path to CLI entry file or binary (relative to repo, leave blank to skip):'
       : 'Path to MCP server entry file (relative to repo, leave blank to skip):';
     const placeholder = surface === 'cli' ? 'src/cli.ts' : 'src/server.ts';
-    const raw = cancelGuard(await p.text({ message, placeholder }) as string);
-    entryFile = raw.trim() || undefined;
+    const raw = cancelGuard(await p.text({ message, placeholder, defaultValue: preseed?.entryFile }) as string);
+    entryFile = raw.trim() || preseed?.entryFile || undefined;
   }
 
-  const answers: WizardAnswers = { surface, repoPath, models, maxTasks, maxIterations, entryFile };
+  const answers: WizardAnswers = { surface, repoPath, models, maxTasks, maxIterations, entryFile, name: preseed?.name };
 
   const spinner = p.spinner();
   spinner.start('Scaffolding...');

--- a/src/init/wizard.ts
+++ b/src/init/wizard.ts
@@ -59,7 +59,7 @@ export async function runWizard(cwd: string, preseedSurface?: 'sdk' | 'cli' | 'm
     required: true,
     initialValues: ['openrouter/anthropic/claude-sonnet-4-6', 'openrouter/google/gemini-2.0-flash-001'],
   }) as string[]);
-  const models: string[] = [...selectedPresets];
+  const models: string[] = selectedPresets;
 
   // Optional custom model
   const customModel = cancelGuard(await p.text({
@@ -99,21 +99,14 @@ export async function runWizard(cwd: string, preseedSurface?: 'sdk' | 'cli' | 'm
   }) as string);
   const maxIterations = parseInt(maxIterationsRaw || '5', 10);
 
-  // 6. Entry file (cli / mcp)
+  // 6. Entry file (cli / mcp only)
   let entryFile: string | undefined;
-  if (surface === 'cli') {
-    const raw = cancelGuard(await p.text({
-      message: 'Path to CLI entry file or binary (relative to repo, leave blank to skip):',
-      placeholder: 'src/cli.ts',
-      validate: () => undefined,
-    }) as string);
-    entryFile = raw.trim() || undefined;
-  } else if (surface === 'mcp') {
-    const raw = cancelGuard(await p.text({
-      message: 'Path to MCP server entry file (relative to repo, leave blank to skip):',
-      placeholder: 'src/server.ts',
-      validate: () => undefined,
-    }) as string);
+  if (surface === 'cli' || surface === 'mcp') {
+    const message = surface === 'cli'
+      ? 'Path to CLI entry file or binary (relative to repo, leave blank to skip):'
+      : 'Path to MCP server entry file (relative to repo, leave blank to skip):';
+    const placeholder = surface === 'cli' ? 'src/cli.ts' : 'src/server.ts';
+    const raw = cancelGuard(await p.text({ message, placeholder }) as string);
     entryFile = raw.trim() || undefined;
   }
 

--- a/src/init/wizard.ts
+++ b/src/init/wizard.ts
@@ -1,0 +1,134 @@
+import * as p from '@clack/prompts';
+import { resolve } from 'node:path';
+import type { WizardAnswers } from './answers.js';
+import { scaffoldInit } from './scaffold.js';
+
+export const MODEL_PRESETS = [
+  { value: 'openrouter/anthropic/claude-sonnet-4-6', label: 'Claude Sonnet 4.6  · Anthropic', hint: 'recommended' },
+  { value: 'openrouter/anthropic/claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5   · Anthropic', hint: 'fast' },
+  { value: 'openrouter/openai/gpt-4o', label: 'GPT-4o             · OpenAI' },
+  { value: 'openrouter/openai/gpt-4o-mini', label: 'GPT-4o Mini        · OpenAI', hint: 'fast' },
+  { value: 'openrouter/google/gemini-2.5-pro-preview', label: 'Gemini 2.5 Pro     · Google' },
+  { value: 'openrouter/google/gemini-2.0-flash-001', label: 'Gemini 2.0 Flash   · Google', hint: 'fast' },
+  { value: 'openrouter/meta-llama/llama-3.3-70b-instruct', label: 'Llama 3.3 70B      · Meta', hint: 'open' },
+  { value: 'openrouter/mistralai/mistral-large-2411', label: 'Mistral Large      · Mistral' },
+  { value: 'openrouter/deepseek/deepseek-chat', label: 'DeepSeek Chat      · DeepSeek', hint: 'open' },
+  { value: 'openrouter/qwen/qwen-2.5-72b-instruct', label: 'Qwen 2.5 72B       · Alibaba', hint: 'open' },
+];
+
+function cancelGuard<T>(value: T | symbol): T {
+  if (p.isCancel(value)) {
+    p.cancel('Cancelled.');
+    process.exit(0);
+  }
+  return value as T;
+}
+
+export async function runWizard(cwd: string, preseedSurface?: 'sdk' | 'cli' | 'mcp'): Promise<void> {
+  p.intro('skill-optimizer init');
+
+  // 1. Surface
+  let surface: 'sdk' | 'cli' | 'mcp';
+  if (preseedSurface) {
+    surface = preseedSurface;
+    p.log.info(`Surface: ${surface}`);
+  } else {
+    surface = cancelGuard(await p.select({
+      message: 'What surface are you targeting?',
+      options: [
+        { value: 'sdk', label: 'sdk', hint: 'TypeScript / Python / Rust library' },
+        { value: 'cli', label: 'cli', hint: 'command-line tool with subcommands' },
+        { value: 'mcp', label: 'mcp', hint: 'MCP server with tools' },
+      ],
+    }) as 'sdk' | 'cli' | 'mcp');
+  }
+
+  // 2. Target repo path
+  const repoPathRaw = cancelGuard(await p.text({
+    message: 'Target repo path (absolute):',
+    defaultValue: cwd,
+    placeholder: cwd,
+    validate: (v) => (v !== undefined && v.trim().length === 0 ? 'Required — enter the absolute path to your project' : undefined),
+  }) as string);
+  const repoPath = resolve(repoPathRaw.trim() || cwd);
+
+  // 3. Models (multi-select)
+  const selectedPresets = cancelGuard(await p.multiselect({
+    message: 'Which models to benchmark? (space to toggle, enter to confirm)',
+    options: MODEL_PRESETS,
+    required: true,
+    initialValues: ['openrouter/anthropic/claude-sonnet-4-6', 'openrouter/google/gemini-2.0-flash-001'],
+  }) as string[]);
+  const models: string[] = [...selectedPresets];
+
+  // Optional custom model
+  const customModel = cancelGuard(await p.text({
+    message: 'Add a custom model ID? (leave blank to skip)',
+    placeholder: 'openrouter/provider/model-name',
+    validate: (v) => {
+      if (!v || !v.trim()) return undefined;
+      if (!v.startsWith('openrouter/')) return 'Must start with openrouter/';
+      return undefined;
+    },
+  }) as string);
+  if (customModel.trim()) models.push(customModel.trim());
+
+  // 4. Max tasks
+  const maxTasksRaw = cancelGuard(await p.text({
+    message: 'Max tasks to generate per benchmark run:',
+    defaultValue: '20',
+    placeholder: '20',
+    validate: (v) => {
+      const n = parseInt(v ?? '', 10);
+      if (isNaN(n) || n < 1) return 'Must be a positive integer';
+      return undefined;
+    },
+  }) as string);
+  const maxTasks = parseInt(maxTasksRaw || '20', 10);
+
+  // 5. Max iterations
+  const maxIterationsRaw = cancelGuard(await p.text({
+    message: 'Max optimize iterations:',
+    defaultValue: '5',
+    placeholder: '5',
+    validate: (v) => {
+      const n = parseInt(v ?? '', 10);
+      if (isNaN(n) || n < 1) return 'Must be a positive integer';
+      return undefined;
+    },
+  }) as string);
+  const maxIterations = parseInt(maxIterationsRaw || '5', 10);
+
+  // 6. Entry file (cli / mcp)
+  let entryFile: string | undefined;
+  if (surface === 'cli') {
+    const raw = cancelGuard(await p.text({
+      message: 'Path to CLI entry file or binary (relative to repo, leave blank to skip):',
+      placeholder: 'src/cli.ts',
+      validate: () => undefined,
+    }) as string);
+    entryFile = raw.trim() || undefined;
+  } else if (surface === 'mcp') {
+    const raw = cancelGuard(await p.text({
+      message: 'Path to MCP server entry file (relative to repo, leave blank to skip):',
+      placeholder: 'src/server.ts',
+      validate: () => undefined,
+    }) as string);
+    entryFile = raw.trim() || undefined;
+  }
+
+  const answers: WizardAnswers = { surface, repoPath, models, maxTasks, maxIterations, entryFile };
+
+  const spinner = p.spinner();
+  spinner.start('Scaffolding...');
+  try {
+    await scaffoldInit(answers, cwd);
+    spinner.stop('Done!');
+  } catch (err) {
+    spinner.stop('Error during scaffolding');
+    p.log.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
+  p.outro('Config written. Next: skill-optimizer run --config ./skill-optimizer/skill-optimizer.json');
+}

--- a/src/project/schema.ts
+++ b/src/project/schema.ts
@@ -1,7 +1,7 @@
 // src/project/schema.ts
 // Zod schema for config documentation generation only.
 // Runtime validation stays in src/project/validate.ts.
-import { z } from 'zod';
+import { z } from 'zod/v3';
 
 const ModelConfigSchema = z.object({
   id: z.string().describe('OpenRouter model ID, e.g. openrouter/anthropic/claude-sonnet-4-6'),

--- a/src/project/schema.ts
+++ b/src/project/schema.ts
@@ -1,0 +1,94 @@
+// src/project/schema.ts
+// Zod schema for config documentation generation only.
+// Runtime validation stays in src/project/validate.ts.
+import { z } from 'zod';
+
+const ModelConfigSchema = z.object({
+  id: z.string().describe('OpenRouter model ID, e.g. openrouter/anthropic/claude-sonnet-4-6'),
+  name: z.string().describe('Human-readable model name for reports'),
+  tier: z.enum(['flagship', 'mid', 'low']).optional().describe('Model tier — affects weighting in weighted average'),
+  weight: z.number().optional().describe('Weight in weighted average (default 1.0). Higher = more influence'),
+});
+
+const DiscoveryConfigSchema = z.object({
+  mode: z.enum(['auto', 'manifest']).optional().describe('"auto" = code-first tree-sitter; "manifest" = use provided file only'),
+  sources: z.array(z.string()).optional().describe('Source files to scan for callable methods/commands/tools'),
+  fallbackManifest: z.string().optional().describe('Path to manifest JSON when code-first discovery is incomplete'),
+  language: z.enum(['typescript', 'python', 'rust']).optional().describe('Language for code-first discovery'),
+});
+
+const SdkConfigSchema = z.object({
+  language: z.enum(['typescript', 'python', 'rust']).optional().describe('SDK language'),
+  entrypoints: z.array(z.string()).optional().describe('SDK entry files for discovery'),
+});
+
+const CliConfigSchema = z.object({
+  commands: z.string().optional().describe('Path to CLI commands manifest JSON (CliCommandDefinition[])'),
+});
+
+const McpConfigSchema = z.object({
+  tools: z.string().optional().describe('Path to MCP tools manifest JSON (OpenAI function tool definitions)'),
+});
+
+const ScopeConfigSchema = z.object({
+  include: z.array(z.string()).optional().describe('Glob patterns for actions to include (default ["*"])'),
+  exclude: z.array(z.string()).optional().describe('Glob patterns for actions to exclude (default [])'),
+});
+
+const TargetConfigSchema = z.object({
+  surface: z.enum(['sdk', 'cli', 'mcp']).describe('Type of callable surface'),
+  repoPath: z.string().optional().describe('Path to the target repo (default ".")'),
+  skill: z.union([
+    z.string(),
+    z.object({ source: z.string(), cache: z.boolean().optional() }),
+  ]).optional().describe('Path to SKILL.md or { source, cache } object'),
+  discovery: DiscoveryConfigSchema.optional().describe('How to discover callable actions'),
+  sdk: SdkConfigSchema.optional().describe('SDK-specific config'),
+  cli: CliConfigSchema.optional().describe('CLI-specific config'),
+  mcp: McpConfigSchema.optional().describe('MCP-specific config'),
+  scope: ScopeConfigSchema.optional().describe('Scope filter — which actions to benchmark'),
+});
+
+const TaskGenerationConfigSchema = z.object({
+  enabled: z.boolean().optional().describe('Whether to generate tasks automatically (default false)'),
+  maxTasks: z.number().int().positive().optional().describe('Max tasks to generate — must be >= in-scope action count (default 10)'),
+  seed: z.number().int().nonnegative().optional().describe('RNG seed for reproducible generation (default 1)'),
+  outputDir: z.string().optional().describe('Where to write generated task artifacts (default ".skill-optimizer")'),
+});
+
+const VerdictConfigSchema = z.object({
+  perModelFloor: z.number().min(0).max(1).optional().describe('Minimum per-model pass fraction for PASS verdict (default 0.6)'),
+  targetWeightedAverage: z.number().min(0).max(1).optional().describe('Minimum weighted average across all models for PASS (default 0.7)'),
+});
+
+const BenchmarkConfigSchema = z.object({
+  format: z.enum(['pi', 'openai', 'anthropic']).optional().describe('LLM transport format: pi, openai, or anthropic'),
+  apiKeyEnv: z.string().optional().describe('Env var name for the API key (default OPENROUTER_API_KEY)'),
+  timeout: z.number().int().positive().optional().describe('Milliseconds per model call (default 240000)'),
+  models: z.array(ModelConfigSchema).describe('Models to benchmark — at least one required'),
+  taskGeneration: TaskGenerationConfigSchema.optional().describe('Automatic task generation config'),
+  output: z.object({
+    dir: z.string().optional().describe('Directory where reports are saved (default "benchmark-results/")'),
+  }).optional(),
+  verdict: VerdictConfigSchema.optional().describe('PASS/FAIL thresholds'),
+});
+
+const OptimizeConfigSchema = z.object({
+  model: z.string().optional().describe('Model for mutation, e.g. openrouter/anthropic/claude-sonnet-4-6'),
+  apiKeyEnv: z.string().optional().describe('Env var for the optimizer API key'),
+  thinkingLevel: z.enum(['off', 'minimal', 'low', 'medium', 'high', 'xhigh']).optional()
+    .describe('Reasoning depth for mutation calls (default "medium")'),
+  allowedPaths: z.array(z.string()).optional().describe('Paths the optimizer may edit — safety boundary'),
+  validation: z.array(z.string()).optional().describe('Shell commands to run to validate each mutation'),
+  requireCleanGit: z.boolean().optional().describe('Require clean git state before starting (default true)'),
+  maxIterations: z.number().int().positive().optional().describe('Maximum optimization iterations (default 5)'),
+  minImprovement: z.number().nonnegative().optional().describe('Minimum weighted-average gain per accepted iteration (default 0.02)'),
+  reportContextMaxBytes: z.number().int().positive().optional().describe('Byte budget for mutation context (default 16000)'),
+});
+
+export const ProjectConfigSchema = z.object({
+  name: z.string().describe('Human-readable project name'),
+  target: TargetConfigSchema.describe('Target surface configuration'),
+  benchmark: BenchmarkConfigSchema.describe('Benchmark configuration'),
+  optimize: OptimizeConfigSchema.optional().describe('Optimizer configuration (optional)'),
+});

--- a/src/project/schema.ts
+++ b/src/project/schema.ts
@@ -69,7 +69,7 @@ const BenchmarkConfigSchema = z.object({
   taskGeneration: TaskGenerationConfigSchema.optional().describe('Automatic task generation config'),
   output: z.object({
     dir: z.string().optional().describe('Directory where reports are saved (default "benchmark-results/")'),
-  }).optional(),
+  }).optional().describe('Output configuration'),
   verdict: VerdictConfigSchema.optional().describe('PASS/FAIL thresholds'),
 });
 

--- a/tests/fixtures/import-commands/argparse-sample.py
+++ b/tests/fixtures/import-commands/argparse-sample.py
@@ -1,0 +1,13 @@
+import argparse
+
+parser = argparse.ArgumentParser(description='CLI tool')
+subparsers = parser.add_subparsers(dest='command')
+
+create_parser = subparsers.add_parser('create', help='Create a new item')
+create_parser.add_argument('--name', help='Item name')
+create_parser.add_argument('--count', type=int, help='Count')
+
+list_parser = subparsers.add_parser('list', help='List all items')
+list_parser.add_argument('--limit', type=int, help='Max results')
+
+args = parser.parse_args()

--- a/tests/fixtures/import-commands/clap-sample.rs
+++ b/tests/fixtures/import-commands/clap-sample.rs
@@ -1,0 +1,17 @@
+use clap::{Command, Arg};
+
+fn main() {
+    let matches = Command::new("mycli")
+        .subcommand(
+            Command::new("create")
+                .about("Create a new item")
+                .arg(Arg::new("name").long("name").help("Item name").required(false))
+                .arg(Arg::new("verbose").long("verbose").help("Verbose output").action(clap::ArgAction::SetTrue))
+        )
+        .subcommand(
+            Command::new("delete")
+                .about("Delete an item")
+                .arg(Arg::new("id").long("id").help("Item ID").required(true))
+        )
+        .get_matches();
+}

--- a/tests/fixtures/import-commands/click-sample.py
+++ b/tests/fixtures/import-commands/click-sample.py
@@ -1,0 +1,23 @@
+import click
+
+@click.group()
+def cli():
+    """CLI app."""
+    pass
+
+@cli.command()
+@click.option('--name', help='Item name')
+@click.option('--verbose', is_flag=True, help='Verbose output')
+def create(name, verbose):
+    """Create a new item."""
+    pass
+
+@cli.command()
+@click.argument('item_id')
+@click.option('--force', is_flag=True, help='Skip confirmation')
+def delete(item_id, force):
+    """Delete an item."""
+    pass
+
+if __name__ == '__main__':
+    cli()

--- a/tests/fixtures/import-commands/commander-sample.ts
+++ b/tests/fixtures/import-commands/commander-sample.ts
@@ -1,0 +1,23 @@
+import { Command } from 'commander';
+
+const program = new Command();
+
+program
+  .command('create')
+  .description('Create a new item')
+  .option('--name <value>', 'Item name')
+  .option('--dry-run', 'Preview only')
+  .action(() => {});
+
+program
+  .command('delete <id>')
+  .description('Delete an item by ID')
+  .action(() => {});
+
+program
+  .command('list')
+  .description('List all items')
+  .option('--limit <n>', 'Max results')
+  .action(() => {});
+
+program.parse(process.argv);

--- a/tests/fixtures/import-commands/help-output-account.txt
+++ b/tests/fixtures/import-commands/help-output-account.txt
@@ -1,0 +1,9 @@
+Usage: fast-cli account [options] [command]
+
+Commands:
+  create       Create a new account
+  list         List all accounts
+  delete <name>  Delete an account
+
+Options:
+  -h, --help  output usage information

--- a/tests/fixtures/import-commands/help-output-sample.txt
+++ b/tests/fixtures/import-commands/help-output-sample.txt
@@ -1,0 +1,13 @@
+Usage: fast-cli [options] [command]
+
+Commands:
+  account     Account management
+  network     Network management
+  send        Send tokens
+  fund        Fund account
+  pay         Pay a URL
+  help [cmd]  display help for [cmd]
+
+Options:
+  -h, --help     output usage information
+  -V, --version  output the version number

--- a/tests/fixtures/import-commands/yargs-sample.ts
+++ b/tests/fixtures/import-commands/yargs-sample.ts
@@ -1,0 +1,18 @@
+import yargs from 'yargs';
+
+yargs
+  .command(
+    'create',
+    'Create a new item',
+    (y) => y
+      .option('name', { describe: 'Item name', type: 'string' })
+      .option('verbose', { describe: 'Verbose output', type: 'boolean' }),
+    (_argv) => {},
+  )
+  .command(
+    'delete <id>',
+    'Delete an item',
+    (y) => y.positional('id', { describe: 'Item ID', type: 'string' }),
+    (_argv) => {},
+  )
+  .parse();

--- a/tests/smoke-code.ts
+++ b/tests/smoke-code.ts
@@ -319,7 +319,7 @@ await test('initBenchmark cli: creates cli-commands.json and sets target.cli.com
   try {
     initBenchmark(dir, 'cli');
     const configPath = join(dir, 'skill-optimizer', 'skill-optimizer.json');
-    const commandsPath = join(dir, 'skill-optimizer', 'cli-commands.json');
+    const commandsPath = join(dir, 'skill-optimizer', '.skill-optimizer', 'cli-commands.json');
     const config = JSON.parse(readFileSync(configPath, 'utf-8')) as {
       target: { surface: string; cli?: { commands?: string } };
       benchmark: { taskGeneration?: { enabled?: boolean }; tasks?: string };
@@ -339,7 +339,7 @@ await test('initBenchmark mcp: creates tools.json and sets target.mcp.tools', ()
   try {
     initBenchmark(dir, 'mcp');
     const configPath = join(dir, 'skill-optimizer', 'skill-optimizer.json');
-    const toolsPath = join(dir, 'skill-optimizer', 'tools.json');
+    const toolsPath = join(dir, 'skill-optimizer', '.skill-optimizer', 'tools.json');
     const config = JSON.parse(readFileSync(configPath, 'utf-8')) as {
       target: { surface: string; mcp?: { tools?: string } };
       benchmark: { taskGeneration?: { enabled?: boolean }; tasks?: string };

--- a/tests/smoke-import.ts
+++ b/tests/smoke-import.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { CliCommandDefinition } from '../src/import/types.js';
 import { writeOutput } from '../src/import/output.js';
+import { parseHelpOutput } from '../src/import/extractors/help-scraper.js';
 
 // === Types check ===
 const _typeCheck: CliCommandDefinition = { command: 'create', description: 'Create item' };
@@ -23,28 +24,21 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
   assert.strictEqual(written[0]!.command, 'create');
 }
 
-import { parseHelpOutput } from '../src/import/extractors/help-scraper.js';
-import { readFileSync } from 'node:fs';
-
 // === help-scraper: parseHelpOutput (root) ===
 {
   const rootHelp = readFileSync('tests/fixtures/import-commands/help-output-sample.txt', 'utf-8');
   const commands = parseHelpOutput(rootHelp, []);
-  // Should find: account, network, send, fund, pay (5 commands; skip "help" as it starts with 'h' not '-')
-  // Actually "help" is a valid command name — should be 6. But "help [cmd]" — the name is "help" without brackets.
-  // Filter: exclude "help" since it's a meta-command? No — just parse everything non-dash.
-  // Expected: at minimum 5 real commands (account, network, send, fund, pay). "help" may or may not be included.
-  assert.ok(commands.length >= 5, `Expected >=5 commands, got ${commands.length}: ${commands.map(c=>c.command).join(', ')}`);
+  assert.ok(commands.length >= 5, `Expected >=5 commands, got ${commands.length}: ${commands.map(c => c.command).join(', ')}`);
   const accountCmd = commands.find(c => c.command === 'account');
   assert.ok(accountCmd !== undefined, 'Should find "account" command');
   assert.strictEqual(accountCmd?.description, 'Account management');
 }
 
-// === help-scraper: parseHelpOutput (subcommand) ===
+// === help-scraper: parseHelpOutput (subcommand with prefix) ===
 {
   const subHelp = readFileSync('tests/fixtures/import-commands/help-output-account.txt', 'utf-8');
   const commands = parseHelpOutput(subHelp, ['account']);
-  assert.strictEqual(commands.length, 3, `Expected 3, got ${commands.length}: ${commands.map(c=>c.command).join(', ')}`);
+  assert.strictEqual(commands.length, 3, `Expected 3, got ${commands.length}: ${commands.map(c => c.command).join(', ')}`);
   assert.ok(commands.find(c => c.command === 'account create') !== undefined);
   assert.ok(commands.find(c => c.command === 'account delete') !== undefined);
 }

--- a/tests/smoke-import.ts
+++ b/tests/smoke-import.ts
@@ -8,6 +8,7 @@ import { parseHelpOutput } from '../src/import/extractors/help-scraper.js';
 import { extractCommander } from '../src/import/extractors/ts-commander.js';
 import { extractYargs } from '../src/import/extractors/ts-yargs.js';
 import { extractClick } from '../src/import/extractors/py-click.js';
+import { extractArgparse } from '../src/import/extractors/py-argparse.js';
 
 // === Types check ===
 const _typeCheck: CliCommandDefinition = { command: 'create', description: 'Create item' };
@@ -110,6 +111,25 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
 
   const deleteCmd = commands.find(c => c.command === 'delete');
   assert.ok(deleteCmd !== undefined, 'Should find "delete" command');
+}
+
+// === py-argparse extractor ===
+{
+  const fixturePath = join('tests/fixtures/import-commands/argparse-sample.py');
+  const commands = await extractArgparse(fixturePath);
+  assert.strictEqual(commands.length, 2, `Expected 2 commands, got ${commands.length}: ${commands.map(c => c.command).join(', ')}`);
+
+  const create = commands.find(c => c.command === 'create');
+  assert.ok(create !== undefined, 'Should find "create" command');
+  assert.strictEqual(create?.description, 'Create a new item');
+
+  const nameOpt = create?.options?.find(o => o.name === '--name');
+  assert.ok(nameOpt !== undefined, 'Should find --name option');
+  assert.strictEqual(nameOpt?.takesValue, true);
+
+  const listCmd = commands.find(c => c.command === 'list');
+  assert.ok(listCmd !== undefined, 'Should find "list" command');
+  assert.strictEqual(listCmd?.description, 'List all items');
 }
 
 console.log('smoke-import: all tests passed');

--- a/tests/smoke-import.ts
+++ b/tests/smoke-import.ts
@@ -9,6 +9,7 @@ import { extractCommander } from '../src/import/extractors/ts-commander.js';
 import { extractYargs } from '../src/import/extractors/ts-yargs.js';
 import { extractClick } from '../src/import/extractors/py-click.js';
 import { extractArgparse } from '../src/import/extractors/py-argparse.js';
+import { extractClap } from '../src/import/extractors/rs-clap.js';
 
 // === Types check ===
 const _typeCheck: CliCommandDefinition = { command: 'create', description: 'Create item' };
@@ -130,6 +131,28 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
   const listCmd = commands.find(c => c.command === 'list');
   assert.ok(listCmd !== undefined, 'Should find "list" command');
   assert.strictEqual(listCmd?.description, 'List all items');
+}
+
+// === rs-clap extractor ===
+{
+  const fixturePath = join('tests/fixtures/import-commands/clap-sample.rs');
+  const commands = await extractClap(fixturePath);
+  assert.ok(commands.length >= 2, `Expected >=2 commands, got ${commands.length}`);
+
+  const create = commands.find(c => c.command === 'create');
+  assert.ok(create !== undefined, 'Should find "create" command');
+  assert.strictEqual(create?.description, 'Create a new item');
+
+  const nameOpt = create?.options?.find(o => o.name === '--name');
+  assert.ok(nameOpt !== undefined, 'Should find --name option');
+  assert.strictEqual(nameOpt?.takesValue, true);
+
+  const verboseOpt = create?.options?.find(o => o.name === '--verbose');
+  assert.ok(verboseOpt !== undefined, 'Should find --verbose option');
+  assert.strictEqual(verboseOpt?.takesValue, false); // SetTrue → takesValue false
+
+  const deleteCmd = commands.find(c => c.command === 'delete');
+  assert.ok(deleteCmd !== undefined, 'Should find "delete" command');
 }
 
 console.log('smoke-import: all tests passed');

--- a/tests/smoke-import.ts
+++ b/tests/smoke-import.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'node:assert';
-import { mkdtempSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { mkdtempSync, existsSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { CliCommandDefinition } from '../src/import/types.js';
@@ -24,7 +24,7 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
   const commands: CliCommandDefinition[] = [
     { command: 'create', description: 'Create item', options: [{ name: '--name', takesValue: true }] },
   ];
-  await writeOutput(commands, outPath);
+  writeOutput(commands, outPath);
   assert.strictEqual(existsSync(outPath), true);
   const written = JSON.parse(readFileSync(outPath, 'utf-8')) as CliCommandDefinition[];
   assert.strictEqual(written.length, 1);
@@ -45,9 +45,13 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
 {
   const subHelp = readFileSync('tests/fixtures/import-commands/help-output-account.txt', 'utf-8');
   const commands = parseHelpOutput(subHelp, ['account']);
-  assert.strictEqual(commands.length, 3, `Expected 3, got ${commands.length}: ${commands.map(c => c.command).join(', ')}`);
+  // 3 subcommands + 1 synthetic parent entry with options
+  assert.ok(commands.length >= 3, `Expected >=3, got ${commands.length}: ${commands.map(c => c.command).join(', ')}`);
   assert.ok(commands.find(c => c.command === 'account create') !== undefined);
   assert.ok(commands.find(c => c.command === 'account delete') !== undefined);
+  // Parent entry includes options from the page
+  const parent = commands.find(c => c.command === 'account');
+  assert.ok(parent !== undefined, 'Should find synthetic parent "account" entry with options');
 }
 
 // === ts-commander extractor ===
@@ -106,11 +110,11 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
 
   const nameOpt = create?.options?.find(o => o.name === '--name');
   assert.ok(nameOpt !== undefined, 'Should find --name option');
-  assert.strictEqual(nameOpt?.takesValue, true);  // no is_flag → takesValue true
+  assert.strictEqual(nameOpt?.takesValue, true);
 
   const verboseOpt = create?.options?.find(o => o.name === '--verbose');
   assert.ok(verboseOpt !== undefined, 'Should find --verbose option');
-  assert.strictEqual(verboseOpt?.takesValue, false);  // is_flag=True → takesValue false
+  assert.strictEqual(verboseOpt?.takesValue, false);
 
   const deleteCmd = commands.find(c => c.command === 'delete');
   assert.ok(deleteCmd !== undefined, 'Should find "delete" command');
@@ -151,7 +155,7 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
 
   const verboseOpt = create?.options?.find(o => o.name === '--verbose');
   assert.ok(verboseOpt !== undefined, 'Should find --verbose option');
-  assert.strictEqual(verboseOpt?.takesValue, false); // SetTrue → takesValue false
+  assert.strictEqual(verboseOpt?.takesValue, false);
 
   const deleteCmd = commands.find(c => c.command === 'delete');
   assert.ok(deleteCmd !== undefined, 'Should find "delete" command');
@@ -171,6 +175,11 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
 {
   const result = detectFramework('tests/fixtures/import-commands/commander-sample.ts', process.cwd());
   assert.strictEqual(result.kind, 'commander');
+}
+
+{
+  const result = detectFramework('tests/fixtures/import-commands/clap-sample.rs', process.cwd());
+  assert.strictEqual(result.kind, 'clap');
 }
 
 // === importCommands orchestration ===

--- a/tests/smoke-import.ts
+++ b/tests/smoke-import.ts
@@ -1,0 +1,26 @@
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { CliCommandDefinition } from '../src/import/types.js';
+import { writeOutput } from '../src/import/output.js';
+
+// === Types check ===
+const _typeCheck: CliCommandDefinition = { command: 'create', description: 'Create item' };
+assert.strictEqual(typeof _typeCheck.command, 'string');
+
+// === writeOutput ===
+{
+  const dir = mkdtempSync(join(tmpdir(), 'import-test-'));
+  const outPath = join(dir, 'cli-commands.json');
+  const commands: CliCommandDefinition[] = [
+    { command: 'create', description: 'Create item', options: [{ name: '--name', takesValue: true }] },
+  ];
+  await writeOutput(commands, outPath);
+  assert.strictEqual(existsSync(outPath), true);
+  const written = JSON.parse(readFileSync(outPath, 'utf-8')) as CliCommandDefinition[];
+  assert.strictEqual(written.length, 1);
+  assert.strictEqual(written[0]!.command, 'create');
+}
+
+console.log('smoke-import: all tests passed');

--- a/tests/smoke-import.ts
+++ b/tests/smoke-import.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import type { CliCommandDefinition } from '../src/import/types.js';
 import { writeOutput } from '../src/import/output.js';
 import { parseHelpOutput } from '../src/import/extractors/help-scraper.js';
+import { extractCommander } from '../src/import/extractors/ts-commander.js';
 
 // === Types check ===
 const _typeCheck: CliCommandDefinition = { command: 'create', description: 'Create item' };
@@ -41,6 +42,28 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
   assert.strictEqual(commands.length, 3, `Expected 3, got ${commands.length}: ${commands.map(c => c.command).join(', ')}`);
   assert.ok(commands.find(c => c.command === 'account create') !== undefined);
   assert.ok(commands.find(c => c.command === 'account delete') !== undefined);
+}
+
+// === ts-commander extractor ===
+{
+  const fixturePath = join('tests/fixtures/import-commands/commander-sample.ts');
+  const commands = extractCommander(fixturePath);
+  assert.strictEqual(commands.length, 3, `Expected 3 commands, got ${commands.length}: ${commands.map(c => c.command).join(', ')}`);
+
+  const create = commands.find(c => c.command === 'create');
+  assert.ok(create !== undefined, 'Should find "create" command');
+  assert.strictEqual(create?.description, 'Create a new item');
+
+  const nameOpt = create?.options?.find(o => o.name === '--name <value>');
+  assert.ok(nameOpt !== undefined, 'Should find --name option');
+  assert.strictEqual(nameOpt?.takesValue, true);
+
+  const dryRun = create?.options?.find(o => o.name === '--dry-run');
+  assert.ok(dryRun !== undefined, 'Should find --dry-run option');
+  assert.strictEqual(dryRun?.takesValue, false);
+
+  const deleteCmd = commands.find(c => c.command === 'delete');
+  assert.ok(deleteCmd !== undefined, 'Should find "delete" command (positional stripped)');
 }
 
 console.log('smoke-import: all tests passed');

--- a/tests/smoke-import.ts
+++ b/tests/smoke-import.ts
@@ -6,6 +6,7 @@ import type { CliCommandDefinition } from '../src/import/types.js';
 import { writeOutput } from '../src/import/output.js';
 import { parseHelpOutput } from '../src/import/extractors/help-scraper.js';
 import { extractCommander } from '../src/import/extractors/ts-commander.js';
+import { extractYargs } from '../src/import/extractors/ts-yargs.js';
 
 // === Types check ===
 const _typeCheck: CliCommandDefinition = { command: 'create', description: 'Create item' };
@@ -61,6 +62,28 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
   const dryRun = create?.options?.find(o => o.name === '--dry-run');
   assert.ok(dryRun !== undefined, 'Should find --dry-run option');
   assert.strictEqual(dryRun?.takesValue, false);
+
+  const deleteCmd = commands.find(c => c.command === 'delete');
+  assert.ok(deleteCmd !== undefined, 'Should find "delete" command (positional stripped)');
+}
+
+// === ts-yargs extractor ===
+{
+  const fixturePath = join('tests/fixtures/import-commands/yargs-sample.ts');
+  const commands = extractYargs(fixturePath);
+  assert.strictEqual(commands.length, 2, `Expected 2 commands, got ${commands.length}: ${commands.map(c => c.command).join(', ')}`);
+
+  const create = commands.find(c => c.command === 'create');
+  assert.ok(create !== undefined, 'Should find "create" command');
+  assert.strictEqual(create?.description, 'Create a new item');
+
+  const nameOpt = create?.options?.find(o => o.name === '--name');
+  assert.ok(nameOpt !== undefined, 'Should find --name option');
+  assert.strictEqual(nameOpt?.takesValue, true);
+
+  const verboseOpt = create?.options?.find(o => o.name === '--verbose');
+  assert.ok(verboseOpt !== undefined, 'Should find --verbose option');
+  assert.strictEqual(verboseOpt?.takesValue, false);
 
   const deleteCmd = commands.find(c => c.command === 'delete');
   assert.ok(deleteCmd !== undefined, 'Should find "delete" command (positional stripped)');

--- a/tests/smoke-import.ts
+++ b/tests/smoke-import.ts
@@ -52,7 +52,7 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
 
 // === ts-commander extractor ===
 {
-  const fixturePath = join('tests/fixtures/import-commands/commander-sample.ts');
+  const fixturePath = 'tests/fixtures/import-commands/commander-sample.ts';
   const commands = extractCommander(fixturePath);
   assert.strictEqual(commands.length, 3, `Expected 3 commands, got ${commands.length}: ${commands.map(c => c.command).join(', ')}`);
 
@@ -74,7 +74,7 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
 
 // === ts-yargs extractor ===
 {
-  const fixturePath = join('tests/fixtures/import-commands/yargs-sample.ts');
+  const fixturePath = 'tests/fixtures/import-commands/yargs-sample.ts';
   const commands = extractYargs(fixturePath);
   assert.strictEqual(commands.length, 2, `Expected 2 commands, got ${commands.length}: ${commands.map(c => c.command).join(', ')}`);
 
@@ -96,7 +96,7 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
 
 // === py-click extractor ===
 {
-  const fixturePath = join('tests/fixtures/import-commands/click-sample.py');
+  const fixturePath = 'tests/fixtures/import-commands/click-sample.py';
   const commands = await extractClick(fixturePath);
   assert.strictEqual(commands.length, 2, `Expected 2 commands, got ${commands.length}: ${commands.map(c => c.command).join(', ')}`);
 
@@ -118,7 +118,7 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
 
 // === py-argparse extractor ===
 {
-  const fixturePath = join('tests/fixtures/import-commands/argparse-sample.py');
+  const fixturePath = 'tests/fixtures/import-commands/argparse-sample.py';
   const commands = await extractArgparse(fixturePath);
   assert.strictEqual(commands.length, 2, `Expected 2 commands, got ${commands.length}: ${commands.map(c => c.command).join(', ')}`);
 
@@ -137,7 +137,7 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
 
 // === rs-clap extractor ===
 {
-  const fixturePath = join('tests/fixtures/import-commands/clap-sample.rs');
+  const fixturePath = 'tests/fixtures/import-commands/clap-sample.rs';
   const commands = await extractClap(fixturePath);
   assert.ok(commands.length >= 2, `Expected >=2 commands, got ${commands.length}`);
 
@@ -159,20 +159,17 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
 
 // === detectFramework ===
 {
-  const clickFixture = join('tests/fixtures/import-commands/click-sample.py');
-  const result = detectFramework(clickFixture, process.cwd());
+  const result = detectFramework('tests/fixtures/import-commands/click-sample.py', process.cwd());
   assert.strictEqual(result.kind, 'click');
 }
 
 {
-  const argparseFixture = join('tests/fixtures/import-commands/argparse-sample.py');
-  const result = detectFramework(argparseFixture, process.cwd());
+  const result = detectFramework('tests/fixtures/import-commands/argparse-sample.py', process.cwd());
   assert.strictEqual(result.kind, 'argparse');
 }
 
 {
-  const commanderFixture = join('tests/fixtures/import-commands/commander-sample.ts');
-  const result = detectFramework(commanderFixture, process.cwd());
+  const result = detectFramework('tests/fixtures/import-commands/commander-sample.ts', process.cwd());
   assert.strictEqual(result.kind, 'commander');
 }
 

--- a/tests/smoke-import.ts
+++ b/tests/smoke-import.ts
@@ -23,4 +23,30 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
   assert.strictEqual(written[0]!.command, 'create');
 }
 
+import { parseHelpOutput } from '../src/import/extractors/help-scraper.js';
+import { readFileSync } from 'node:fs';
+
+// === help-scraper: parseHelpOutput (root) ===
+{
+  const rootHelp = readFileSync('tests/fixtures/import-commands/help-output-sample.txt', 'utf-8');
+  const commands = parseHelpOutput(rootHelp, []);
+  // Should find: account, network, send, fund, pay (5 commands; skip "help" as it starts with 'h' not '-')
+  // Actually "help" is a valid command name — should be 6. But "help [cmd]" — the name is "help" without brackets.
+  // Filter: exclude "help" since it's a meta-command? No — just parse everything non-dash.
+  // Expected: at minimum 5 real commands (account, network, send, fund, pay). "help" may or may not be included.
+  assert.ok(commands.length >= 5, `Expected >=5 commands, got ${commands.length}: ${commands.map(c=>c.command).join(', ')}`);
+  const accountCmd = commands.find(c => c.command === 'account');
+  assert.ok(accountCmd !== undefined, 'Should find "account" command');
+  assert.strictEqual(accountCmd?.description, 'Account management');
+}
+
+// === help-scraper: parseHelpOutput (subcommand) ===
+{
+  const subHelp = readFileSync('tests/fixtures/import-commands/help-output-account.txt', 'utf-8');
+  const commands = parseHelpOutput(subHelp, ['account']);
+  assert.strictEqual(commands.length, 3, `Expected 3, got ${commands.length}: ${commands.map(c=>c.command).join(', ')}`);
+  assert.ok(commands.find(c => c.command === 'account create') !== undefined);
+  assert.ok(commands.find(c => c.command === 'account delete') !== undefined);
+}
+
 console.log('smoke-import: all tests passed');

--- a/tests/smoke-import.ts
+++ b/tests/smoke-import.ts
@@ -7,6 +7,7 @@ import { writeOutput } from '../src/import/output.js';
 import { parseHelpOutput } from '../src/import/extractors/help-scraper.js';
 import { extractCommander } from '../src/import/extractors/ts-commander.js';
 import { extractYargs } from '../src/import/extractors/ts-yargs.js';
+import { extractClick } from '../src/import/extractors/py-click.js';
 
 // === Types check ===
 const _typeCheck: CliCommandDefinition = { command: 'create', description: 'Create item' };
@@ -87,6 +88,28 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
 
   const deleteCmd = commands.find(c => c.command === 'delete');
   assert.ok(deleteCmd !== undefined, 'Should find "delete" command (positional stripped)');
+}
+
+// === py-click extractor ===
+{
+  const fixturePath = join('tests/fixtures/import-commands/click-sample.py');
+  const commands = await extractClick(fixturePath);
+  assert.strictEqual(commands.length, 2, `Expected 2 commands, got ${commands.length}: ${commands.map(c => c.command).join(', ')}`);
+
+  const create = commands.find(c => c.command === 'create');
+  assert.ok(create !== undefined, 'Should find "create" command');
+  assert.strictEqual(create?.description, 'Create a new item.');
+
+  const nameOpt = create?.options?.find(o => o.name === '--name');
+  assert.ok(nameOpt !== undefined, 'Should find --name option');
+  assert.strictEqual(nameOpt?.takesValue, true);  // no is_flag → takesValue true
+
+  const verboseOpt = create?.options?.find(o => o.name === '--verbose');
+  assert.ok(verboseOpt !== undefined, 'Should find --verbose option');
+  assert.strictEqual(verboseOpt?.takesValue, false);  // is_flag=True → takesValue false
+
+  const deleteCmd = commands.find(c => c.command === 'delete');
+  assert.ok(deleteCmd !== undefined, 'Should find "delete" command');
 }
 
 console.log('smoke-import: all tests passed');

--- a/tests/smoke-import.ts
+++ b/tests/smoke-import.ts
@@ -10,6 +10,8 @@ import { extractYargs } from '../src/import/extractors/ts-yargs.js';
 import { extractClick } from '../src/import/extractors/py-click.js';
 import { extractArgparse } from '../src/import/extractors/py-argparse.js';
 import { extractClap } from '../src/import/extractors/rs-clap.js';
+import { detectFramework } from '../src/import/detect.js';
+import { importCommands } from '../src/import/index.js';
 
 // === Types check ===
 const _typeCheck: CliCommandDefinition = { command: 'create', description: 'Create item' };
@@ -153,6 +155,41 @@ assert.strictEqual(typeof _typeCheck.command, 'string');
 
   const deleteCmd = commands.find(c => c.command === 'delete');
   assert.ok(deleteCmd !== undefined, 'Should find "delete" command');
+}
+
+// === detectFramework ===
+{
+  const clickFixture = join('tests/fixtures/import-commands/click-sample.py');
+  const result = detectFramework(clickFixture, process.cwd());
+  assert.strictEqual(result.kind, 'click');
+}
+
+{
+  const argparseFixture = join('tests/fixtures/import-commands/argparse-sample.py');
+  const result = detectFramework(argparseFixture, process.cwd());
+  assert.strictEqual(result.kind, 'argparse');
+}
+
+{
+  const commanderFixture = join('tests/fixtures/import-commands/commander-sample.ts');
+  const result = detectFramework(commanderFixture, process.cwd());
+  assert.strictEqual(result.kind, 'commander');
+}
+
+// === importCommands orchestration ===
+{
+  const dir = mkdtempSync(join(tmpdir(), 'import-orch-'));
+  const outPath = join(dir, 'cli-commands.json');
+  await importCommands({
+    from: 'tests/fixtures/import-commands/commander-sample.ts',
+    out: outPath,
+    scrape: false,
+    depth: 2,
+    cwd: process.cwd(),
+  });
+  assert.strictEqual(existsSync(outPath), true);
+  const written = JSON.parse(readFileSync(outPath, 'utf-8')) as CliCommandDefinition[];
+  assert.strictEqual(written.length, 3);
 }
 
 console.log('smoke-import: all tests passed');

--- a/tests/smoke-init.ts
+++ b/tests/smoke-init.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { WizardAnswers } from '../src/init/answers.js';
 import { buildDefaultAnswers, readAnswersFile } from '../src/init/answers.js';
+import { scaffoldInit } from '../src/init/scaffold.js';
 
 // Type check
 const _a: WizardAnswers = {
@@ -56,6 +57,98 @@ assert.strictEqual(typeof _a.surface, 'string');
     let threw = false;
     try { readAnswersFile(bad); } catch { threw = true; }
     assert.ok(threw, 'readAnswersFile should throw on missing surface');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// scaffoldInit sdk
+{
+  const dir = mkdtempSync(join(tmpdir(), 'scaffold-sdk-'));
+  try {
+    await scaffoldInit({
+      surface: 'sdk',
+      repoPath: dir,
+      models: ['openrouter/openai/gpt-4o'],
+      maxTasks: 10,
+      maxIterations: 3,
+    }, dir);
+    const configPath = join(dir, 'skill-optimizer', 'skill-optimizer.json');
+    assert.ok(existsSync(configPath), 'sdk scaffold should create skill-optimizer.json');
+    const config = JSON.parse(readFileSync(configPath, 'utf-8')) as {
+      target: { surface: string; repoPath: string };
+      benchmark: { models: Array<{ id: string }>; taskGeneration: { maxTasks: number } };
+      optimize: { maxIterations: number };
+    };
+    assert.strictEqual(config.target.surface, 'sdk');
+    assert.strictEqual(config.benchmark.models[0]?.id, 'openrouter/openai/gpt-4o');
+    assert.strictEqual(config.benchmark.taskGeneration.maxTasks, 10);
+    assert.strictEqual(config.optimize.maxIterations, 3);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// scaffoldInit cli — no entryFile, writes template
+{
+  const dir = mkdtempSync(join(tmpdir(), 'scaffold-cli-'));
+  try {
+    await scaffoldInit({
+      surface: 'cli',
+      repoPath: dir,
+      models: ['openrouter/openai/gpt-4o'],
+      maxTasks: 15,
+      maxIterations: 2,
+    }, dir);
+    const configPath = join(dir, 'skill-optimizer', 'skill-optimizer.json');
+    const commandsPath = join(dir, 'skill-optimizer', '.skill-optimizer', 'cli-commands.json');
+    assert.ok(existsSync(configPath), 'cli scaffold should create skill-optimizer.json');
+    assert.ok(existsSync(commandsPath), 'cli scaffold should create .skill-optimizer/cli-commands.json');
+    const config = JSON.parse(readFileSync(configPath, 'utf-8')) as {
+      target: { surface: string; cli?: { commands?: string } };
+    };
+    assert.strictEqual(config.target.surface, 'cli');
+    assert.ok(config.target.cli?.commands?.includes('cli-commands.json'), 'config should reference cli-commands.json');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// scaffoldInit mcp — writes template tools.json
+{
+  const dir = mkdtempSync(join(tmpdir(), 'scaffold-mcp-'));
+  try {
+    await scaffoldInit({
+      surface: 'mcp',
+      repoPath: dir,
+      models: ['openrouter/openai/gpt-4o'],
+      maxTasks: 5,
+      maxIterations: 1,
+    }, dir);
+    const toolsPath = join(dir, 'skill-optimizer', '.skill-optimizer', 'tools.json');
+    assert.ok(existsSync(toolsPath), 'mcp scaffold should create .skill-optimizer/tools.json');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// --answers equivalent: readAnswersFile + scaffoldInit mcp
+{
+  const dir = mkdtempSync(join(tmpdir(), 'scaffold-answers-'));
+  try {
+    const answersObj = {
+      surface: 'mcp',
+      repoPath: dir,
+      models: ['openrouter/openai/gpt-4o'],
+      maxTasks: 5,
+      maxIterations: 1,
+    };
+    const answersFile = join(dir, 'answers.json');
+    writeFileSync(answersFile, JSON.stringify(answersObj), 'utf-8');
+    const answers = readAnswersFile(answersFile);
+    await scaffoldInit(answers, dir);
+    const toolsPath = join(dir, 'skill-optimizer', '.skill-optimizer', 'tools.json');
+    assert.ok(existsSync(toolsPath), 'mcp scaffold via readAnswersFile should create tools.json');
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/smoke-init.ts
+++ b/tests/smoke-init.ts
@@ -318,7 +318,6 @@ assert.strictEqual(typeof _a.surface, 'string');
 
 // --auto --yes high confidence path: scaffoldInit called without wizard
 {
-  const { buildDefaultAnswers } = await import('../src/init/answers.js');
   const dir = mkdtempSync(join(tmpdir(), 'auto-yes-'));
   try {
     writeFileSync(join(dir, 'package.json'), JSON.stringify({

--- a/tests/smoke-init.ts
+++ b/tests/smoke-init.ts
@@ -154,4 +154,28 @@ assert.strictEqual(typeof _a.surface, 'string');
   }
 }
 
+// --yes equivalent test (buildDefaultAnswers + scaffoldInit)
+{
+  const dir = mkdtempSync(join(tmpdir(), 'scaffold-yes-'));
+  try {
+    const answers = buildDefaultAnswers('sdk', dir);
+    await scaffoldInit(answers, dir);
+    const configPath = join(dir, 'skill-optimizer', 'skill-optimizer.json');
+    assert.ok(existsSync(configPath), '--yes sdk should create skill-optimizer.json');
+    const config = JSON.parse(readFileSync(configPath, 'utf-8')) as { target: { surface: string }; optimize: { maxIterations: number }; benchmark: { taskGeneration: { maxTasks: number } } };
+    assert.strictEqual(config.target.surface, 'sdk');
+    assert.strictEqual(config.optimize.maxIterations, 5);
+    assert.strictEqual(config.benchmark.taskGeneration.maxTasks, 20);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// MODEL_PRESETS should have 10 entries
+{
+  const { MODEL_PRESETS } = await import('../src/init/wizard.js');
+  assert.strictEqual(MODEL_PRESETS.length, 10, `Expected 10 presets, got ${MODEL_PRESETS.length}`);
+  assert.ok(MODEL_PRESETS.every(p => p.value.startsWith('openrouter/')), 'All presets should be openrouter/ IDs');
+}
+
 console.log('smoke-init: all tests passed');

--- a/tests/smoke-init.ts
+++ b/tests/smoke-init.ts
@@ -260,4 +260,39 @@ assert.strictEqual(typeof _a.surface, 'string');
   }
 }
 
+// SkillOptimizerError — structured error with fix hints
+{
+  const { ERRORS, SkillOptimizerError, printError } = await import('../src/errors.js');
+
+  // Basic throw/catch
+  let caught: InstanceType<typeof SkillOptimizerError> | undefined;
+  try {
+    throw new SkillOptimizerError(ERRORS.E_MISSING_API_KEY);
+  } catch (err) {
+    if (err instanceof SkillOptimizerError) caught = err;
+  }
+  assert.ok(caught, 'should have caught SkillOptimizerError');
+  assert.strictEqual(caught.name, 'E_MISSING_API_KEY');
+  assert.ok(caught.message.includes('API key'), `message should mention API key, got: ${caught.message}`);
+
+  // Detail appended
+  const withDetail = new SkillOptimizerError(ERRORS.E_MAXTASKS_TOO_LOW, 'scope has 5 actions, maxTasks is 3');
+  assert.ok(withDetail.message.includes('scope has 5'), `detail should be appended, got: ${withDetail.message}`);
+
+  // ERRORS registry: all entries have code, message, fix array
+  for (const [key, def] of Object.entries(ERRORS)) {
+    assert.strictEqual(def.code, key, `code mismatch for ${key}`);
+    assert.ok(typeof def.message === 'string' && def.message.length > 0, `${key} needs a message`);
+    assert.ok(Array.isArray(def.fix) && def.fix.length > 0, `${key} needs at least one fix step`);
+  }
+
+  // printError is callable (won't throw)
+  const orig = console.error;
+  let printed = '';
+  console.error = (...args: unknown[]) => { printed += args.join(' '); };
+  printError(new SkillOptimizerError(ERRORS.E_DIRTY_GIT));
+  console.error = orig;
+  assert.ok(printed.includes('E_DIRTY_GIT'), `printError should include code, got: ${printed}`);
+}
+
 console.log('smoke-init: all tests passed');

--- a/tests/smoke-init.ts
+++ b/tests/smoke-init.ts
@@ -1,7 +1,8 @@
 import { strict as assert } from 'node:assert';
-import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { detectProject } from '../src/init/detect-project.js';
 import type { WizardAnswers } from '../src/init/answers.js';
 import { buildDefaultAnswers, readAnswersFile } from '../src/init/answers.js';
 import { scaffoldInit } from '../src/init/scaffold.js';
@@ -176,6 +177,87 @@ assert.strictEqual(typeof _a.surface, 'string');
   const { MODEL_PRESETS } = await import('../src/init/wizard.js');
   assert.strictEqual(MODEL_PRESETS.length, 10, `Expected 10 presets, got ${MODEL_PRESETS.length}`);
   assert.ok(MODEL_PRESETS.every(p => p.value.startsWith('openrouter/')), 'All presets should be openrouter/ IDs');
+}
+
+// detectProject: TypeScript SDK (package.json with main, no bin)
+{
+  const dir = mkdtempSync(join(tmpdir(), 'detect-ts-sdk-'));
+  try {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({
+      name: 'my-sdk',
+      main: './dist/index.js',
+    }), 'utf-8');
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(join(dir, 'src', 'index.ts'), '');
+    const result = detectProject(dir);
+    assert.strictEqual(result.surface, 'sdk');
+    assert.strictEqual(result.name, 'my-sdk');
+    assert.ok(result.entryFile.includes('index'), `entryFile should reference index, got: ${result.entryFile}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// detectProject: TypeScript CLI (package.json with bin)
+{
+  const dir = mkdtempSync(join(tmpdir(), 'detect-ts-cli-'));
+  try {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({
+      name: 'my-cli',
+      bin: { 'my-cli': './dist/cli.js' },
+    }), 'utf-8');
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(join(dir, 'src', 'cli.ts'), '');
+    const result = detectProject(dir);
+    assert.strictEqual(result.surface, 'cli');
+    assert.strictEqual(result.name, 'my-cli');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// detectProject: MCP server (package.json with @modelcontextprotocol/sdk dep)
+{
+  const dir = mkdtempSync(join(tmpdir(), 'detect-mcp-'));
+  try {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({
+      name: 'my-mcp',
+      dependencies: { '@modelcontextprotocol/sdk': '^1.0.0' },
+    }), 'utf-8');
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(join(dir, 'src', 'server.ts'), '');
+    const result = detectProject(dir);
+    assert.strictEqual(result.surface, 'mcp');
+    assert.strictEqual(result.name, 'my-mcp');
+    assert.ok(result.entryFile.includes('server'), `entryFile should reference server.ts, got: ${result.entryFile}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// detectProject: unknown dir (no manifest) → defaults to sdk with low confidence
+{
+  const dir = mkdtempSync(join(tmpdir(), 'detect-empty-'));
+  try {
+    const result = detectProject(dir);
+    assert.strictEqual(result.surface, 'sdk');
+    assert.strictEqual(result.confidence, 'low');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// detectProject: SKILL.md found → skillFile set
+{
+  const dir = mkdtempSync(join(tmpdir(), 'detect-skill-'));
+  try {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'x' }), 'utf-8');
+    writeFileSync(join(dir, 'SKILL.md'), '# skill');
+    const result = detectProject(dir);
+    assert.strictEqual(result.skillFile, 'SKILL.md');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 }
 
 console.log('smoke-init: all tests passed');

--- a/tests/smoke-init.ts
+++ b/tests/smoke-init.ts
@@ -1,0 +1,64 @@
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { WizardAnswers } from '../src/init/answers.js';
+import { buildDefaultAnswers, readAnswersFile } from '../src/init/answers.js';
+
+// Type check
+const _a: WizardAnswers = {
+  surface: 'sdk',
+  repoPath: '/tmp/repo',
+  models: ['openrouter/openai/gpt-4o'],
+  maxTasks: 20,
+  maxIterations: 5,
+};
+assert.strictEqual(typeof _a.surface, 'string');
+
+// buildDefaultAnswers
+{
+  const defaults = buildDefaultAnswers('cli');
+  assert.strictEqual(defaults.surface, 'cli');
+  assert.ok(defaults.models.length >= 1, 'should have at least one default model');
+  assert.strictEqual(typeof defaults.maxTasks, 'number');
+  assert.strictEqual(typeof defaults.maxIterations, 'number');
+}
+
+// readAnswersFile
+{
+  const dir = mkdtempSync(join(tmpdir(), 'answers-test-'));
+  try {
+    const answers: WizardAnswers = {
+      surface: 'mcp',
+      repoPath: '/tmp/myrepo',
+      models: ['openrouter/openai/gpt-4o'],
+      maxTasks: 15,
+      maxIterations: 3,
+      entryFile: 'src/server.ts',
+    };
+    const file = join(dir, 'answers.json');
+    writeFileSync(file, JSON.stringify(answers), 'utf-8');
+    const loaded = readAnswersFile(file);
+    assert.strictEqual(loaded.surface, 'mcp');
+    assert.strictEqual(loaded.entryFile, 'src/server.ts');
+    assert.strictEqual(loaded.maxIterations, 3);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// readAnswersFile error: missing surface
+{
+  const dir = mkdtempSync(join(tmpdir(), 'answers-err-'));
+  try {
+    const bad = join(dir, 'bad.json');
+    writeFileSync(bad, JSON.stringify({ repoPath: '/tmp', models: ['openrouter/openai/gpt-4o'], maxTasks: 5, maxIterations: 1 }), 'utf-8');
+    let threw = false;
+    try { readAnswersFile(bad); } catch { threw = true; }
+    assert.ok(threw, 'readAnswersFile should throw on missing surface');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+console.log('smoke-init: all tests passed');

--- a/tests/smoke-init.ts
+++ b/tests/smoke-init.ts
@@ -295,4 +295,78 @@ assert.strictEqual(typeof _a.surface, 'string');
   assert.ok(printed.includes('E_DIRTY_GIT'), `printError should include code, got: ${printed}`);
 }
 
+// detectedToPreseed maps DetectedProject to Partial<WizardAnswers>
+{
+  const { detectedToPreseed, detectProject } = await import('../src/init/detect-project.js');
+  const dir = mkdtempSync(join(tmpdir(), 'preseed-'));
+  try {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({
+      name: 'preseed-cli',
+      bin: { 'preseed-cli': './dist/cli.js' },
+    }), 'utf-8');
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(join(dir, 'src', 'cli.ts'), '');
+    const detected = detectProject(dir);
+    const preseed = detectedToPreseed(detected);
+    assert.strictEqual(preseed.surface, 'cli');
+    assert.strictEqual(preseed.repoPath, dir);
+    assert.ok(typeof preseed.name === 'string' && preseed.name.length > 0, 'preseed.name should be set');
+    assert.ok(preseed.entryFile !== undefined, 'preseed.entryFile should be set for cli');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// --auto --yes high confidence path: scaffoldInit called without wizard
+{
+  const { detectProject, detectedToPreseed } = await import('../src/init/detect-project.js');
+  const { buildDefaultAnswers } = await import('../src/init/answers.js');
+  const dir = mkdtempSync(join(tmpdir(), 'auto-yes-'));
+  try {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({
+      name: 'auto-test',
+      dependencies: { '@modelcontextprotocol/sdk': '^1.0.0' },
+    }), 'utf-8');
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(join(dir, 'src', 'server.ts'), '');
+    const detected = detectProject(dir);
+    assert.strictEqual(detected.confidence, 'high', 'mcp with dep should be high confidence');
+    assert.strictEqual(detected.surface, 'mcp');
+    const answers = {
+      ...buildDefaultAnswers(detected.surface, detected.repoPath),
+      ...detectedToPreseed(detected),
+    };
+    await scaffoldInit(answers, dir);
+    const configPath = join(dir, 'skill-optimizer', 'skill-optimizer.json');
+    assert.ok(existsSync(configPath), '--auto --yes should scaffold config');
+    const config = JSON.parse(readFileSync(configPath, 'utf-8')) as { target: { surface: string } };
+    assert.strictEqual(config.target.surface, 'mcp');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// --auto --yes low confidence should reject (E_INIT_AUTO_LOW_CONFIDENCE)
+{
+  const { detectProject } = await import('../src/init/detect-project.js');
+  const { ERRORS, SkillOptimizerError } = await import('../src/errors.js');
+  const dir = mkdtempSync(join(tmpdir(), 'auto-low-'));
+  try {
+    const detected = detectProject(dir);
+    assert.strictEqual(detected.confidence, 'low');
+    let threw = false;
+    try {
+      if (detected.confidence !== 'high') {
+        throw new SkillOptimizerError(ERRORS.E_INIT_AUTO_LOW_CONFIDENCE, `confidence is ${detected.confidence}`);
+      }
+    } catch (err) {
+      if (err instanceof SkillOptimizerError && err.def.code === 'E_INIT_AUTO_LOW_CONFIDENCE') threw = true;
+      else throw err;
+    }
+    assert.ok(threw, 'low confidence with --yes should throw E_INIT_AUTO_LOW_CONFIDENCE');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 console.log('smoke-init: all tests passed');

--- a/tests/smoke-init.ts
+++ b/tests/smoke-init.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'node:assert';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { detectProject } from '../src/init/detect-project.js';
+import { detectProject, detectedToPreseed } from '../src/init/detect-project.js';
 import type { WizardAnswers } from '../src/init/answers.js';
 import { buildDefaultAnswers, readAnswersFile } from '../src/init/answers.js';
 import { scaffoldInit } from '../src/init/scaffold.js';
@@ -297,7 +297,6 @@ assert.strictEqual(typeof _a.surface, 'string');
 
 // detectedToPreseed maps DetectedProject to Partial<WizardAnswers>
 {
-  const { detectedToPreseed, detectProject } = await import('../src/init/detect-project.js');
   const dir = mkdtempSync(join(tmpdir(), 'preseed-'));
   try {
     writeFileSync(join(dir, 'package.json'), JSON.stringify({
@@ -319,7 +318,6 @@ assert.strictEqual(typeof _a.surface, 'string');
 
 // --auto --yes high confidence path: scaffoldInit called without wizard
 {
-  const { detectProject, detectedToPreseed } = await import('../src/init/detect-project.js');
   const { buildDefaultAnswers } = await import('../src/init/answers.js');
   const dir = mkdtempSync(join(tmpdir(), 'auto-yes-'));
   try {
@@ -346,7 +344,9 @@ assert.strictEqual(typeof _a.surface, 'string');
   }
 }
 
-// --auto --yes low confidence should reject (E_INIT_AUTO_LOW_CONFIDENCE)
+// --auto --yes low confidence: verifies error infrastructure (E_INIT_AUTO_LOW_CONFIDENCE exists and can be thrown)
+// Note: this simulates the guard logic in cli.ts rather than calling through the CLI handler,
+// since the full CLI path requires process.argv and process.exit mocking.
 {
   const { detectProject } = await import('../src/init/detect-project.js');
   const { ERRORS, SkillOptimizerError } = await import('../src/errors.js');


### PR DESCRIPTION
## Summary

Phase 4 of the DX overhaul — three tightly coupled additions that together eliminate the two biggest friction points after install:

- **`init --auto`** — detects project type from manifest files (`package.json`, `pyproject.toml`, `Cargo.toml`) with high/medium/low confidence, prints a detection summary, and pre-fills the wizard. `--auto --yes` at high confidence skips the wizard entirely; non-high confidence rejects `--yes` with a structured error.
- **Typed error registry** (`src/errors.ts`) — ~23 named `ErrorDef` codes + `E_UNEXPECTED` catch-all, `SkillOptimizerError` class, `printError` formatter. All CLI catch blocks now produce structured, actionable output with fix hints.
- **Auto-generated reference docs** — `scripts/gen-docs.ts` generates `docs/reference/errors.md` and `docs/reference/config-schema.md` at build time from the registry and a new additive Zod schema (`src/project/schema.ts`). Hand-written config tables removed from README.

## Files changed

| File | Change |
|---|---|
| `src/errors.ts` | New — `ErrorDef`, `SkillOptimizerError`, `ERRORS` registry, `printError` |
| `src/project/schema.ts` | New — Zod schema for doc-gen only (uses `zod/v3` compat for `zod-to-json-schema`) |
| `scripts/gen-docs.ts` | New — renders `errors.md` + `config-schema.md` |
| `docs/reference/errors.md` | New generated file (committed, auto-regenerated at build) |
| `docs/reference/config-schema.md` | New generated file |
| `src/init/detect-project.ts` | Add `detectedToPreseed()`, `printDetectionSummary()` |
| `src/init/wizard.ts` | `preseed?: Partial<WizardAnswers>` replaces `preseedSurface` |
| `src/cli.ts` | Wire `--auto`, `fatalError()` helper, structured catch blocks |
| `tests/smoke-init.ts` | Error registry tests, `--auto` paths, detection helpers |
| `README.md` | Remove hand-written config tables; link to generated docs; add `--auto` to quickstart |
| `package.json` | Add `zod`, `zod-to-json-schema`; add `gen-docs` script; hook into `build` |

## Test plan

- [ ] `npm run typecheck` — passes
- [ ] `npm test` — 18 passed, 6 pre-existing failures in smoke-optimize (unrelated)
- [ ] `npm run gen-docs` — `docs/reference/` files regenerated correctly
- [ ] `npx tsx src/cli.ts init --auto` in a TypeScript CLI repo — wizard opens pre-filled
- [ ] `npx tsx src/cli.ts init --auto --yes` in a high-confidence project — scaffolds without prompts
- [ ] `npx tsx src/cli.ts init --auto --yes` in an empty dir — prints `E_INIT_AUTO_LOW_CONFIDENCE` + exits 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)