### PR TITLE
Add Codex auth support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,18 +88,21 @@ npx tsx src/cli.ts optimize --config ./.tmp/mock-repos/mcp-tracker-demo/skill-op
 
 ## Model ID Convention
 
-Model IDs in configs and presets follow a strict format:
+Model IDs use a provider-prefixed format. The prefix determines how the request is routed:
 
 ```
-openrouter/<provider>/<model-slug>
+openrouter/<provider>/<model-slug>   — routed through OpenRouter (format: "pi")
+anthropic/<model-slug>               — direct Anthropic API    (format: "anthropic")
+openai/<model-slug>                  — direct OpenAI API       (format: "openai")
 ```
 
-**Version segments use hyphens, not dots.** Examples:
+**Version segments use hyphens, not dots**, regardless of provider. Examples:
 - `openrouter/anthropic/claude-sonnet-4-6` ✓ (not `claude-sonnet-4.6`)
 - `openrouter/google/gemini-2-5-flash` ✓ (not `gemini-2.5-flash`)
 - `openrouter/deepseek/deepseek-v3-2` ✓ (not `deepseek-v3.2`)
+- `openai/gpt-5-4` ✓ (not `openai/gpt-5.4`)
 
-`src/project/validate.ts` warns on dot-notation version segments (`model-id-bad-format`) and `src/project/fix.ts` auto-corrects them. When adding new model presets to `src/init/scaffold.ts`, `src/init/wizard.ts`, or `src/benchmark/init.ts`, always use hyphens in the model ID path.
+`src/project/validate.ts` warns on dot-notation version segments for `openrouter/` model IDs (`model-id-bad-format`) and `src/project/fix.ts` auto-corrects them. When adding new model presets to `src/init/scaffold.ts`, `src/init/wizard.ts`, or `src/benchmark/init.ts`, always use hyphens in the model ID path.
 
 Display names (`name:` / `label:` fields) are human-readable and should keep dots (e.g. `'Claude Sonnet 4.6'`, `'Gemini 2.5 Flash'`).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Benchmark and self-optimize SDK, CLI, and MCP guidance so every agent model can 
 
 skill-optimizer runs your SDK / CLI / MCP docs against multiple LLMs, measures whether they call the right actions with the right arguments, and iteratively rewrites your `SKILL.md` / docs until a floor score is met across every model.
 
-**Requirements:** Node.js 20+, an [OpenRouter](https://openrouter.ai) API key.
+**Requirements:** Node.js 20+, plus either an [OpenRouter](https://openrouter.ai) API key or a local Codex login when using direct OpenAI models.
 
 ## Installation
 
@@ -20,6 +20,20 @@ npm link        # makes `skill-optimizer` available globally
 
 ```bash
 export OPENROUTER_API_KEY=sk-or-...
+```
+
+For direct OpenAI runs you can also use your local Codex browser login instead of exporting `OPENAI_API_KEY`:
+
+```json
+{
+  "benchmark": {
+    "format": "pi",
+    "authMode": "codex",
+    "models": [
+      { "id": "openai/gpt-5.4", "name": "GPT-5.4", "tier": "flagship" }
+    ]
+  }
+}
 ```
 
 **Step 1 — Scaffold config** (run from your project root):
@@ -97,6 +111,7 @@ npx skill-optimizer init --answers answers.json
 | `target.discovery.sources` | Source files to scan for callable methods/commands/tools | e.g. `["../src/index.ts"]` or `["../src/server.ts"]` |
 | `target.skill` | Docs file the optimizer will edit | Path to your `SKILL.md` or equivalent guidance doc |
 | `benchmark.models` | Models to benchmark | Valid [OpenRouter](https://openrouter.ai/models) model IDs |
+| `benchmark.authMode` | How model auth is resolved | `env` (default), `codex`, or `auto` |
 
 ## How it works
 
@@ -160,7 +175,7 @@ No per-failure LLM calls — feedback is deterministic (structured failure detai
 
 ## Dependencies
 
-The optimizer's coding agent is powered by `@mariozechner/pi-coding-agent` — a small OSS wrapper around OpenRouter that handles agent sessions and tool loops. Models are accessed through [OpenRouter](https://openrouter.ai/) — you need one API key for everything.
+The optimizer's coding agent is powered by `@mariozechner/pi-coding-agent`. OpenRouter-backed runs still use your configured API key env var. Direct OpenAI runs can use either `OPENAI_API_KEY` or the browser-login tokens that Codex stores in `~/.codex/auth.json`.
 
 ## Troubleshooting
 
@@ -168,6 +183,8 @@ The optimizer's coding agent is powered by `@mariozechner/pi-coding-agent` — a
 ```bash
 export OPENROUTER_API_KEY=sk-or-...
 ```
+
+**Using Codex auth**: Set `benchmark.authMode` (and optionally `optimize.authMode`) to `"codex"` or `"auto"` and use direct OpenAI model refs such as `openai/gpt-5.4`. Codex auth only applies to the `openai` provider and reads either a browser-login access token or `OPENAI_API_KEY` from `~/.codex/auth.json`.
 
 **Dirty git**: The optimizer requires a clean git state in the target repo (`requireCleanGit: true` by default). Commit or stash uncommitted changes before running. Note: the optimizer never writes to the target repo's skill file — it works from local versioned copies in `.skill-optimizer/`.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For direct OpenAI runs you can also use your local Codex browser login instead o
     "format": "pi",
     "authMode": "codex",
     "models": [
-      { "id": "openai/gpt-5.4", "name": "GPT-5.4", "tier": "flagship" }
+      { "id": "openai/gpt-5-4", "name": "GPT-5.4", "tier": "flagship" }
     ]
   }
 }
@@ -184,7 +184,7 @@ The optimizer's coding agent is powered by `@mariozechner/pi-coding-agent`. Open
 export OPENROUTER_API_KEY=sk-or-...
 ```
 
-**Using Codex auth**: Set `benchmark.authMode` (and optionally `optimize.authMode`) to `"codex"` or `"auto"` and use direct OpenAI model refs such as `openai/gpt-5.4`. Codex auth only applies to the `openai` provider and reads either a browser-login access token or `OPENAI_API_KEY` from `~/.codex/auth.json`. Alternatively, set `benchmark.format` to `"openai"` with `authMode: "codex"` and `openai/...` model IDs — the client bridges to the Pi/Codex path automatically.
+**Using Codex auth**: Set `benchmark.authMode` (and optionally `optimize.authMode`) to `"codex"` or `"auto"` and use direct OpenAI model refs such as `openai/gpt-5-4`. Codex auth only applies to the `openai` provider and reads either a browser-login access token or `OPENAI_API_KEY` from `~/.codex/auth.json`. Alternatively, set `benchmark.format` to `"openai"` with `authMode: "codex"` and `openai/...` model IDs — the client bridges to the Pi/Codex path automatically.
 
 **Dirty git**: The optimizer requires a clean git state in the target repo (`requireCleanGit: true` by default). Commit or stash uncommitted changes before running. Note: the optimizer never writes to the target repo's skill file — it works from local versioned copies in `.skill-optimizer/`.
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ The optimizer's coding agent is powered by `@mariozechner/pi-coding-agent`. Open
 export OPENROUTER_API_KEY=sk-or-...
 ```
 
-**Using Codex auth**: Set `benchmark.authMode` (and optionally `optimize.authMode`) to `"codex"` or `"auto"` and use direct OpenAI model refs such as `openai/gpt-5.4`. Codex auth only applies to the `openai` provider and reads either a browser-login access token or `OPENAI_API_KEY` from `~/.codex/auth.json`.
+**Using Codex auth**: Set `benchmark.authMode` (and optionally `optimize.authMode`) to `"codex"` or `"auto"` and use direct OpenAI model refs such as `openai/gpt-5.4`. Codex auth only applies to the `openai` provider and reads either a browser-login access token or `OPENAI_API_KEY` from `~/.codex/auth.json`. Alternatively, set `benchmark.format` to `"openai"` with `authMode: "codex"` and `openai/...` model IDs — the client bridges to the Pi/Codex path automatically.
 
 **Dirty git**: The optimizer requires a clean git state in the target repo (`requireCleanGit: true` by default). Commit or stash uncommitted changes before running. Note: the optimizer never writes to the target repo's skill file — it works from local versioned copies in `.skill-optimizer/`.
 

--- a/docs/reference/config-schema.md
+++ b/docs/reference/config-schema.md
@@ -23,6 +23,7 @@ Paths in the config are relative to the config file location.
 | `target.scope.include` | `string[]` | — | Glob patterns for actions to include (default ["*"]) |
 | `target.scope.exclude` | `string[]` | — | Glob patterns for actions to exclude (default []) |
 | `benchmark.format` | `"pi" | "openai" | "anthropic"` | — | LLM transport format: pi, openai, or anthropic |
+| `benchmark.authMode` | `"env" | "codex" | "auto"` | — | How to resolve credentials: env var, ~/.codex/auth.json browser-login tokens, or env-then-codex fallback |
 | `benchmark.apiKeyEnv` | `string` | — | Env var name for the API key (default OPENROUTER_API_KEY) |
 | `benchmark.timeout` | `integer` | — | Milliseconds per model call (default 240000) |
 | `benchmark.models` | `object[]` | — | Models to benchmark — at least one required |
@@ -34,6 +35,7 @@ Paths in the config are relative to the config file location.
 | `benchmark.verdict.perModelFloor` | `number` | — | Minimum per-model pass fraction for PASS verdict (default 0.6) |
 | `benchmark.verdict.targetWeightedAverage` | `number` | — | Minimum weighted average across all models for PASS (default 0.7) |
 | `optimize.model` | `string` | — | Model for mutation, e.g. openrouter/anthropic/claude-sonnet-4-6 |
+| `optimize.authMode` | `"env" | "codex" | "auto"` | — | How to resolve optimizer credentials: env var, ~/.codex/auth.json browser-login tokens, or env-then-codex fallback |
 | `optimize.apiKeyEnv` | `string` | — | Env var for the optimizer API key |
 | `optimize.thinkingLevel` | `"off" | "minimal" | "low" | "medium" | "high" | "xhigh"` | — | Reasoning depth for mutation calls (default "medium") |
 | `optimize.allowedPaths` | `string[]` | — | Paths the optimizer may edit — safety boundary |

--- a/docs/reference/config-schema.md
+++ b/docs/reference/config-schema.md
@@ -22,9 +22,9 @@ Paths in the config are relative to the config file location.
 | `target.mcp.tools` | `string` | — | Path to MCP tools manifest JSON (OpenAI function tool definitions) |
 | `target.scope.include` | `string[]` | — | Glob patterns for actions to include (default ["*"]) |
 | `target.scope.exclude` | `string[]` | — | Glob patterns for actions to exclude (default []) |
-| `benchmark.format` | `"pi" | "openai" | "anthropic"` | — | LLM transport format: pi, openai, or anthropic |
+| `benchmark.format` | `"pi" | "openai" | "anthropic"` | — | LLM transport format: "pi" routes through OpenRouter/Pi (use openrouter/* or openai/* model refs); "openai" calls the OpenAI API directly (supports Codex auth); "anthropic" calls the Anthropic API directly |
 | `benchmark.authMode` | `"env" | "codex" | "auto"` | — | How to resolve credentials: env var, ~/.codex/auth.json browser-login tokens, or env-then-codex fallback |
-| `benchmark.apiKeyEnv` | `string` | — | Env var name for the API key (default OPENROUTER_API_KEY) |
+| `benchmark.apiKeyEnv` | `string` | — | Env var name for the API key (default: OPENROUTER_API_KEY for format:pi, OPENAI_API_KEY for format:openai, ANTHROPIC_API_KEY for format:anthropic) |
 | `benchmark.timeout` | `integer` | — | Milliseconds per model call (default 240000) |
 | `benchmark.models` | `object[]` | — | Models to benchmark — at least one required |
 | `benchmark.taskGeneration.enabled` | `boolean` | — | Whether to generate tasks automatically (default false) |

--- a/src/actions/discover.ts
+++ b/src/actions/discover.ts
@@ -95,6 +95,9 @@ export function discoverActions(project: ResolvedProjectConfig): ActionCatalog {
         required: (tool.function.parameters?.required ?? []).includes(name),
         type: typeof schema === 'object' && schema && 'type' in schema ? String((schema as { type?: unknown }).type ?? '') || undefined : undefined,
         description: typeof schema === 'object' && schema && 'description' in schema ? String((schema as { description?: unknown }).description ?? '') || undefined : undefined,
+        schema: typeof schema === 'object' && schema && !Array.isArray(schema)
+          ? schema as Record<string, unknown>
+          : undefined,
       })),
       source: 'mcp.tools',
     })),

--- a/src/actions/snapshot.ts
+++ b/src/actions/snapshot.ts
@@ -37,12 +37,16 @@ function validateActionArgs(snapshotPath: string, actionIndex: number, args: unk
     if (candidate.description !== undefined && typeof candidate.description !== 'string') {
       invalidSnapshot(snapshotPath, `${path}.description must be a string when provided`);
     }
+    if (candidate.schema !== undefined && (!candidate.schema || typeof candidate.schema !== 'object' || Array.isArray(candidate.schema))) {
+      invalidSnapshot(snapshotPath, `${path}.schema must be an object when provided`);
+    }
 
     return {
       name: candidate.name,
       required: candidate.required,
       type: candidate.type,
       description: candidate.description,
+      schema: candidate.schema as Record<string, unknown> | undefined,
     };
   });
 }
@@ -81,6 +85,28 @@ function validateCatalogActions(snapshotPath: string, actions: unknown): ActionD
   });
 }
 
+function normalizeSchemaValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(normalizeSchemaValue);
+  }
+
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  const normalizedEntries = Object.entries(value as Record<string, unknown>)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, childValue]) => {
+      if (key === 'required' && Array.isArray(childValue) && childValue.every((entry) => typeof entry === 'string')) {
+        return [key, [...childValue].sort()] as const;
+      }
+
+      return [key, normalizeSchemaValue(childValue)] as const;
+    });
+
+  return Object.fromEntries(normalizedEntries);
+}
+
 export function normalizeActionArgSchema(args: ActionArgSchema[]): ActionArgSchema[] {
   return [...args]
     .map((arg) => ({
@@ -88,6 +114,7 @@ export function normalizeActionArgSchema(args: ActionArgSchema[]): ActionArgSche
       required: Boolean(arg.required),
       type: arg.type,
       description: arg.description,
+      schema: arg.schema ? normalizeSchemaValue(arg.schema) as Record<string, unknown> : undefined,
     }))
     .sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -5,6 +5,7 @@ export interface ActionArgSchema {
   required: boolean;
   type?: string;
   description?: string;
+  schema?: Record<string, unknown>;
 }
 
 export interface ActionDefinition {

--- a/src/benchmark/init.ts
+++ b/src/benchmark/init.ts
@@ -110,7 +110,6 @@ export function initBenchmark(targetDir: string = process.cwd(), surface: 'sdk' 
 
 function buildConfig(surface: 'sdk' | 'cli' | 'mcp'): object {
   const commonBenchmark = {
-    apiKeyEnv: 'OPENROUTER_API_KEY',
     format: 'pi',
     timeout: 240000,
     taskGeneration: {
@@ -134,7 +133,6 @@ function buildConfig(surface: 'sdk' | 'cli' | 'mcp'): object {
 
   const commonOptimize = {
     model: 'openrouter/anthropic/claude-sonnet-4-6',
-    apiKeyEnv: 'OPENROUTER_API_KEY',
     allowedPaths: ['./SKILL.md'],
     validation: [],
     maxIterations: 5,

--- a/src/benchmark/llm/index.ts
+++ b/src/benchmark/llm/index.ts
@@ -2,6 +2,7 @@ import type { LLMConfig, LLMResponse, McpToolDefinition, ToolExecutor } from '..
 import { chatOpenAI, chatWithToolsOpenAI, chatAgentLoopOpenAI } from './openai-format.js';
 import { chatAnthropic, chatWithToolsAnthropic, chatAgentLoopAnthropic } from './anthropic-format.js';
 import { chatPi, chatWithToolsPi, chatAgentLoopPi } from './pi-format.js';
+import { requireConfiguredApiKey, resolveApiCredential } from '../../runtime/pi/index.js';
 
 export interface LLMClient {
   /** Regular chat — LLM returns text output (SDK/CLI surfaces) */
@@ -36,13 +37,25 @@ function stripProviderPrefix(modelId: string): string {
 export function createLLMClient(config: LLMConfig): LLMClient {
   const baseUrl = config.baseUrl?.replace(/\/+$/, ''); // strip trailing slash
   const timeout = config.timeout ?? 240_000;
-  const apiKey = config.apiKeyEnv ? process.env[config.apiKeyEnv] : undefined;
-
-  if (config.apiKeyEnv && !apiKey) {
-    throw new Error(`Environment variable ${config.apiKeyEnv} is not set`);
-  }
-
   const extraHeaders = config.headers ?? {};
+  const resolvedOpenAICredential = config.format === 'openai'
+    ? resolveApiCredential({
+      provider: 'openai',
+      authMode: config.authMode,
+      apiKeyEnv: config.apiKeyEnv,
+    })
+    : undefined;
+  const useCodexBridgeForOpenAI = config.format === 'openai' && resolvedOpenAICredential?.source === 'codex';
+  const resolveDirectApiKey = (provider: 'openai' | 'anthropic'): string | undefined =>
+    provider === 'openai' && resolvedOpenAICredential?.apiKey
+      ? resolvedOpenAICredential.apiKey
+      : requireConfiguredApiKey({
+        provider,
+        authMode: config.authMode,
+        apiKeyEnv: config.apiKeyEnv,
+      });
+  const toOpenAIProviderModelRef = (modelId: string): string =>
+    modelId.includes('/') ? modelId : `openai/${modelId}`;
 
   // When format is 'anthropic' or 'openai', we're talking directly to a provider
   // API that doesn't understand prefixed model IDs like "anthropic/claude-sonnet-4-6".
@@ -53,32 +66,153 @@ export function createLLMClient(config: LLMConfig): LLMClient {
     async chat(modelId, system, user) {
       const resolvedModelId = shouldStripPrefix ? stripProviderPrefix(modelId) : modelId;
       if (config.format === 'pi') {
-        return chatPi({ timeout, modelId, system, user, apiKeyOverride: apiKey, headers: config.headers });
+        return chatPi({
+          timeout,
+          modelId,
+          system,
+          user,
+          authMode: config.authMode,
+          apiKeyEnv: config.apiKeyEnv,
+          headers: config.headers,
+        });
+      }
+      if (useCodexBridgeForOpenAI) {
+        return chatPi({
+          timeout,
+          modelId: toOpenAIProviderModelRef(modelId),
+          system,
+          user,
+          authMode: config.authMode,
+          apiKeyEnv: config.apiKeyEnv,
+          headers: config.headers,
+        });
       }
       if (config.format === 'anthropic') {
-        return chatAnthropic({ baseUrl: baseUrl!, apiKey, timeout, extraHeaders, modelId: resolvedModelId, system, user });
+        return chatAnthropic({
+          baseUrl: baseUrl!,
+          apiKey: resolveDirectApiKey('anthropic'),
+          timeout,
+          extraHeaders,
+          modelId: resolvedModelId,
+          system,
+          user,
+        });
       }
-      return chatOpenAI({ baseUrl: baseUrl!, apiKey, timeout, extraHeaders, modelId: resolvedModelId, system, user });
+      return chatOpenAI({
+        baseUrl: baseUrl!,
+        apiKey: resolveDirectApiKey('openai'),
+        timeout,
+        extraHeaders,
+        modelId: resolvedModelId,
+        system,
+        user,
+      });
     },
     async chatWithTools(modelId, system, user, tools) {
       const resolvedModelId = shouldStripPrefix ? stripProviderPrefix(modelId) : modelId;
       if (config.format === 'pi') {
-        return chatWithToolsPi({ timeout, modelId, system, user, tools, apiKeyOverride: apiKey, headers: config.headers });
+        return chatWithToolsPi({
+          timeout,
+          modelId,
+          system,
+          user,
+          tools,
+          authMode: config.authMode,
+          apiKeyEnv: config.apiKeyEnv,
+          headers: config.headers,
+        });
+      }
+      if (useCodexBridgeForOpenAI) {
+        return chatWithToolsPi({
+          timeout,
+          modelId: toOpenAIProviderModelRef(modelId),
+          system,
+          user,
+          tools,
+          authMode: config.authMode,
+          apiKeyEnv: config.apiKeyEnv,
+          headers: config.headers,
+        });
       }
       if (config.format === 'anthropic') {
-        return chatWithToolsAnthropic({ baseUrl: baseUrl!, apiKey, timeout, extraHeaders, modelId: resolvedModelId, system, user, tools });
+        return chatWithToolsAnthropic({
+          baseUrl: baseUrl!,
+          apiKey: resolveDirectApiKey('anthropic'),
+          timeout,
+          extraHeaders,
+          modelId: resolvedModelId,
+          system,
+          user,
+          tools,
+        });
       }
-      return chatWithToolsOpenAI({ baseUrl: baseUrl!, apiKey, timeout, extraHeaders, modelId: resolvedModelId, system, user, tools });
+      return chatWithToolsOpenAI({
+        baseUrl: baseUrl!,
+        apiKey: resolveDirectApiKey('openai'),
+        timeout,
+        extraHeaders,
+        modelId: resolvedModelId,
+        system,
+        user,
+        tools,
+      });
     },
     async chatAgentLoop(modelId, system, user, tools, executor, maxTurns = 5) {
       const resolvedModelId = shouldStripPrefix ? stripProviderPrefix(modelId) : modelId;
       if (config.format === 'pi') {
-        return chatAgentLoopPi({ timeout, modelId, system, user, tools, executor, maxTurns, apiKeyOverride: apiKey, headers: config.headers });
+        return chatAgentLoopPi({
+          timeout,
+          modelId,
+          system,
+          user,
+          tools,
+          executor,
+          maxTurns,
+          authMode: config.authMode,
+          apiKeyEnv: config.apiKeyEnv,
+          headers: config.headers,
+        });
+      }
+      if (useCodexBridgeForOpenAI) {
+        return chatAgentLoopPi({
+          timeout,
+          modelId: toOpenAIProviderModelRef(modelId),
+          system,
+          user,
+          tools,
+          executor,
+          maxTurns,
+          authMode: config.authMode,
+          apiKeyEnv: config.apiKeyEnv,
+          headers: config.headers,
+        });
       }
       if (config.format === 'anthropic') {
-        return chatAgentLoopAnthropic({ baseUrl: baseUrl!, apiKey, timeout, extraHeaders, modelId: resolvedModelId, system, user, tools, executor, maxTurns });
+        return chatAgentLoopAnthropic({
+          baseUrl: baseUrl!,
+          apiKey: resolveDirectApiKey('anthropic'),
+          timeout,
+          extraHeaders,
+          modelId: resolvedModelId,
+          system,
+          user,
+          tools,
+          executor,
+          maxTurns,
+        });
       }
-      return chatAgentLoopOpenAI({ baseUrl: baseUrl!, apiKey, timeout, extraHeaders, modelId: resolvedModelId, system, user, tools, executor, maxTurns });
+      return chatAgentLoopOpenAI({
+        baseUrl: baseUrl!,
+        apiKey: resolveDirectApiKey('openai'),
+        timeout,
+        extraHeaders,
+        modelId: resolvedModelId,
+        system,
+        user,
+        tools,
+        executor,
+        maxTurns,
+      });
     },
   };
 }

--- a/src/benchmark/llm/index.ts
+++ b/src/benchmark/llm/index.ts
@@ -79,6 +79,7 @@ export function createLLMClient(config: LLMConfig): LLMClient {
           headers: config.headers,
         });
       }
+      // openAICredential is only non-undefined when config.format === 'openai' (see resolveOpenAICredential)
       if (openAICredential?.source === 'codex') {
         return chatPi({
           timeout,
@@ -125,6 +126,7 @@ export function createLLMClient(config: LLMConfig): LLMClient {
           headers: config.headers,
         });
       }
+      // openAICredential is only non-undefined when config.format === 'openai' (see resolveOpenAICredential)
       if (openAICredential?.source === 'codex') {
         return chatWithToolsPi({
           timeout,
@@ -176,6 +178,7 @@ export function createLLMClient(config: LLMConfig): LLMClient {
           headers: config.headers,
         });
       }
+      // openAICredential is only non-undefined when config.format === 'openai' (see resolveOpenAICredential)
       if (openAICredential?.source === 'codex') {
         return chatAgentLoopPi({
           timeout,

--- a/src/benchmark/llm/index.ts
+++ b/src/benchmark/llm/index.ts
@@ -38,17 +38,19 @@ export function createLLMClient(config: LLMConfig): LLMClient {
   const baseUrl = config.baseUrl?.replace(/\/+$/, ''); // strip trailing slash
   const timeout = config.timeout ?? 240_000;
   const extraHeaders = config.headers ?? {};
-  const resolvedOpenAICredential = config.format === 'openai'
-    ? resolveApiCredential({
+
+  function resolveOpenAICredential() {
+    if (config.format !== 'openai') return undefined;
+    return resolveApiCredential({
       provider: 'openai',
       authMode: config.authMode,
       apiKeyEnv: config.apiKeyEnv,
-    })
-    : undefined;
-  const useCodexBridgeForOpenAI = config.format === 'openai' && resolvedOpenAICredential?.source === 'codex';
-  const resolveDirectApiKey = (provider: 'openai' | 'anthropic'): string | undefined =>
-    provider === 'openai' && resolvedOpenAICredential?.apiKey
-      ? resolvedOpenAICredential.apiKey
+    });
+  }
+
+  const resolveDirectApiKey = (provider: 'openai' | 'anthropic', openAICredential?: ReturnType<typeof resolveOpenAICredential>): string | undefined =>
+    provider === 'openai' && openAICredential?.apiKey
+      ? openAICredential.apiKey
       : requireConfiguredApiKey({
         provider,
         authMode: config.authMode,
@@ -64,6 +66,8 @@ export function createLLMClient(config: LLMConfig): LLMClient {
 
   return {
     async chat(modelId, system, user) {
+      const openAICredential = resolveOpenAICredential();
+      const useCodexBridgeForOpenAI = config.format === 'openai' && openAICredential?.source === 'codex';
       const resolvedModelId = shouldStripPrefix ? stripProviderPrefix(modelId) : modelId;
       if (config.format === 'pi') {
         return chatPi({
@@ -82,8 +86,7 @@ export function createLLMClient(config: LLMConfig): LLMClient {
           modelId: toOpenAIProviderModelRef(modelId),
           system,
           user,
-          authMode: config.authMode,
-          apiKeyEnv: config.apiKeyEnv,
+          apiKeyOverride: openAICredential?.apiKey,
           headers: config.headers,
         });
       }
@@ -100,7 +103,7 @@ export function createLLMClient(config: LLMConfig): LLMClient {
       }
       return chatOpenAI({
         baseUrl: baseUrl!,
-        apiKey: resolveDirectApiKey('openai'),
+        apiKey: resolveDirectApiKey('openai', openAICredential),
         timeout,
         extraHeaders,
         modelId: resolvedModelId,
@@ -109,6 +112,8 @@ export function createLLMClient(config: LLMConfig): LLMClient {
       });
     },
     async chatWithTools(modelId, system, user, tools) {
+      const openAICredential = resolveOpenAICredential();
+      const useCodexBridgeForOpenAI = config.format === 'openai' && openAICredential?.source === 'codex';
       const resolvedModelId = shouldStripPrefix ? stripProviderPrefix(modelId) : modelId;
       if (config.format === 'pi') {
         return chatWithToolsPi({
@@ -129,8 +134,7 @@ export function createLLMClient(config: LLMConfig): LLMClient {
           system,
           user,
           tools,
-          authMode: config.authMode,
-          apiKeyEnv: config.apiKeyEnv,
+          apiKeyOverride: openAICredential?.apiKey,
           headers: config.headers,
         });
       }
@@ -148,7 +152,7 @@ export function createLLMClient(config: LLMConfig): LLMClient {
       }
       return chatWithToolsOpenAI({
         baseUrl: baseUrl!,
-        apiKey: resolveDirectApiKey('openai'),
+        apiKey: resolveDirectApiKey('openai', openAICredential),
         timeout,
         extraHeaders,
         modelId: resolvedModelId,
@@ -158,6 +162,8 @@ export function createLLMClient(config: LLMConfig): LLMClient {
       });
     },
     async chatAgentLoop(modelId, system, user, tools, executor, maxTurns = 5) {
+      const openAICredential = resolveOpenAICredential();
+      const useCodexBridgeForOpenAI = config.format === 'openai' && openAICredential?.source === 'codex';
       const resolvedModelId = shouldStripPrefix ? stripProviderPrefix(modelId) : modelId;
       if (config.format === 'pi') {
         return chatAgentLoopPi({
@@ -182,8 +188,7 @@ export function createLLMClient(config: LLMConfig): LLMClient {
           tools,
           executor,
           maxTurns,
-          authMode: config.authMode,
-          apiKeyEnv: config.apiKeyEnv,
+          apiKeyOverride: openAICredential?.apiKey,
           headers: config.headers,
         });
       }
@@ -203,7 +208,7 @@ export function createLLMClient(config: LLMConfig): LLMClient {
       }
       return chatAgentLoopOpenAI({
         baseUrl: baseUrl!,
-        apiKey: resolveDirectApiKey('openai'),
+        apiKey: resolveDirectApiKey('openai', openAICredential),
         timeout,
         extraHeaders,
         modelId: resolvedModelId,

--- a/src/benchmark/llm/index.ts
+++ b/src/benchmark/llm/index.ts
@@ -81,12 +81,17 @@ export function createLLMClient(config: LLMConfig): LLMClient {
       }
       // openAICredential is only non-undefined when config.format === 'openai' (see resolveOpenAICredential)
       if (openAICredential?.source === 'codex') {
+        // Pass authMode:'codex' so Pi re-reads ~/.codex/auth.json and sets source:'codex',
+        // which is required for resolvePiModel to route to the openai-codex provider
+        // (synthesizeOpenAICodexModel guards on provider === 'openai-codex'). Using
+        // apiKeyOverride here would return source:'override' and break that routing.
         return chatPi({
           timeout,
           modelId: toOpenAIProviderModelRef(modelId),
           system,
           user,
-          apiKeyOverride: openAICredential?.apiKey,
+          authMode: 'codex',
+          apiKeyEnv: config.apiKeyEnv,
           headers: config.headers,
         });
       }
@@ -134,7 +139,8 @@ export function createLLMClient(config: LLMConfig): LLMClient {
           system,
           user,
           tools,
-          apiKeyOverride: openAICredential?.apiKey,
+          authMode: 'codex',
+          apiKeyEnv: config.apiKeyEnv,
           headers: config.headers,
         });
       }
@@ -188,7 +194,8 @@ export function createLLMClient(config: LLMConfig): LLMClient {
           tools,
           executor,
           maxTurns,
-          apiKeyOverride: openAICredential?.apiKey,
+          authMode: 'codex',
+          apiKeyEnv: config.apiKeyEnv,
           headers: config.headers,
         });
       }

--- a/src/benchmark/llm/index.ts
+++ b/src/benchmark/llm/index.ts
@@ -48,7 +48,7 @@ export function createLLMClient(config: LLMConfig): LLMClient {
     });
   }
 
-  const resolveDirectApiKey = (provider: 'openai' | 'anthropic', openAICredential?: ReturnType<typeof resolveOpenAICredential>): string | undefined =>
+  const resolveDirectApiKey = (provider: 'openai' | 'anthropic', openAICredential?: ReturnType<typeof resolveOpenAICredential>): string =>
     provider === 'openai' && openAICredential?.apiKey
       ? openAICredential.apiKey
       : requireConfiguredApiKey({

--- a/src/benchmark/llm/index.ts
+++ b/src/benchmark/llm/index.ts
@@ -67,7 +67,6 @@ export function createLLMClient(config: LLMConfig): LLMClient {
   return {
     async chat(modelId, system, user) {
       const openAICredential = resolveOpenAICredential();
-      const useCodexBridgeForOpenAI = config.format === 'openai' && openAICredential?.source === 'codex';
       const resolvedModelId = shouldStripPrefix ? stripProviderPrefix(modelId) : modelId;
       if (config.format === 'pi') {
         return chatPi({
@@ -80,7 +79,7 @@ export function createLLMClient(config: LLMConfig): LLMClient {
           headers: config.headers,
         });
       }
-      if (useCodexBridgeForOpenAI) {
+      if (openAICredential?.source === 'codex') {
         return chatPi({
           timeout,
           modelId: toOpenAIProviderModelRef(modelId),
@@ -113,7 +112,6 @@ export function createLLMClient(config: LLMConfig): LLMClient {
     },
     async chatWithTools(modelId, system, user, tools) {
       const openAICredential = resolveOpenAICredential();
-      const useCodexBridgeForOpenAI = config.format === 'openai' && openAICredential?.source === 'codex';
       const resolvedModelId = shouldStripPrefix ? stripProviderPrefix(modelId) : modelId;
       if (config.format === 'pi') {
         return chatWithToolsPi({
@@ -127,7 +125,7 @@ export function createLLMClient(config: LLMConfig): LLMClient {
           headers: config.headers,
         });
       }
-      if (useCodexBridgeForOpenAI) {
+      if (openAICredential?.source === 'codex') {
         return chatWithToolsPi({
           timeout,
           modelId: toOpenAIProviderModelRef(modelId),
@@ -163,7 +161,6 @@ export function createLLMClient(config: LLMConfig): LLMClient {
     },
     async chatAgentLoop(modelId, system, user, tools, executor, maxTurns = 5) {
       const openAICredential = resolveOpenAICredential();
-      const useCodexBridgeForOpenAI = config.format === 'openai' && openAICredential?.source === 'codex';
       const resolvedModelId = shouldStripPrefix ? stripProviderPrefix(modelId) : modelId;
       if (config.format === 'pi') {
         return chatAgentLoopPi({
@@ -179,7 +176,7 @@ export function createLLMClient(config: LLMConfig): LLMClient {
           headers: config.headers,
         });
       }
-      if (useCodexBridgeForOpenAI) {
+      if (openAICredential?.source === 'codex') {
         return chatAgentLoopPi({
           timeout,
           modelId: toOpenAIProviderModelRef(modelId),

--- a/src/benchmark/llm/openai-format.ts
+++ b/src/benchmark/llm/openai-format.ts
@@ -1,4 +1,5 @@
 import type { LLMResponse, McpToolDefinition, ToolExecutor } from '../types.js';
+import { createToolNameAliasCodec } from './tool-name-aliases.js';
 
 interface CallParams {
   baseUrl: string;
@@ -35,17 +36,18 @@ export async function chatOpenAI(params: CallParams): Promise<LLMResponse> {
  * POST {baseUrl}/chat/completions with tools array
  */
 export async function chatWithToolsOpenAI(params: CallWithToolsParams): Promise<LLMResponse> {
+  const toolCodec = createToolNameAliasCodec(params.tools);
   const body = {
     model: params.modelId,
     messages: [
       { role: 'system', content: params.system },
       { role: 'user', content: params.user },
     ],
-    tools: params.tools,
+    tools: toolCodec.tools,
     tool_choice: 'auto',
     temperature: 0.2,
   };
-  return callWithRetry(params, body);
+  return callWithRetry(params, body, toolCodec.toCanonical);
 }
 
 async function doFetch(params: CallParams, body: Record<string, unknown>): Promise<LLMResponse> {
@@ -132,6 +134,7 @@ interface AgentLoopParams extends CallWithToolsParams {
 }
 
 export async function chatAgentLoopOpenAI(params: AgentLoopParams): Promise<LLMResponse> {
+  const toolCodec = createToolNameAliasCodec(params.tools);
   const messages: Array<Record<string, unknown>> = [
     { role: 'system', content: params.system },
     { role: 'user', content: params.user },
@@ -141,9 +144,9 @@ export async function chatAgentLoopOpenAI(params: AgentLoopParams): Promise<LLMR
 
   for (let turn = 0; turn < params.maxTurns; turn++) {
     const body: Record<string, unknown> = {
-      model: params.modelId, messages, tools: params.tools, tool_choice: 'auto', temperature: 0.2,
+      model: params.modelId, messages, tools: toolCodec.tools, tool_choice: 'auto', temperature: 0.2,
     };
-    const response = await callWithRetry(params, body);
+    const response = await callWithRetry(params, body, toolCodec.toCanonical);
     if (response.usage) {
       totalUsage.prompt += response.usage.prompt;
       totalUsage.completion += response.usage.completion;
@@ -155,7 +158,14 @@ export async function chatAgentLoopOpenAI(params: AgentLoopParams): Promise<LLMR
     allToolCalls.push(...response.toolCalls);
     messages.push({
       role: 'assistant', content: response.content || null,
-      tool_calls: response.toolCalls.map((tc, i) => ({ id: `call_${turn}_${i}`, type: 'function', function: { name: tc.name, arguments: JSON.stringify(tc.arguments) } })),
+      tool_calls: response.toolCalls.map((tc, i) => ({
+        id: `call_${turn}_${i}`,
+        type: 'function',
+        function: {
+          name: toolCodec.toProvider(tc.name),
+          arguments: JSON.stringify(tc.arguments),
+        },
+      })),
     });
     const MAX_TOOL_RESULT_CHARS = 50_000;
     for (let i = 0; i < response.toolCalls.length; i++) {
@@ -175,9 +185,21 @@ export async function chatAgentLoopOpenAI(params: AgentLoopParams): Promise<LLMR
 async function callWithRetry(
   params: CallParams,
   body: Record<string, unknown>,
+  toCanonicalToolName: (name: string) => string = (name) => name,
 ): Promise<LLMResponse> {
   try {
-    return await doFetch(params, body);
+    const response = await doFetch(params, body);
+    if (!response.toolCalls || response.toolCalls.length === 0) {
+      return response;
+    }
+
+    return {
+      ...response,
+      toolCalls: response.toolCalls.map((toolCall) => ({
+        ...toolCall,
+        name: toCanonicalToolName(toolCall.name),
+      })),
+    };
   } catch (err) {
     if (err && typeof err === 'object' && 'name' in err && err.name === 'AbortError') {
       throw err;
@@ -191,6 +213,17 @@ async function callWithRetry(
     }
     // Retry once after 3s
     await new Promise((resolve) => setTimeout(resolve, 3_000));
-    return doFetch(params, body);
+    const response = await doFetch(params, body);
+    if (!response.toolCalls || response.toolCalls.length === 0) {
+      return response;
+    }
+
+    return {
+      ...response,
+      toolCalls: response.toolCalls.map((toolCall) => ({
+        ...toolCall,
+        name: toCanonicalToolName(toolCall.name),
+      })),
+    };
   }
 }

--- a/src/benchmark/llm/pi-format.ts
+++ b/src/benchmark/llm/pi-format.ts
@@ -6,7 +6,9 @@ import type { LLMResponse, McpToolDefinition, ToolExecutor } from '../types.js';
 import { resolvePiModelByRef } from '../../runtime/pi/index.js';
 
 interface PiCallParams {
+  authMode?: import('../../runtime/pi/auth.js').PiAuthMode;
   apiKeyOverride?: string;
+  apiKeyEnv?: string;
   headers?: Record<string, string>;
   timeout: number;
   modelId: string;
@@ -27,7 +29,14 @@ interface ResolvedPiRequest {
 }
 
 type PiImplementationSet = {
-  resolve(modelId: string, apiKeyOverride?: string): Promise<ResolvedPiRequest>;
+  resolve(
+    modelId: string,
+    authOptions?: {
+      authMode?: import('../../runtime/pi/auth.js').PiAuthMode;
+      apiKeyEnv?: string;
+      apiKeyOverride?: string;
+    },
+  ): Promise<ResolvedPiRequest>;
   completeSimple(model: Model<any>, context: Context, options?: SimpleStreamOptions): Promise<AssistantMessage>;
   complete(model: Model<any>, context: Context, options?: SimpleStreamOptions): Promise<AssistantMessage>;
 };
@@ -40,7 +49,11 @@ export function __setPiImplementationsForTest(implementations: PiImplementationS
 
 export async function chatPi(params: PiCallParams): Promise<LLMResponse> {
   const impl = getPiImplementations();
-  const { model, auth } = await impl.resolve(params.modelId, params.apiKeyOverride);
+  const { model, auth } = await impl.resolve(params.modelId, {
+    authMode: params.authMode,
+    apiKeyEnv: params.apiKeyEnv,
+    apiKeyOverride: params.apiKeyOverride,
+  });
   const response = await impl.completeSimple(
     model,
     {
@@ -54,7 +67,11 @@ export async function chatPi(params: PiCallParams): Promise<LLMResponse> {
 
 export async function chatWithToolsPi(params: PiCallWithToolsParams): Promise<LLMResponse> {
   const impl = getPiImplementations();
-  const { model, auth } = await impl.resolve(params.modelId, params.apiKeyOverride);
+  const { model, auth } = await impl.resolve(params.modelId, {
+    authMode: params.authMode,
+    apiKeyEnv: params.apiKeyEnv,
+    apiKeyOverride: params.apiKeyOverride,
+  });
   const response = await impl.complete(
     model,
     {
@@ -74,7 +91,11 @@ interface PiAgentLoopParams extends PiCallWithToolsParams {
 
 export async function chatAgentLoopPi(params: PiAgentLoopParams): Promise<LLMResponse> {
   const impl = getPiImplementations();
-  const { model, auth } = await impl.resolve(params.modelId, params.apiKeyOverride);
+  const { model, auth } = await impl.resolve(params.modelId, {
+    authMode: params.authMode,
+    apiKeyEnv: params.apiKeyEnv,
+    apiKeyOverride: params.apiKeyOverride,
+  });
   const messages: Context['messages'] = [
     { role: 'user', content: params.user, timestamp: Date.now() },
   ];
@@ -146,8 +167,15 @@ function getPiImplementations(): PiImplementationSet {
   };
 }
 
-async function resolvePiRequest(modelId: string, apiKeyOverride?: string): Promise<ResolvedPiRequest> {
-  const resolved = await resolvePiModelByRef(modelId, { apiKeyOverride });
+async function resolvePiRequest(
+  modelId: string,
+  authOptions?: {
+    authMode?: import('../../runtime/pi/auth.js').PiAuthMode;
+    apiKeyEnv?: string;
+    apiKeyOverride?: string;
+  },
+): Promise<ResolvedPiRequest> {
+  const resolved = await resolvePiModelByRef(modelId, authOptions);
   return {
     model: resolved.model,
     auth: {

--- a/src/benchmark/llm/pi-format.ts
+++ b/src/benchmark/llm/pi-format.ts
@@ -4,6 +4,7 @@ import { complete, completeSimple } from '@mariozechner/pi-ai';
 
 import type { LLMResponse, McpToolDefinition, ToolExecutor } from '../types.js';
 import { resolvePiModelByRef } from '../../runtime/pi/index.js';
+import { createToolNameAliasCodec } from './tool-name-aliases.js';
 
 interface PiCallParams {
   authMode?: import('../../runtime/pi/auth.js').PiAuthMode;
@@ -62,11 +63,13 @@ export async function chatPi(params: PiCallParams): Promise<LLMResponse> {
     },
     buildPiOptions(params.timeout, auth, params.headers),
   );
+  assertPiResponseSucceeded(response);
   return toLLMResponse(response);
 }
 
 export async function chatWithToolsPi(params: PiCallWithToolsParams): Promise<LLMResponse> {
   const impl = getPiImplementations();
+  const toolCodec = createToolNameAliasCodec(params.tools);
   const { model, auth } = await impl.resolve(params.modelId, {
     authMode: params.authMode,
     apiKeyEnv: params.apiKeyEnv,
@@ -77,11 +80,12 @@ export async function chatWithToolsPi(params: PiCallWithToolsParams): Promise<LL
     {
       systemPrompt: params.system,
       messages: [{ role: 'user', content: params.user, timestamp: Date.now() }],
-      tools: params.tools.map(toPiTool),
+      tools: toolCodec.tools.map(toPiTool),
     },
     buildPiOptions(params.timeout, auth, params.headers),
   );
-  return toLLMResponse(response);
+  assertPiResponseSucceeded(response);
+  return toLLMResponse(response, toolCodec.toCanonical);
 }
 
 interface PiAgentLoopParams extends PiCallWithToolsParams {
@@ -91,6 +95,7 @@ interface PiAgentLoopParams extends PiCallWithToolsParams {
 
 export async function chatAgentLoopPi(params: PiAgentLoopParams): Promise<LLMResponse> {
   const impl = getPiImplementations();
+  const toolCodec = createToolNameAliasCodec(params.tools);
   const { model, auth } = await impl.resolve(params.modelId, {
     authMode: params.authMode,
     apiKeyEnv: params.apiKeyEnv,
@@ -108,12 +113,13 @@ export async function chatAgentLoopPi(params: PiAgentLoopParams): Promise<LLMRes
       {
         systemPrompt: params.system,
         messages,
-        tools: params.tools.map(toPiTool),
+        tools: toolCodec.tools.map(toPiTool),
       },
       buildPiOptions(params.timeout, auth, params.headers),
     );
 
-    finalResponse = toLLMResponse(response);
+    assertPiResponseSucceeded(response);
+    finalResponse = toLLMResponse(response, toolCodec.toCanonical);
     if (!finalResponse.toolCalls || finalResponse.toolCalls.length === 0) {
       return {
         ...finalResponse,
@@ -129,10 +135,11 @@ export async function chatAgentLoopPi(params: PiAgentLoopParams): Promise<LLMRes
     );
 
     for (const toolCall of responseToolCalls) {
+      const canonicalToolName = toolCodec.toCanonical(toolCall.name);
       let result: string;
       let isError = false;
       try {
-        result = await params.executor(toolCall.name, toolCall.arguments);
+        result = await params.executor(canonicalToolName, toolCall.arguments);
       } catch (error) {
         isError = true;
         result = `Error: ${error instanceof Error ? error.message : String(error)}`;
@@ -208,7 +215,16 @@ function toPiTool(tool: McpToolDefinition): PiTool {
   };
 }
 
-function toLLMResponse(message: AssistantMessage): LLMResponse {
+function assertPiResponseSucceeded(message: AssistantMessage): void {
+  if (message.stopReason === 'error') {
+    throw new Error(message.errorMessage ?? 'PI model returned an unknown error');
+  }
+}
+
+function toLLMResponse(
+  message: AssistantMessage,
+  toCanonicalToolName: (name: string) => string = (name) => name,
+): LLMResponse {
   const content = message.content
     .filter((block): block is Extract<AssistantMessage['content'][number], { type: 'text' }> => block.type === 'text')
     .map((block) => block.text)
@@ -216,7 +232,10 @@ function toLLMResponse(message: AssistantMessage): LLMResponse {
 
   const toolCalls = message.content
     .filter((block): block is Extract<AssistantMessage['content'][number], { type: 'toolCall' }> => block.type === 'toolCall')
-    .map((block) => ({ name: block.name, arguments: block.arguments as Record<string, unknown> }));
+    .map((block) => ({
+      name: toCanonicalToolName(block.name),
+      arguments: block.arguments as Record<string, unknown>,
+    }));
 
   return {
     content,

--- a/src/benchmark/llm/tool-name-aliases.ts
+++ b/src/benchmark/llm/tool-name-aliases.ts
@@ -1,0 +1,65 @@
+import type { McpToolDefinition } from '../types.js';
+
+const PROVIDER_TOOL_NAME_PATTERN = /[^a-zA-Z0-9_-]/g;
+
+export interface ToolNameAliasCodec {
+  tools: McpToolDefinition[];
+  toCanonical(name: string): string;
+  toProvider(name: string): string;
+}
+
+export function createToolNameAliasCodec(
+  tools: McpToolDefinition[],
+): ToolNameAliasCodec {
+  const usedProviderNames = new Set<string>();
+  const canonicalToProvider = new Map<string, string>();
+  const providerToCanonical = new Map<string, string>();
+
+  const aliasedTools = tools.map((tool) => {
+    const canonicalName = tool.function.name;
+    let providerName = sanitizeToolName(canonicalName);
+
+    if (providerName.length === 0) {
+      providerName = 'tool';
+    }
+
+    if (usedProviderNames.has(providerName)) {
+      const baseName = providerName;
+      let suffix = 1;
+      while (usedProviderNames.has(`${baseName}__${suffix}`)) {
+        suffix += 1;
+      }
+      providerName = `${baseName}__${suffix}`;
+    }
+
+    usedProviderNames.add(providerName);
+    canonicalToProvider.set(canonicalName, providerName);
+    providerToCanonical.set(providerName, canonicalName);
+
+    if (providerName === canonicalName) {
+      return tool;
+    }
+
+    return {
+      ...tool,
+      function: {
+        ...tool.function,
+        name: providerName,
+      },
+    };
+  });
+
+  return {
+    tools: aliasedTools,
+    toCanonical(name: string) {
+      return providerToCanonical.get(name) ?? name;
+    },
+    toProvider(name: string) {
+      return canonicalToProvider.get(name) ?? name;
+    },
+  };
+}
+
+function sanitizeToolName(name: string): string {
+  return name.replace(PROVIDER_TOOL_NAME_PATTERN, '_');
+}

--- a/src/benchmark/types.ts
+++ b/src/benchmark/types.ts
@@ -87,6 +87,7 @@ export interface SkillConfig {
 
 export interface LLMConfig {
   baseUrl?: string;                // required for direct openai/anthropic formats
+  authMode?: 'env' | 'codex' | 'auto';
   apiKeyEnv?: string;              // e.g. "OPENROUTER_API_KEY" — reads from process.env
   format: 'openai' | 'anthropic' | 'pi';
   timeout?: number;                // ms, default 240000

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -485,22 +485,27 @@ async function main(): Promise<void> {
           `Edit "target.repoPath" in ${project.configPath}.`,
       );
     }
-    const benchmarkProvider = project.benchmark.format === 'openai'
-      ? 'openai'
+    // Preflight: check credentials for every unique provider in the benchmark config.
+    // For direct-API formats there is one provider; for pi format each model may need
+    // a different key (e.g. openrouter + openai in the same run).
+    const benchmarkProviders = project.benchmark.format === 'openai'
+      ? ['openai']
       : project.benchmark.format === 'anthropic'
-        ? 'anthropic'
-        : parseModelRef(project.benchmark.models[0]!.id).provider;
-    try {
-      requireConfiguredApiKey({
-        provider: benchmarkProvider,
-        authMode: project.benchmark.authMode,
-        apiKeyEnv: project.benchmark.apiKeyEnv,
-      });
-    } catch (error) {
-      throw new Error(
-        `${error instanceof Error ? error.message : String(error)} ` +
-          `Configure auth in ${project.configPath} before running the benchmark.`,
-      );
+        ? ['anthropic']
+        : [...new Set(project.benchmark.models.map(m => parseModelRef(m.id).provider))];
+    for (const benchmarkProvider of benchmarkProviders) {
+      try {
+        requireConfiguredApiKey({
+          provider: benchmarkProvider,
+          authMode: project.benchmark.authMode,
+          apiKeyEnv: project.benchmark.apiKeyEnv,
+        });
+      } catch (error) {
+        throw new Error(
+          `${error instanceof Error ? error.message : String(error)} ` +
+            `Configure auth in ${project.configPath} before running the benchmark.`,
+        );
+      }
     }
     if (project.benchmark.taskGeneration.enabled) {
       const modelRef = project.optimize?.model ?? project.benchmark.models[0]!.id;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,7 @@ import type { WizardAnswers } from './init/answers.js';
 import { runWizard } from './init/wizard.js';
 import { detectProject, detectedToPreseed, printDetectionSummary } from './init/detect-project.js';
 import { ERRORS, SkillOptimizerError, printError } from './errors.js';
+import { requireConfiguredApiKey } from './runtime/pi/index.js';
 
 // ── Error handling ────────────────────────────────────────────────────────────
 
@@ -393,6 +394,7 @@ async function main(): Promise<void> {
               const criticDeps = createDefaultPiCritic({
                 provider: mutation.provider,
                 model: mutation.model,
+                authMode: mutation.authMode,
                 apiKeyEnv: mutation.apiKeyEnv,
               });
               recs = await generateRecommendations(
@@ -426,6 +428,7 @@ async function main(): Promise<void> {
       const deps = createDefaultPiTaskGenerator({
         provider,
         model,
+        authMode: project.optimize?.authMode ?? project.benchmark.authMode,
         apiKeyEnv: project.optimize?.apiKeyEnv ?? project.benchmark.apiKeyEnv,
       });
       const result = await generateTasksForProject({
@@ -482,10 +485,21 @@ async function main(): Promise<void> {
           `Edit "target.repoPath" in ${project.configPath}.`,
       );
     }
-    if (project.benchmark.format !== 'anthropic' && !process.env[project.benchmark.apiKeyEnv ?? 'OPENROUTER_API_KEY']) {
+    const benchmarkProvider = project.benchmark.format === 'openai'
+      ? 'openai'
+      : project.benchmark.format === 'anthropic'
+        ? 'anthropic'
+        : parseModelRef(project.benchmark.models[0]!.id).provider;
+    try {
+      requireConfiguredApiKey({
+        provider: benchmarkProvider,
+        authMode: project.benchmark.authMode,
+        apiKeyEnv: project.benchmark.apiKeyEnv,
+      });
+    } catch (error) {
       throw new Error(
-        `Missing ${project.benchmark.apiKeyEnv ?? 'OPENROUTER_API_KEY'} environment variable. ` +
-          `Set it in your shell or in a .env file alongside ${project.configPath}.`,
+        `${error instanceof Error ? error.message : String(error)} ` +
+          `Configure auth in ${project.configPath} before running the benchmark.`,
       );
     }
     if (project.benchmark.taskGeneration.enabled) {
@@ -494,6 +508,7 @@ async function main(): Promise<void> {
       const deps = createDefaultPiTaskGenerator({
         provider,
         model,
+        authMode: project.optimize?.authMode ?? project.benchmark.authMode,
         apiKeyEnv: project.optimize?.apiKeyEnv ?? project.benchmark.apiKeyEnv,
       });
       const generation = await generateTasksForProject({
@@ -544,6 +559,7 @@ async function main(): Promise<void> {
       const criticDeps = createDefaultPiCritic({
         provider,
         model,
+        authMode: project.optimize?.authMode ?? project.benchmark.authMode,
         apiKeyEnv: project.optimize?.apiKeyEnv ?? project.benchmark.apiKeyEnv,
       });
       recommendations = await generateRecommendations(

--- a/src/discovery/mcp.ts
+++ b/src/discovery/mcp.ts
@@ -301,6 +301,7 @@ function toDiscoveredAction(toolDefinition: LiteralObject, source: string): Disc
       required: requiredNames.includes(argName),
       type: typeof schemaValue.type === 'string' ? schemaValue.type : undefined,
       description: typeof schemaValue.description === 'string' ? schemaValue.description : undefined,
+      schema: schemaValue,
     });
   }
 

--- a/src/discovery/types.ts
+++ b/src/discovery/types.ts
@@ -3,6 +3,7 @@ export interface DiscoveredActionArg {
   required: boolean;
   type?: string;
   description?: string;
+  schema?: Record<string, unknown>;
 }
 
 export interface DiscoveredAction {

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -1,6 +1,7 @@
 import type { ResolvedProjectConfig } from '../project/types.js';
 import type { Issue } from '../project/validate.js';
 import { discoverActionsOnly, resolveScope } from '../tasks/index.js';
+import { requireConfiguredApiKey } from '../runtime/pi/index.js';
 
 /**
  * Tier-2: discover actions and verify scope + maxTasks.
@@ -63,8 +64,6 @@ export function checkDiscovery(project: ResolvedProjectConfig): Issue[] {
  */
 export async function checkModelReachability(project: ResolvedProjectConfig): Promise<Issue[]> {
   const issues: Issue[] = [];
-  const apiKey = process.env[project.benchmark.apiKeyEnv ?? 'OPENROUTER_API_KEY'];
-  if (!apiKey) return issues; // already reported by checkConfig
 
   // Only PI format uses OpenRouter; skip reachability for other formats
   if (project.benchmark.format && project.benchmark.format !== 'pi') {
@@ -74,6 +73,29 @@ export async function checkModelReachability(project: ResolvedProjectConfig): Pr
       fixable: false,
     });
     return issues;
+  }
+
+  const provider = project.benchmark.models.length > 0
+    ? project.benchmark.models[0]!.id.split('/')[0]!
+    : 'openrouter';
+  if (provider !== 'openrouter') {
+    issues.push({
+      code: 'reachability-skipped', severity: 'info', field: 'benchmark.models',
+      message: 'Skipping reachability check (--check-models currently probes OpenRouter models only)',
+      fixable: false,
+    });
+    return issues;
+  }
+
+  let apiKey: string;
+  try {
+    apiKey = requireConfiguredApiKey({
+      provider,
+      authMode: project.benchmark.authMode,
+      apiKeyEnv: project.benchmark.apiKeyEnv,
+    });
+  } catch {
+    return issues; // already reported by checkConfig
   }
 
   for (let i = 0; i < project.benchmark.models.length; i++) {

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -75,22 +75,27 @@ export async function checkModelReachability(project: ResolvedProjectConfig): Pr
     return issues;
   }
 
-  const provider = project.benchmark.models.length > 0
-    ? project.benchmark.models[0]!.id.split('/')[0]!
-    : 'openrouter';
-  if (provider !== 'openrouter') {
+  const openrouterEntries = project.benchmark.models
+    .map((model, i) => ({ model, i }))
+    .filter(({ model }) => model.id.startsWith('openrouter/'));
+  const skippedCount = project.benchmark.models.length - openrouterEntries.length;
+
+  if (skippedCount > 0) {
     issues.push({
       code: 'reachability-skipped', severity: 'info', field: 'benchmark.models',
-      message: 'Skipping reachability check (--check-models currently probes OpenRouter models only)',
+      message: `Skipping reachability for ${skippedCount} non-OpenRouter model(s) (only OpenRouter models can be probed)`,
       fixable: false,
     });
+  }
+
+  if (openrouterEntries.length === 0) {
     return issues;
   }
 
   let apiKey: string;
   try {
     apiKey = requireConfiguredApiKey({
-      provider,
+      provider: 'openrouter',
       authMode: project.benchmark.authMode,
       apiKeyEnv: project.benchmark.apiKeyEnv,
     });
@@ -98,8 +103,7 @@ export async function checkModelReachability(project: ResolvedProjectConfig): Pr
     return issues; // already reported by checkConfig
   }
 
-  for (let i = 0; i < project.benchmark.models.length; i++) {
-    const model = project.benchmark.models[i]!;
+  for (const { model, i } of openrouterEntries) {
     try {
       const res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
         method: 'POST',

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -69,7 +69,7 @@ export async function checkModelReachability(project: ResolvedProjectConfig): Pr
   if (project.benchmark.format && project.benchmark.format !== 'pi') {
     issues.push({
       code: 'reachability-skipped', severity: 'info', field: 'benchmark.format',
-      message: `Skipping reachability check (--check-models only supports format "pi" for now)`,
+      message: `Skipping reachability check — model probing is only implemented for openrouter/* model IDs via the OpenRouter API`,
       fixable: false,
     });
     return issues;

--- a/src/init/scaffold.ts
+++ b/src/init/scaffold.ts
@@ -67,7 +67,6 @@ export function buildConfigFromAnswers(answers: WizardAnswers, configDir: string
   const skillAllowedPath = relative(repoPath, skillAbsPath);
 
   const commonBenchmark = {
-    apiKeyEnv: 'OPENROUTER_API_KEY',
     format: 'pi',
     timeout: 240000,
     taskGeneration: { enabled: true, maxTasks, outputDir: '.' },

--- a/src/init/scaffold.ts
+++ b/src/init/scaffold.ts
@@ -78,7 +78,6 @@ export function buildConfigFromAnswers(answers: WizardAnswers, configDir: string
 
   const commonOptimize = {
     model: 'openrouter/anthropic/claude-sonnet-4-6',
-    apiKeyEnv: 'OPENROUTER_API_KEY',
     allowedPaths: [skillAllowedPath],
     validation: [],
     maxIterations,

--- a/src/optimizer/main.ts
+++ b/src/optimizer/main.ts
@@ -101,6 +101,7 @@ export async function runOptimizeFromConfig(
           const deps = createDefaultPiTaskGenerator({
             provider: mutation.provider,
             model: mutation.model,
+            authMode: mutation.authMode,
             apiKeyEnv: mutation.apiKeyEnv,
           });
           const generation = await generateTasksForProject({

--- a/src/optimizer/mutation/pi-coding.ts
+++ b/src/optimizer/mutation/pi-coding.ts
@@ -28,6 +28,7 @@ export class PiCodingMutationExecutor {
     const { session } = await createCodingOrchestratorSession({
       cwd: agentCwd,
       modelRef: `${mutation.provider}/${mutation.model}`,
+      authMode: mutation.authMode,
       apiKeyEnv: mutation.apiKeyEnv,
       thinkingLevel: mutation.thinkingLevel ?? 'medium',
     });

--- a/src/optimizer/types.ts
+++ b/src/optimizer/types.ts
@@ -35,6 +35,7 @@ export interface OptimizeMutationConfig {
   provider: string;
   model: string;
   thinkingLevel?: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+  authMode?: 'env' | 'codex' | 'auto';
   apiKeyEnv?: string;
   reportContextMaxBytes?: number;
 }

--- a/src/optimizer/types.ts
+++ b/src/optimizer/types.ts
@@ -1,4 +1,5 @@
 import type { BenchmarkReport, BenchmarkSurface, ModelConfig, ModelSummary } from '../benchmark/types.js';
+import type { PiAuthMode } from '../runtime/pi/auth.js';
 
 export type FailureBucketKind = 'missing-tool' | 'bad-args' | 'hallucination' | 'error';
 export type StopReason = 'max-iterations' | 'stable';
@@ -35,7 +36,7 @@ export interface OptimizeMutationConfig {
   provider: string;
   model: string;
   thinkingLevel?: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
-  authMode?: 'env' | 'codex' | 'auto';
+  authMode?: PiAuthMode;
   apiKeyEnv?: string;
   reportContextMaxBytes?: number;
 }

--- a/src/project/adapters.ts
+++ b/src/project/adapters.ts
@@ -21,6 +21,7 @@ export function toBenchmarkConfig(project: ResolvedProjectConfig): BenchmarkConf
     llm: {
       format: project.benchmark.format,
       baseUrl: project.benchmark.baseUrl,
+      authMode: project.benchmark.authMode,
       apiKeyEnv: project.benchmark.apiKeyEnv,
       timeout: project.benchmark.timeout,
       headers: project.benchmark.headers,
@@ -78,6 +79,7 @@ export function toOptimizeManifest(project: ResolvedProjectConfig): ResolvedOpti
     mutation: {
       provider: mutationModel.provider,
       model: mutationModel.model,
+      authMode: optimize.authMode,
       apiKeyEnv: optimize.apiKeyEnv,
       thinkingLevel: optimize.thinkingLevel,
       reportContextMaxBytes: optimize.reportContextMaxBytes,
@@ -115,6 +117,7 @@ export function toLegacyOptimizeManifest(project: ResolvedProjectConfig): Optimi
     },
     mutation: {
       ...parseModelRef(optimize.model),
+      authMode: optimize.authMode,
       apiKeyEnv: optimize.apiKeyEnv,
       thinkingLevel: optimize.thinkingLevel,
       reportContextMaxBytes: optimize.reportContextMaxBytes,

--- a/src/project/resolve.ts
+++ b/src/project/resolve.ts
@@ -3,6 +3,7 @@ import { dirname, resolve } from 'node:path';
 import type { ProjectConfig, ResolvedProjectConfig } from './types.js';
 
 const DEFAULT_BENCHMARK_FORMAT = 'pi';
+const DEFAULT_AUTH_MODE = 'env';
 const DEFAULT_TIMEOUT = 240_000;
 const DEFAULT_OUTPUT_DIR = 'benchmark-results';
 const DEFAULT_GENERATION_OUTPUT_DIR = '.skill-optimizer';
@@ -97,6 +98,7 @@ export function resolveProjectConfig(config: ProjectConfig, configPath: string):
     benchmark: {
       format: config.benchmark.format ?? DEFAULT_BENCHMARK_FORMAT,
       baseUrl: config.benchmark.baseUrl,
+      authMode: config.benchmark.authMode ?? DEFAULT_AUTH_MODE,
       apiKeyEnv: config.benchmark.apiKeyEnv,
       timeout: config.benchmark.timeout ?? DEFAULT_TIMEOUT,
       headers: config.benchmark.headers,
@@ -123,6 +125,7 @@ export function resolveProjectConfig(config: ProjectConfig, configPath: string):
           enabled: config.optimize.enabled ?? true,
           mode: config.optimize.mode ?? 'stable-surface',
           model: config.optimize.model ?? config.benchmark.models[0]!.id,
+          authMode: config.optimize.authMode ?? config.benchmark.authMode ?? DEFAULT_AUTH_MODE,
           apiKeyEnv: config.optimize.apiKeyEnv ?? config.benchmark.apiKeyEnv,
           thinkingLevel: config.optimize.thinkingLevel ?? 'medium',
           allowedPaths: [...(config.optimize.allowedPaths ?? [])],

--- a/src/project/schema.ts
+++ b/src/project/schema.ts
@@ -63,6 +63,7 @@ const VerdictConfigSchema = z.object({
 
 const BenchmarkConfigSchema = z.object({
   format: z.enum(['pi', 'openai', 'anthropic']).optional().describe('LLM transport format: pi, openai, or anthropic'),
+  authMode: z.enum(['env', 'codex', 'auto']).optional().describe('How to resolve credentials: env var, ~/.codex/auth.json browser-login tokens, or env-then-codex fallback'),
   apiKeyEnv: z.string().optional().describe('Env var name for the API key (default OPENROUTER_API_KEY)'),
   timeout: z.number().int().positive().optional().describe('Milliseconds per model call (default 240000)'),
   models: z.array(ModelConfigSchema).describe('Models to benchmark — at least one required'),
@@ -75,6 +76,7 @@ const BenchmarkConfigSchema = z.object({
 
 const OptimizeConfigSchema = z.object({
   model: z.string().optional().describe('Model for mutation, e.g. openrouter/anthropic/claude-sonnet-4-6'),
+  authMode: z.enum(['env', 'codex', 'auto']).optional().describe('How to resolve optimizer credentials: env var, ~/.codex/auth.json browser-login tokens, or env-then-codex fallback'),
   apiKeyEnv: z.string().optional().describe('Env var for the optimizer API key'),
   thinkingLevel: z.enum(['off', 'minimal', 'low', 'medium', 'high', 'xhigh']).optional()
     .describe('Reasoning depth for mutation calls (default "medium")'),

--- a/src/project/schema.ts
+++ b/src/project/schema.ts
@@ -62,9 +62,9 @@ const VerdictConfigSchema = z.object({
 });
 
 const BenchmarkConfigSchema = z.object({
-  format: z.enum(['pi', 'openai', 'anthropic']).optional().describe('LLM transport format: pi, openai, or anthropic'),
+  format: z.enum(['pi', 'openai', 'anthropic']).optional().describe('LLM transport format: "pi" routes through OpenRouter/Pi (use openrouter/* or openai/* model refs); "openai" calls the OpenAI API directly (supports Codex auth); "anthropic" calls the Anthropic API directly'),
   authMode: z.enum(['env', 'codex', 'auto']).optional().describe('How to resolve credentials: env var, ~/.codex/auth.json browser-login tokens, or env-then-codex fallback'),
-  apiKeyEnv: z.string().optional().describe('Env var name for the API key (default OPENROUTER_API_KEY)'),
+  apiKeyEnv: z.string().optional().describe('Env var name for the API key (default: OPENROUTER_API_KEY for format:pi, OPENAI_API_KEY for format:openai, ANTHROPIC_API_KEY for format:anthropic)'),
   timeout: z.number().int().positive().optional().describe('Milliseconds per model call (default 240000)'),
   models: z.array(ModelConfigSchema).describe('Models to benchmark — at least one required'),
   taskGeneration: TaskGenerationConfigSchema.optional().describe('Automatic task generation config'),

--- a/src/project/snapshot.ts
+++ b/src/project/snapshot.ts
@@ -106,6 +106,7 @@ export function buildMcpToolDefinitionsFromSnapshot(snapshot: SurfaceSnapshot): 
           action.args.map((arg) => [
             arg.name,
             {
+              ...(arg.schema ?? {}),
               ...(arg.type ? { type: arg.type } : {}),
               ...(arg.description ? { description: arg.description } : {}),
             },

--- a/src/project/types.ts
+++ b/src/project/types.ts
@@ -52,6 +52,7 @@ export interface ProjectBenchmarkVerdictConfig {
 export interface ProjectBenchmarkConfig {
   format?: LLMConfig['format'];
   baseUrl?: string;
+  authMode?: LLMConfig['authMode'];
   apiKeyEnv?: string;
   timeout?: number;
   headers?: Record<string, string>;
@@ -68,6 +69,7 @@ export interface ProjectOptimizeConfig {
   enabled?: boolean;
   mode?: 'stable-surface' | 'surface-changing';
   model?: string;
+  authMode?: LLMConfig['authMode'];
   apiKeyEnv?: string;
   thinkingLevel?: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
   allowedPaths?: string[];
@@ -114,6 +116,7 @@ export interface ResolvedProjectTargetConfig {
 export interface ResolvedProjectBenchmarkConfig {
   format: LLMConfig['format'];
   baseUrl?: string;
+  authMode: NonNullable<LLMConfig['authMode']>;
   apiKeyEnv?: string;
   timeout: number;
   headers?: Record<string, string>;
@@ -130,6 +133,7 @@ export interface ResolvedProjectOptimizeConfig {
   enabled: boolean;
   mode: 'stable-surface' | 'surface-changing';
   model: string;
+  authMode: NonNullable<LLMConfig['authMode']>;
   apiKeyEnv?: string;
   thinkingLevel: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
   allowedPaths: string[];

--- a/src/project/validate.ts
+++ b/src/project/validate.ts
@@ -409,8 +409,8 @@ export async function checkConfig(
     }
   }
 
-  // Check: optimize API key env var / Codex auth
-  if (optimize !== undefined) {
+  // Check: optimize API key env var / Codex auth (skip when optimization is disabled)
+  if (optimize !== undefined && optimize.enabled !== false) {
     const optimizeAuthMode = optimize.authMode ?? benchmark.authMode ?? 'env';
     const optimizeModelRef = optimize.model
       ?? (Array.isArray(benchmark.models) && benchmark.models.length > 0 ? benchmark.models[0]!.id : undefined);

--- a/src/project/validate.ts
+++ b/src/project/validate.ts
@@ -135,20 +135,20 @@ export async function checkConfig(
       }
     }
 
-    for (const model of benchmark.models) {
+    for (const [i, model] of benchmark.models.entries()) {
       if (model.weight !== undefined && (!Number.isFinite(model.weight) || model.weight < 0)) {
-        err('invalid-model-weight', `benchmark.models[${model.id}].weight`, `model "${model.id}" has invalid weight; must be a non-negative number`);
+        err('invalid-model-weight', `benchmark.models[${i}].weight`, `model "${model.id}" has invalid weight; must be a non-negative number`);
       }
     }
 
     if (benchmark.authMode === 'codex') {
-      for (const model of benchmark.models) {
+      for (const [i, model] of benchmark.models.entries()) {
         try {
           const { provider } = parseModelRef(model.id);
           if (provider !== 'openai') {
             err(
               'codex-auth-provider-mismatch',
-              `benchmark.models[${model.id}].id`,
+              `benchmark.models[${i}].id`,
               `benchmark.authMode="codex" only supports openai/* models, but found "${model.id}"`,
               'Use openai/* model IDs with codex auth, or switch benchmark.authMode to "env" / "auto"',
             );

--- a/src/project/validate.ts
+++ b/src/project/validate.ts
@@ -335,11 +335,14 @@ export async function checkConfig(
         });
       }
 
-      if (model.id.startsWith('openrouter/') && /\d+\.\d+/.test(model.id)) {
+      // OpenAI's own API uses dots in some model slugs (e.g. gpt-4.5), so skip the
+      // dot check for openai/ IDs. All other providers (openrouter/, anthropic/, etc.)
+      // expect hyphens in version segments.
+      if (!model.id.startsWith('openai/') && /\d+\.\d+/.test(model.id)) {
         const corrected = model.id.replace(/(\d+)\.(\d+)/g, '$1-$2');
         issues.push({
           code: 'model-id-bad-format', severity: 'warning', field: `benchmark.models[${i}].id`,
-          message: `model ID "${model.id}" uses dots in version segment — OpenRouter expects hyphens`,
+          message: `model ID "${model.id}" uses dots in version segment — use hyphens instead`,
           hint: `Change to: ${corrected}`,
           fixable: true,
         });

--- a/src/project/validate.ts
+++ b/src/project/validate.ts
@@ -365,39 +365,58 @@ export async function checkConfig(
 
   // Check: API key env var / Codex auth
   const authMode = benchmark.authMode ?? 'env';
-  const benchmarkProvider = benchmark.format === 'openai'
-    ? 'openai'
-    : benchmark.format === 'anthropic'
-      ? 'anthropic'
-      : Array.isArray(benchmark.models) && benchmark.models.length > 0
-        ? String(benchmark.models[0]?.id ?? '').split('/')[0] || 'openrouter'
-        : 'openrouter';
-  const apiKey = resolveApiKey({
-    provider: benchmarkProvider,
-    authMode,
-    apiKeyEnv: benchmark.apiKeyEnv,
-  });
-  if (!apiKey) {
-    const defaultEnvName = benchmark.apiKeyEnv
-      ?? (benchmarkProvider === 'openai'
-        ? 'OPENAI_API_KEY'
-        : benchmarkProvider === 'anthropic'
-          ? 'ANTHROPIC_API_KEY'
-          : 'OPENROUTER_API_KEY');
-    const hint = authMode === 'codex'
-      ? 'Sign in with Codex so ~/.codex/auth.json contains a browser-login access token or OPENAI_API_KEY, or switch benchmark.authMode to "env"'
-      : authMode === 'auto' && benchmarkProvider === 'openai'
+  // Helper: push a missing-credential warning for a given provider
+  function warnMissingApiKey(provider: string, effectiveAuthMode: typeof authMode, apiKeyEnv: string | undefined, fieldPrefix: 'benchmark' | 'optimize'): void {
+    const defaultEnvName = apiKeyEnv
+      ?? (provider === 'openai' ? 'OPENAI_API_KEY'
+        : provider === 'anthropic' ? 'ANTHROPIC_API_KEY'
+        : 'OPENROUTER_API_KEY');
+    const hint = effectiveAuthMode === 'codex'
+      ? `Sign in with Codex so ~/.codex/auth.json contains a browser-login access token or OPENAI_API_KEY, or switch ${fieldPrefix}.authMode to "env"`
+      : effectiveAuthMode === 'auto' && provider === 'openai'
         ? `Run: export ${defaultEnvName}=... or sign in with Codex`
         : `Run: export ${defaultEnvName}=...`;
     issues.push({
       code: 'api-key-not-set', severity: 'warning',
-      field: authMode === 'codex' ? 'benchmark.authMode' : 'benchmark.apiKeyEnv',
-      message: authMode === 'codex'
+      field: effectiveAuthMode === 'codex' ? `${fieldPrefix}.authMode` : `${fieldPrefix}.apiKeyEnv`,
+      message: effectiveAuthMode === 'codex'
         ? 'Codex auth is enabled but no usable browser-login access token or OPENAI_API_KEY was found in ~/.codex/auth.json'
-        : `No API key was found for authMode "${authMode}"`,
+        : `No API key was found for authMode "${effectiveAuthMode}"`,
       hint,
       fixable: false,
     });
+  }
+
+  if (benchmark.format === 'openai' || benchmark.format === 'anthropic') {
+    // Single direct-API provider — one credential to check
+    const benchmarkProvider = benchmark.format === 'openai' ? 'openai' : 'anthropic';
+    const apiKey = resolveApiKey({ provider: benchmarkProvider, authMode, apiKeyEnv: benchmark.apiKeyEnv });
+    if (!apiKey) warnMissingApiKey(benchmarkProvider, authMode, benchmark.apiKeyEnv, 'benchmark');
+  } else {
+    // Pi format: each model may route through a different provider — check all unique ones
+    const modelList = Array.isArray(benchmark.models) ? benchmark.models : [];
+    const providers = Array.from(new Set(
+      modelList.length > 0
+        ? modelList.map(m => String(m.id ?? '').split('/')[0] || 'openrouter')
+        : ['openrouter'],
+    ));
+    for (const provider of providers) {
+      const apiKey = resolveApiKey({ provider, authMode, apiKeyEnv: benchmark.apiKeyEnv });
+      if (!apiKey) warnMissingApiKey(provider, authMode, benchmark.apiKeyEnv, 'benchmark');
+    }
+  }
+
+  // Check: optimize API key env var / Codex auth
+  if (optimize !== undefined) {
+    const optimizeAuthMode = optimize.authMode ?? benchmark.authMode ?? 'env';
+    const optimizeModelRef = optimize.model
+      ?? (Array.isArray(benchmark.models) && benchmark.models.length > 0 ? benchmark.models[0]!.id : undefined);
+    const optimizeProvider = typeof optimizeModelRef === 'string'
+      ? (optimizeModelRef.split('/')[0] || 'openrouter')
+      : 'openrouter';
+    const optimizeApiKeyEnv = optimize.apiKeyEnv ?? benchmark.apiKeyEnv;
+    const optimizeApiKey = resolveApiKey({ provider: optimizeProvider, authMode: optimizeAuthMode, apiKeyEnv: optimizeApiKeyEnv });
+    if (!optimizeApiKey) warnMissingApiKey(optimizeProvider, optimizeAuthMode, optimizeApiKeyEnv, 'optimize');
   }
 
   // Check: dirty git (injection-safe: fixed arg array, no shell)

--- a/src/project/validate.ts
+++ b/src/project/validate.ts
@@ -4,7 +4,8 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
 import type { ProjectConfig } from './types.js';
-import { isSdkLanguage } from './types.js';
+import { isSdkLanguage, parseModelRef } from './types.js';
+import { resolveApiKey } from '../runtime/pi/auth.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -139,6 +140,24 @@ export async function checkConfig(
         err('invalid-model-weight', `benchmark.models[${model.id}].weight`, `model "${model.id}" has invalid weight; must be a non-negative number`);
       }
     }
+
+    if (benchmark.authMode === 'codex') {
+      for (const model of benchmark.models) {
+        try {
+          const { provider } = parseModelRef(model.id);
+          if (provider !== 'openai') {
+            err(
+              'codex-auth-provider-mismatch',
+              `benchmark.models[${model.id}].id`,
+              `benchmark.authMode="codex" only supports openai/* models, but found "${model.id}"`,
+              'Use openai/* model IDs with codex auth, or switch benchmark.authMode to "env" / "auto"',
+            );
+          }
+        } catch {
+          // model-id format issues are reported separately
+        }
+      }
+    }
   }
 
   if (benchmark.verdict !== undefined) {
@@ -203,6 +222,27 @@ export async function checkConfig(
 
     if (optimize.requireCleanGit === false) {
       err('require-clean-git-disabled', 'optimize.requireCleanGit', '"optimize.requireCleanGit" must remain true in v1');
+    }
+
+    const effectiveOptimizeAuthMode = optimize.authMode ?? benchmark.authMode;
+    if (effectiveOptimizeAuthMode === 'codex') {
+      const optimizeModelRef = optimize.model
+        ?? (Array.isArray(benchmark.models) && benchmark.models.length > 0 ? benchmark.models[0]!.id : undefined);
+      if (typeof optimizeModelRef === 'string') {
+        try {
+          const { provider } = parseModelRef(optimizeModelRef);
+          if (provider !== 'openai') {
+            err(
+              'codex-auth-provider-mismatch',
+              'optimize.model',
+              `optimize.authMode="codex" only supports openai/* models, but found "${optimizeModelRef}"`,
+              'Use an openai/* optimize.model with codex auth, or switch optimize.authMode to "env" / "auto"',
+            );
+          }
+        } catch {
+          // model-id format issues are reported separately
+        }
+      }
     }
   }
 
@@ -295,7 +335,7 @@ export async function checkConfig(
         });
       }
 
-      if (/\d+\.\d+/.test(model.id)) {
+      if (model.id.startsWith('openrouter/') && /\d+\.\d+/.test(model.id)) {
         const corrected = model.id.replace(/(\d+)\.(\d+)/g, '$1-$2');
         issues.push({
           code: 'model-id-bad-format', severity: 'warning', field: `benchmark.models[${i}].id`,
@@ -323,13 +363,38 @@ export async function checkConfig(
     }
   }
 
-  // Check: API key env var
-  const apiKeyEnv = benchmark.apiKeyEnv ?? 'OPENROUTER_API_KEY';
-  if (!process.env[apiKeyEnv]) {
+  // Check: API key env var / Codex auth
+  const authMode = benchmark.authMode ?? 'env';
+  const benchmarkProvider = benchmark.format === 'openai'
+    ? 'openai'
+    : benchmark.format === 'anthropic'
+      ? 'anthropic'
+      : Array.isArray(benchmark.models) && benchmark.models.length > 0
+        ? String(benchmark.models[0]?.id ?? '').split('/')[0] || 'openrouter'
+        : 'openrouter';
+  const apiKey = resolveApiKey({
+    provider: benchmarkProvider,
+    authMode,
+    apiKeyEnv: benchmark.apiKeyEnv,
+  });
+  if (!apiKey) {
+    const defaultEnvName = benchmark.apiKeyEnv
+      ?? (benchmarkProvider === 'openai'
+        ? 'OPENAI_API_KEY'
+        : benchmarkProvider === 'anthropic'
+          ? 'ANTHROPIC_API_KEY'
+          : 'OPENROUTER_API_KEY');
+    const hint = authMode === 'codex'
+      ? 'Sign in with Codex so ~/.codex/auth.json contains a browser-login access token or OPENAI_API_KEY, or switch benchmark.authMode to "env"'
+      : authMode === 'auto' && benchmarkProvider === 'openai'
+        ? `Run: export ${defaultEnvName}=... or sign in with Codex`
+        : `Run: export ${defaultEnvName}=...`;
     issues.push({
       code: 'api-key-not-set', severity: 'warning', field: 'benchmark.apiKeyEnv',
-      message: `env var "${apiKeyEnv}" is not set`,
-      hint: `Run: export ${apiKeyEnv}=sk-or-...`,
+      message: authMode === 'codex'
+        ? 'Codex auth is enabled but no usable browser-login access token or OPENAI_API_KEY was found in ~/.codex/auth.json'
+        : `No API key was found for authMode "${authMode}"`,
+      hint,
       fixable: false,
     });
   }

--- a/src/project/validate.ts
+++ b/src/project/validate.ts
@@ -390,7 +390,8 @@ export async function checkConfig(
         ? `Run: export ${defaultEnvName}=... or sign in with Codex`
         : `Run: export ${defaultEnvName}=...`;
     issues.push({
-      code: 'api-key-not-set', severity: 'warning', field: 'benchmark.apiKeyEnv',
+      code: 'api-key-not-set', severity: 'warning',
+      field: authMode === 'codex' ? 'benchmark.authMode' : 'benchmark.apiKeyEnv',
       message: authMode === 'codex'
         ? 'Codex auth is enabled but no usable browser-login access token or OPENAI_API_KEY was found in ~/.codex/auth.json'
         : `No API key was found for authMode "${authMode}"`,

--- a/src/runtime/pi/auth.ts
+++ b/src/runtime/pi/auth.ts
@@ -1,10 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
+
 import { AuthStorage } from '@mariozechner/pi-coding-agent';
+
+export type PiAuthMode = 'env' | 'codex' | 'auto';
 
 export interface PiAuthOptions {
   provider: string;
+  authMode?: PiAuthMode;
   apiKeyEnv?: string;
   apiKeyOverride?: string;
 }
+
+export interface ResolvedApiCredential {
+  apiKey?: string;
+  source?: 'override' | 'env' | 'codex';
+}
+
+const CODEX_ACCESS_TOKEN_REFRESH_SKEW_MS = 120_000;
 
 export function createPiAuthStorage(options?: PiAuthOptions): ReturnType<typeof AuthStorage.create> {
   const authStorage = AuthStorage.create();
@@ -12,11 +26,79 @@ export function createPiAuthStorage(options?: PiAuthOptions): ReturnType<typeof 
     return authStorage;
   }
 
-  const apiKey = options.apiKeyOverride ?? (options.apiKeyEnv ? process.env[options.apiKeyEnv] : undefined);
+  const apiKey = resolveApiKey({
+    provider: options.provider,
+    authMode: options.authMode,
+    apiKeyEnv: options.apiKeyEnv,
+    apiKeyOverride: options.apiKeyOverride,
+  });
   if (apiKey) {
     authStorage.setRuntimeApiKey(options.provider as never, apiKey);
   }
   return authStorage;
+}
+
+export function resolveApiKey(options: PiAuthOptions): string | undefined {
+  return resolveApiCredential(options).apiKey;
+}
+
+export function resolveApiCredential(options: PiAuthOptions): ResolvedApiCredential {
+  if (options.apiKeyOverride) {
+    return { apiKey: options.apiKeyOverride, source: 'override' };
+  }
+
+  const authMode = options.authMode ?? 'env';
+  const envName = options.apiKeyEnv ?? defaultApiKeyEnvForProvider(options.provider);
+  const envApiKey = envName ? process.env[envName] : undefined;
+
+  if (authMode === 'env') {
+    return envApiKey ? { apiKey: envApiKey, source: 'env' } : {};
+  }
+
+  if (authMode === 'codex') {
+    return readCodexApiKey(options.provider);
+  }
+
+  if (envApiKey) {
+    return { apiKey: envApiKey, source: 'env' };
+  }
+
+  return readCodexApiKey(options.provider);
+}
+
+export function requireConfiguredApiKey(options: PiAuthOptions): string {
+  const apiKey = resolveApiKey(options);
+  if (apiKey) {
+    return apiKey;
+  }
+
+  const authMode = options.authMode ?? 'env';
+  if (authMode === 'codex') {
+    if (options.provider !== 'openai') {
+      throw new Error(
+        `Codex auth only supports the "openai" provider, got "${options.provider}". ` +
+        `Use authMode: "env" with an appropriate API key env var instead.`,
+      );
+    }
+    throw new Error(
+      `Codex auth is enabled for provider "${options.provider}" but no usable access token or OPENAI_API_KEY was found in ~/.codex/auth.json.`,
+    );
+  }
+
+  if (authMode === 'auto' && options.provider === 'openai') {
+    const envName = options.apiKeyEnv ?? 'OPENAI_API_KEY';
+    throw new Error(
+      `Could not resolve auth for provider "${options.provider}". ` +
+      `Checked env var "${envName}" and ~/.codex/auth.json for a browser-login access token or OPENAI_API_KEY.`,
+    );
+  }
+
+  const envName = options.apiKeyEnv ?? defaultApiKeyEnvForProvider(options.provider);
+  if (!envName) {
+    throw new Error(`No default API key env var is known for provider "${options.provider}"`);
+  }
+
+  throw new Error(`Missing API key env var: ${envName}`);
 }
 
 export function requireApiKeyFromEnv(apiKeyEnv: string): string {
@@ -25,4 +107,70 @@ export function requireApiKeyFromEnv(apiKeyEnv: string): string {
     throw new Error(`Missing API key env var: ${apiKeyEnv}`);
   }
   return apiKey;
+}
+
+function readCodexApiKey(provider: string): ResolvedApiCredential {
+  if (provider !== 'openai') {
+    return {};
+  }
+
+  const authPath = resolve(homedir(), '.codex', 'auth.json');
+  let raw: string;
+  try {
+    raw = readFileSync(authPath, 'utf-8');
+  } catch {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as {
+      OPENAI_API_KEY?: unknown;
+      tokens?: { OPENAI_API_KEY?: unknown; access_token?: unknown };
+    };
+    if (typeof parsed.OPENAI_API_KEY === 'string' && parsed.OPENAI_API_KEY.trim()) {
+      return { apiKey: parsed.OPENAI_API_KEY, source: 'codex' };
+    }
+    if (typeof parsed.tokens?.OPENAI_API_KEY === 'string' && parsed.tokens.OPENAI_API_KEY.trim()) {
+      return { apiKey: parsed.tokens.OPENAI_API_KEY, source: 'codex' };
+    }
+    if (typeof parsed.tokens?.access_token === 'string' && parsed.tokens.access_token.trim()) {
+      return isJwtExpired(parsed.tokens.access_token)
+        ? {}
+        : { apiKey: parsed.tokens.access_token, source: 'codex' };
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+function isJwtExpired(token: string): boolean {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    return false;
+  }
+
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1]!, 'base64url').toString('utf-8')) as { exp?: unknown };
+    if (typeof payload.exp !== 'number') {
+      return false;
+    }
+    return payload.exp * 1000 <= Date.now() + CODEX_ACCESS_TOKEN_REFRESH_SKEW_MS;
+  } catch {
+    return false;
+  }
+}
+
+function defaultApiKeyEnvForProvider(provider: string): string | undefined {
+  switch (provider) {
+    case 'openai':
+    case 'openai-codex':
+      return 'OPENAI_API_KEY';
+    case 'anthropic':
+      return 'ANTHROPIC_API_KEY';
+    case 'openrouter':
+      return 'OPENROUTER_API_KEY';
+    default:
+      return undefined;
+  }
 }

--- a/src/runtime/pi/auth.ts
+++ b/src/runtime/pi/auth.ts
@@ -129,10 +129,12 @@ function readCodexApiKey(provider: string): ResolvedApiCredential {
     };
     // Browser-login JWT takes highest priority: it represents an active user session.
     // A stale static key must not shadow a valid browser-login token.
+    // However, an expired JWT must not shadow a valid static key — fall through on expiry.
     if (typeof parsed.tokens?.access_token === 'string' && parsed.tokens.access_token.trim()) {
-      return isJwtExpired(parsed.tokens.access_token)
-        ? {}
-        : { apiKey: parsed.tokens.access_token, source: 'codex' };
+      if (!isJwtExpired(parsed.tokens.access_token)) {
+        return { apiKey: parsed.tokens.access_token, source: 'codex' };
+      }
+      // JWT is expired — fall through to static key fallbacks below
     }
     if (typeof parsed.tokens?.OPENAI_API_KEY === 'string' && parsed.tokens.OPENAI_API_KEY.trim()) {
       return { apiKey: parsed.tokens.OPENAI_API_KEY, source: 'codex' };

--- a/src/runtime/pi/auth.ts
+++ b/src/runtime/pi/auth.ts
@@ -127,16 +127,18 @@ function readCodexApiKey(provider: string): ResolvedApiCredential {
       OPENAI_API_KEY?: unknown;
       tokens?: { OPENAI_API_KEY?: unknown; access_token?: unknown };
     };
-    if (typeof parsed.OPENAI_API_KEY === 'string' && parsed.OPENAI_API_KEY.trim()) {
-      return { apiKey: parsed.OPENAI_API_KEY, source: 'codex' };
-    }
-    if (typeof parsed.tokens?.OPENAI_API_KEY === 'string' && parsed.tokens.OPENAI_API_KEY.trim()) {
-      return { apiKey: parsed.tokens.OPENAI_API_KEY, source: 'codex' };
-    }
+    // Browser-login JWT takes highest priority: it represents an active user session.
+    // A stale static key must not shadow a valid browser-login token.
     if (typeof parsed.tokens?.access_token === 'string' && parsed.tokens.access_token.trim()) {
       return isJwtExpired(parsed.tokens.access_token)
         ? {}
         : { apiKey: parsed.tokens.access_token, source: 'codex' };
+    }
+    if (typeof parsed.tokens?.OPENAI_API_KEY === 'string' && parsed.tokens.OPENAI_API_KEY.trim()) {
+      return { apiKey: parsed.tokens.OPENAI_API_KEY, source: 'codex' };
+    }
+    if (typeof parsed.OPENAI_API_KEY === 'string' && parsed.OPENAI_API_KEY.trim()) {
+      return { apiKey: parsed.OPENAI_API_KEY, source: 'codex' };
     }
     return {};
   } catch {

--- a/src/runtime/pi/auth.ts
+++ b/src/runtime/pi/auth.ts
@@ -59,7 +59,7 @@ export function resolveApiCredential(options: PiAuthOptions): ResolvedApiCredent
     return readCodexApiKey(options.provider);
   }
 
-  if (envApiKey) {
+  if (options.authMode !== 'codex' && envApiKey) {
     return { apiKey: envApiKey, source: 'env' };
   }
 

--- a/src/runtime/pi/benchmark-agent.ts
+++ b/src/runtime/pi/benchmark-agent.ts
@@ -2,10 +2,12 @@ import { resolvePiModelByRef } from './models.js';
 
 export async function createReadOnlyBenchmarkModel(params: {
   modelRef: string;
+  authMode?: import('./auth.js').PiAuthMode;
   apiKeyEnv?: string;
   apiKeyOverride?: string;
 }) {
   return resolvePiModelByRef(params.modelRef, {
+    authMode: params.authMode,
     apiKeyEnv: params.apiKeyEnv,
     apiKeyOverride: params.apiKeyOverride,
   });

--- a/src/runtime/pi/coding-orchestrator.ts
+++ b/src/runtime/pi/coding-orchestrator.ts
@@ -10,11 +10,15 @@ import { resolvePiModel } from './models.js';
 export async function createCodingOrchestratorSession(params: {
   cwd: string;
   modelRef: string;
+  authMode?: import('./auth.js').PiAuthMode;
   apiKeyEnv?: string;
   thinkingLevel?: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
 }) {
   const { provider, model } = parseModelRef(params.modelRef);
-  const resolved = await resolvePiModel(provider, model, { apiKeyEnv: params.apiKeyEnv });
+  const resolved = await resolvePiModel(provider, model, {
+    authMode: params.authMode,
+    apiKeyEnv: params.apiKeyEnv,
+  });
 
   return createAgentSession({
     cwd: params.cwd,

--- a/src/runtime/pi/index.ts
+++ b/src/runtime/pi/index.ts
@@ -1,7 +1,7 @@
-export { createPiAuthStorage, requireApiKeyFromEnv } from './auth.js';
+export { createPiAuthStorage, requireApiKeyFromEnv, requireConfiguredApiKey, resolveApiCredential, resolveApiKey } from './auth.js';
 export { createReadOnlyBenchmarkModel } from './benchmark-agent.js';
 export { createCodingOrchestratorSession } from './coding-orchestrator.js';
 export { resolvePiModel, resolvePiModelByRef } from './models.js';
 
-export type { PiAuthOptions } from './auth.js';
+export type { PiAuthMode, PiAuthOptions } from './auth.js';
 export type { ResolvedPiModelRequest } from './models.js';

--- a/src/runtime/pi/models.ts
+++ b/src/runtime/pi/models.ts
@@ -2,7 +2,7 @@ import type { Model } from '@mariozechner/pi-ai';
 import { getModel } from '@mariozechner/pi-ai';
 import { ModelRegistry } from '@mariozechner/pi-coding-agent';
 
-import { createPiAuthStorage } from './auth.js';
+import { createPiAuthStorage, resolveApiCredential } from './auth.js';
 import { parseModelRef } from '../../project/types.js';
 
 export interface ResolvedPiModelRequest {
@@ -17,7 +17,7 @@ export interface ResolvedPiModelRequest {
 
 export async function resolvePiModelByRef(
   modelRef: string,
-  options?: { apiKeyEnv?: string; apiKeyOverride?: string },
+  options?: { authMode?: import('./auth.js').PiAuthMode; apiKeyEnv?: string; apiKeyOverride?: string },
 ): Promise<ResolvedPiModelRequest> {
   const { provider, model } = parseModelRef(modelRef);
   return resolvePiModel(provider, model, options);
@@ -45,10 +45,26 @@ function synthesizeOpenRouterModel(provider: string, modelName: string): Model<a
   };
 }
 
+function synthesizeOpenAICodexModel(provider: string, modelName: string): Model<any> | undefined {
+  if (provider !== 'openai-codex') return undefined;
+  return {
+    id: modelName,
+    name: modelName,
+    api: 'openai-codex-responses' as const,
+    provider: 'openai-codex' as const,
+    baseUrl: 'https://chatgpt.com/backend-api/codex',
+    reasoning: true,
+    input: ['text', 'image'] as ('text' | 'image')[],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 272000,
+    maxTokens: 32768,
+  };
+}
+
 export async function resolvePiModel(
   provider: string,
   modelName: string,
-  options?: { apiKeyEnv?: string; apiKeyOverride?: string },
+  options?: { authMode?: import('./auth.js').PiAuthMode; apiKeyEnv?: string; apiKeyOverride?: string },
 ): Promise<ResolvedPiModelRequest> {
   // Guard: direct Anthropic provider + OpenRouter key = guaranteed 401.
   // Users who want Claude should use openrouter/anthropic/claude-* instead.
@@ -59,18 +75,29 @@ export async function resolvePiModel(
     );
   }
 
-  const authStorage = createPiAuthStorage({
+  const credential = resolveApiCredential({
     provider,
+    authMode: options?.authMode,
     apiKeyEnv: options?.apiKeyEnv,
     apiKeyOverride: options?.apiKeyOverride,
   });
+  const resolvedProvider = provider === 'openai' && credential.source === 'codex'
+    ? 'openai-codex'
+    : provider;
+  const authStorage = createPiAuthStorage({
+    provider: resolvedProvider,
+    authMode: options?.authMode,
+    apiKeyEnv: options?.apiKeyEnv,
+    apiKeyOverride: credential.apiKey,
+  });
   const modelRegistry = ModelRegistry.create(authStorage);
-  const registryModel = modelRegistry.find(provider, modelName);
+  const registryModel = modelRegistry.find(resolvedProvider, modelName);
   const resolvedModel = registryModel
-    ?? getModel(provider as never, modelName)
-    ?? synthesizeOpenRouterModel(provider, modelName);
+    ?? getModel(resolvedProvider as never, modelName)
+    ?? synthesizeOpenRouterModel(resolvedProvider, modelName)
+    ?? synthesizeOpenAICodexModel(resolvedProvider, modelName);
   if (!resolvedModel) {
-    throw new Error(`Could not resolve pi model ${provider}/${modelName}`);
+    throw new Error(`Could not resolve pi model ${resolvedProvider}/${modelName}`);
   }
 
   const auth = await modelRegistry.getApiKeyAndHeaders(resolvedModel);

--- a/src/runtime/pi/models.ts
+++ b/src/runtime/pi/models.ts
@@ -66,12 +66,19 @@ export async function resolvePiModel(
   modelName: string,
   options?: { authMode?: import('./auth.js').PiAuthMode; apiKeyEnv?: string; apiKeyOverride?: string },
 ): Promise<ResolvedPiModelRequest> {
-  // Guard: direct Anthropic provider + OpenRouter key = guaranteed 401.
-  // Users who want Claude should use openrouter/anthropic/claude-* instead.
+  // Guard: direct-provider model + OpenRouter key = guaranteed 401.
+  // Catches stale scaffolded configs that had apiKeyEnv:"OPENROUTER_API_KEY" and were
+  // later updated to use a direct openai/ or anthropic/ model without fixing the key.
   if (provider === 'anthropic' && options?.apiKeyEnv === 'OPENROUTER_API_KEY') {
     throw new Error(
       `Model "${provider}/${modelName}" routes through the Anthropic API directly and requires ANTHROPIC_API_KEY. ` +
       `To use Claude via OpenRouter, change the model ID to "openrouter/anthropic/${modelName}".`,
+    );
+  }
+  if (provider === 'openai' && options?.apiKeyEnv === 'OPENROUTER_API_KEY') {
+    throw new Error(
+      `Model "${provider}/${modelName}" routes through the OpenAI API directly and requires OPENAI_API_KEY. ` +
+      `To use this model via OpenRouter, change the model ID to "openrouter/openai/${modelName}".`,
     );
   }
 

--- a/src/tasks/default-pi-critic.ts
+++ b/src/tasks/default-pi-critic.ts
@@ -6,6 +6,7 @@ import type { CriticDeps } from '../verdict/recommendations.js';
 export interface DefaultPiCriticOptions {
   provider: string;
   model: string;
+  authMode?: import('../runtime/pi/auth.js').PiAuthMode;
   apiKeyEnv?: string;
   timeoutMs?: number;
   headers?: Record<string, string>;
@@ -15,6 +16,7 @@ export function createDefaultPiCritic(options: DefaultPiCriticOptions): CriticDe
   return {
     async complete(input) {
       const resolved = await resolvePiModel(options.provider, options.model, {
+        authMode: options.authMode,
         apiKeyEnv: options.apiKeyEnv,
       });
 

--- a/src/tasks/default-pi-generator.ts
+++ b/src/tasks/default-pi-generator.ts
@@ -10,6 +10,7 @@ type ThinkingLevel = NonNullable<SimpleStreamOptions['reasoning']>;
 export interface DefaultPiGeneratorOptions {
   provider: string;
   model: string;
+  authMode?: import('../runtime/pi/auth.js').PiAuthMode;
   apiKeyEnv?: string;
   timeoutMs?: number;
   headers?: Record<string, string>;
@@ -20,6 +21,7 @@ export function createDefaultPiTaskGenerator(options: DefaultPiGeneratorOptions)
   return {
     async complete(input) {
       const resolved = await resolvePiModel(options.provider, options.model, {
+        authMode: options.authMode,
         apiKeyEnv: options.apiKeyEnv,
       });
 

--- a/src/tasks/freeze.ts
+++ b/src/tasks/freeze.ts
@@ -47,6 +47,7 @@ export function freezeTaskArtifacts(params: FreezeTaskArtifactsParams): FrozenTa
     benchmark: {
       format: params.project.benchmark.format,
       baseUrl: params.project.benchmark.baseUrl,
+      authMode: params.project.benchmark.authMode,
       apiKeyEnv: params.project.benchmark.apiKeyEnv,
       timeout: params.project.benchmark.timeout,
       headers: params.project.benchmark.headers,
@@ -63,7 +64,6 @@ export function freezeTaskArtifacts(params: FreezeTaskArtifactsParams): FrozenTa
       output: params.project.benchmark.output,
       agentic: params.project.benchmark.agentic,
     },
-    optimize: params.project.optimize,
   };
   writeFileSync(benchmarkPath, JSON.stringify(generatedProject, null, 2), 'utf-8');
 

--- a/tests/smoke-actions.ts
+++ b/tests/smoke-actions.ts
@@ -10,7 +10,7 @@ import {
   writeActionSnapshotFile,
 } from '../src/actions/snapshot.js';
 import { diffActionCatalog } from '../src/actions/diff.js';
-import { buildSurfaceSnapshot, loadProjectConfig, loadSurfaceSnapshotFile } from '../src/project/index.js';
+import { buildMcpToolDefinitionsFromSnapshot, buildSurfaceSnapshot, loadProjectConfig, loadSurfaceSnapshotFile } from '../src/project/index.js';
 import type { SurfaceSnapshot } from '../src/project/types.js';
 
 let passed = 0;
@@ -64,6 +64,40 @@ await test('snapshot write/load roundtrip includes artifact version', () => {
     const loaded = loadActionSnapshotFile(snapshotPath);
     assertEqual(loaded.version, ACTION_SNAPSHOT_VERSION, 'loaded snapshot version should match constant');
     assertEqual(loaded.catalog.actions[0].key, 'wallet.create', 'action key should roundtrip');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('snapshot roundtrip preserves nested MCP arg schemas', () => {
+  const root = mkdtempSync(join(tmpdir(), 'skill-optimizer-actions-schema-'));
+  try {
+    const snapshotPath = join(root, 'actions.snapshot.json');
+    writeActionSnapshotFile(snapshotPath, {
+      surface: 'mcp',
+      actions: [
+        {
+          key: 'folders.update',
+          name: 'folders.update',
+          args: [
+            {
+              name: 'folderIds',
+              required: true,
+              type: 'array',
+              schema: {
+                type: 'array',
+                items: { type: 'integer' },
+                description: 'Folder ids to update',
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const loaded = loadActionSnapshotFile(snapshotPath);
+    const schema = loaded.catalog.actions[0].args[0].schema as { items?: { type?: string } };
+    assertEqual(schema.items?.type, 'integer', 'nested array items should survive snapshot roundtrip');
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -388,6 +422,43 @@ await test('buildSurfaceSnapshot returns expected legacy snapshot fields from di
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+await test('buildMcpToolDefinitionsFromSnapshot preserves nested arg schemas', () => {
+  const snapshot: SurfaceSnapshot = {
+    surface: 'mcp',
+    actions: [
+      {
+        name: 'folders.update',
+        args: [
+          {
+            name: 'folderIds',
+            required: true,
+            type: 'array',
+            schema: {
+              type: 'array',
+              items: { type: 'integer' },
+              description: 'Folder ids to update',
+            },
+          },
+          {
+            name: 'peers',
+            required: false,
+            type: 'array',
+            schema: {
+              type: 'array',
+              items: { type: 'string' },
+            },
+          },
+        ],
+      },
+    ],
+  };
+
+  const definitions = buildMcpToolDefinitionsFromSnapshot(snapshot);
+  const properties = definitions[0].function.parameters?.properties as Record<string, any>;
+  assertEqual(properties.folderIds.items.type, 'integer', 'array items should be preserved in rebuilt tool schema');
+  assertEqual(properties.peers.items.type, 'string', 'optional array items should be preserved in rebuilt tool schema');
 });
 
 await test('loadSurfaceSnapshotFile supports legacy plain snapshot shape', () => {

--- a/tests/smoke-code.ts
+++ b/tests/smoke-code.ts
@@ -999,6 +999,58 @@ await test('doctor --fix: corrects model ID in-place', async () => {
   }
 });
 
+await test('checkModelReachability: mixed list skips non-openrouter and probes only openrouter models', async () => {
+  const { checkModelReachability } = await import('../src/doctor/checks.js');
+
+  const project = {
+    configPath: '/fake/skill-optimizer.json',
+    configDir: '/fake',
+    name: 'test-mixed',
+    target: {
+      surface: 'mcp',
+      repoPath: '/fake',
+      scope: { include: ['.*'], exclude: [] },
+    },
+    benchmark: {
+      format: 'pi',
+      authMode: 'env',
+      timeout: 30000,
+      models: [
+        { id: 'anthropic/claude-sonnet-4-6', name: 'Claude', tier: 'flagship' as const },
+        { id: 'openrouter/openai/gpt-4o', name: 'GPT-4o', tier: 'flagship' as const },
+      ],
+      taskGeneration: { enabled: false, maxTasks: 10, useExisting: false },
+      output: { dir: '/fake/.results' },
+      verdict: { perModelFloor: 0.5, targetWeightedAverage: 0.6 },
+    },
+  } as unknown as ResolvedProjectConfig;
+
+  // Without OPENROUTER_API_KEY set the key resolution throws, so the function
+  // returns early after emitting reachability-skipped. We verify:
+  //   1. A reachability-skipped issue appears (for the 1 non-openrouter model)
+  //   2. No reachability-skipped with field 'benchmark.format' (wrong early-exit path)
+  //   3. No model-unreachable for the anthropic model
+  const savedKey = process.env['OPENROUTER_API_KEY'];
+  delete process.env['OPENROUTER_API_KEY'];
+  try {
+    const issues = await checkModelReachability(project);
+    const skipped = issues.filter((i) => i.code === 'reachability-skipped');
+    assert(skipped.length >= 1, 'should have at least one reachability-skipped issue');
+    const modelSkipped = skipped.find((i) => i.field === 'benchmark.models');
+    assert(modelSkipped !== undefined, 'reachability-skipped issue should reference benchmark.models field');
+    assert(
+      modelSkipped!.message.includes('1 non-OpenRouter'),
+      `message should count 1 skipped, got: ${modelSkipped!.message}`,
+    );
+    const anthropicUnreachable = issues.find(
+      (i) => i.code === 'model-unreachable' && i.message.includes('anthropic/'),
+    );
+    assert(anthropicUnreachable === undefined, 'anthropic model must not produce a model-unreachable issue');
+  } finally {
+    if (savedKey !== undefined) process.env['OPENROUTER_API_KEY'] = savedKey;
+  }
+});
+
 // ── Summary ────────────────────────────────────────────────────────────────
 
 console.log(`\n${passed} passed, ${failed} failed\n`);

--- a/tests/smoke-code.ts
+++ b/tests/smoke-code.ts
@@ -751,6 +751,22 @@ await test('checkConfig: model ID with dot version → fixable warning', async (
   assert(warn!.hint?.includes('4-6'), `hint should show hyphen version, got: ${warn!.hint}`);
 });
 
+await test('checkConfig: direct openai model IDs do not get OpenRouter dot-version warning', async () => {
+  const { checkConfig } = await import('../src/project/validate.js');
+  const config = {
+    name: 'test',
+    target: { surface: 'cli' as const, discovery: { sources: ['./src/cli.ts'] } },
+    benchmark: {
+      format: 'pi' as const,
+      models: [{ id: 'openai/gpt-5.4', name: 'GPT-5.4', tier: 'flagship' as const }],
+      taskGeneration: { enabled: true, maxTasks: 5 },
+    },
+  };
+  const issues = await checkConfig(config as any, '/fake/skill-optimizer.json');
+  const warn = issues.find(i => i.code === 'model-id-bad-format');
+  assert(warn === undefined, 'direct openai model IDs should not be warned as OpenRouter dot versions');
+});
+
 await test('checkConfig: deprecated benchmark.tasks field → fixable warning', async () => {
   const { checkConfig } = await import('../src/project/validate.js');
   const config = {
@@ -768,6 +784,71 @@ await test('checkConfig: deprecated benchmark.tasks field → fixable warning', 
   assert(warn !== undefined, 'expected deprecated-tasks-field issue');
   assert(warn!.severity === 'warning', 'should be warning');
   assert(warn!.fixable === true, 'deprecated-tasks-field should be fixable');
+});
+
+await test('checkConfig: codex auth rejects non-openai benchmark models', async () => {
+  const { checkConfig } = await import('../src/project/validate.js');
+  const config = {
+    name: 'test',
+    target: { surface: 'sdk' as const, discovery: { sources: ['./src/index.ts'], language: 'typescript' as const } },
+    benchmark: {
+      format: 'pi' as const,
+      authMode: 'codex' as const,
+      models: [
+        { id: 'openai/gpt-5.4', name: 'GPT-5.4', tier: 'flagship' as const },
+        { id: 'openrouter/openai/gpt-5.4', name: 'OpenRouter GPT-5.4', tier: 'flagship' as const },
+      ],
+      tasks: './tasks.json',
+    },
+  };
+  const issues = await checkConfig(config as any, '/fake/skill-optimizer.json');
+  const err = issues.find(i => i.code === 'codex-auth-provider-mismatch' && i.field.includes('benchmark.models'));
+  assert(err !== undefined, 'expected codex-auth-provider-mismatch for benchmark.models');
+  assert(err!.severity === 'error', 'benchmark model/provider mismatch should be an error');
+});
+
+await test('checkConfig: codex auth rejects non-openai optimize model', async () => {
+  const { checkConfig } = await import('../src/project/validate.js');
+  const config = {
+    name: 'test',
+    target: { surface: 'sdk' as const, discovery: { sources: ['./src/index.ts'], language: 'typescript' as const } },
+    benchmark: {
+      format: 'pi' as const,
+      models: [{ id: 'openai/gpt-5.4', name: 'GPT-5.4', tier: 'flagship' as const }],
+      tasks: './tasks.json',
+    },
+    optimize: {
+      authMode: 'codex' as const,
+      model: 'openrouter/anthropic/claude-sonnet-4-6',
+      allowedPaths: ['SKILL.md'],
+    },
+  };
+  const issues = await checkConfig(config as any, '/fake/skill-optimizer.json');
+  const err = issues.find(i => i.code === 'codex-auth-provider-mismatch' && i.field === 'optimize.model');
+  assert(err !== undefined, 'expected codex-auth-provider-mismatch for optimize.model');
+  assert(err!.severity === 'error', 'optimize model/provider mismatch should be an error');
+});
+
+await test('checkConfig: inherited codex auth rejects non-openai optimize model', async () => {
+  const { checkConfig } = await import('../src/project/validate.js');
+  const config = {
+    name: 'test',
+    target: { surface: 'sdk' as const, discovery: { sources: ['./src/index.ts'], language: 'typescript' as const } },
+    benchmark: {
+      format: 'pi' as const,
+      authMode: 'codex' as const,
+      models: [{ id: 'openai/gpt-5.4', name: 'GPT-5.4', tier: 'flagship' as const }],
+      tasks: './tasks.json',
+    },
+    optimize: {
+      model: 'openrouter/anthropic/claude-sonnet-4-6',
+      allowedPaths: ['SKILL.md'],
+    },
+  };
+  const issues = await checkConfig(config as any, '/fake/skill-optimizer.json');
+  const err = issues.find(i => i.code === 'codex-auth-provider-mismatch' && i.field === 'optimize.model');
+  assert(err !== undefined, 'expected inherited codex-auth-provider-mismatch for optimize.model');
+  assert(err!.severity === 'error', 'inherited optimize model/provider mismatch should be an error');
 });
 
 await test('applyFixes: adds openrouter/ prefix to model IDs', async () => {

--- a/tests/smoke-generation.ts
+++ b/tests/smoke-generation.ts
@@ -322,13 +322,16 @@ await test('freezeGeneratedBenchmark: writes artifacts and absolute paths', asyn
 
     const benchmark = JSON.parse(readFileSync(frozen.benchmarkPath, 'utf-8')) as {
       target: { skill: { source: string; cache: boolean } };
-      benchmark: { tasks: string; surfaceSnapshot: string };
+      benchmark: { authMode?: string; tasks: string; surfaceSnapshot: string };
+      optimize?: unknown;
     };
 
     assert(benchmark.target.skill.source.startsWith('/'), 'target.skill.source should be absolute');
     assertEqual(benchmark.target.skill.cache, false, 'target.skill.cache should be preserved');
+    assertEqual(benchmark.benchmark.authMode, 'env', 'benchmark authMode should be preserved in generated config');
     assertEqual(benchmark.benchmark.tasks, frozen.tasksPath, 'tasks should point at generated tasks path');
     assertEqual(benchmark.benchmark.surfaceSnapshot, frozen.snapshotPath, 'surface snapshot should be pinned in generated config');
+    assertEqual(benchmark.optimize, undefined, 'generated benchmark config should omit optimize-only settings');
   } finally {
     rmSync(fixture.root, { recursive: true, force: true });
   }

--- a/tests/smoke-llm.ts
+++ b/tests/smoke-llm.ts
@@ -659,6 +659,37 @@ await test('openai format: codex bridge passes apiKeyOverride (not authMode/apiK
   }
 });
 
+await test('resolveApiKey: auto mode prefers env var over codex token when both present', async () => {
+  const originalHome = process.env.HOME;
+  const originalEnv = process.env.OPENAI_API_KEY;
+  const dir = await import('node:fs/promises').then(({ mkdtemp, mkdir, writeFile }) => ({ mkdtemp, mkdir, writeFile }));
+  const os = await import('node:os');
+  const path = await import('node:path');
+  const tmpHome = await dir.mkdtemp(path.join(os.tmpdir(), 'codex-auto-priority-'));
+  const codexDir = path.join(tmpHome, '.codex');
+  await dir.mkdir(codexDir, { recursive: true });
+  const futureExp = Math.floor(Date.now() / 1000) + 3600;
+  const jwt = [
+    Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url'),
+    Buffer.from(JSON.stringify({ exp: futureExp })).toString('base64url'),
+    'sig',
+  ].join('.');
+  await dir.writeFile(
+    path.join(codexDir, 'auth.json'),
+    JSON.stringify({ auth_mode: 'chatgpt', tokens: { access_token: jwt } }),
+    'utf-8',
+  );
+  process.env.HOME = tmpHome;
+  process.env.OPENAI_API_KEY = 'env-api-key';
+  try {
+    const result = resolveApiKey({ provider: 'openai', authMode: 'auto' });
+    assertEqual(result, 'env-api-key', 'auto mode should prefer env var over codex token');
+  } finally {
+    if (originalHome === undefined) { delete process.env.HOME; } else { process.env.HOME = originalHome; }
+    if (originalEnv === undefined) { delete process.env.OPENAI_API_KEY; } else { process.env.OPENAI_API_KEY = originalEnv; }
+  }
+});
+
 await test('pi format: agent loop feeds tool results back with original tool call ids', async () => {
   const toolCallIds: string[] = [];
   let callCount = 0;

--- a/tests/smoke-llm.ts
+++ b/tests/smoke-llm.ts
@@ -103,6 +103,20 @@ const sampleTools: McpToolDefinition[] = [
   },
 ];
 
+const dottedSampleTools: McpToolDefinition[] = [
+  {
+    type: 'function',
+    function: {
+      name: 'auth.status',
+      description: 'Check session auth state',
+      parameters: {
+        type: 'object',
+        properties: {},
+      },
+    },
+  },
+];
+
 // ---------------------------------------------------------------------------
 // Save original fetch so we can restore it after all tests
 // ---------------------------------------------------------------------------
@@ -235,6 +249,85 @@ await test('pi format: converts tool calls for MCP chat', async () => {
 
   assertEqual(result.toolCalls?.[0]?.name, 'get_weather', 'pi tool call name should be surfaced');
   assertEqual((result.toolCalls?.[0]?.arguments as any).city, 'NYC', 'pi tool call args should be surfaced');
+
+  __setPiImplementationsForTest(null);
+});
+
+await test('pi format: sanitizes dotted MCP tool names and maps them back', async () => {
+  __setPiImplementationsForTest({
+    async resolve() {
+      return {
+        model: { id: 'gpt-5.4', provider: 'openai-codex', api: 'openai-codex-responses', name: 'GPT-5.4' } as any,
+        auth: { apiKey: 'codex-access-token', headers: {} },
+      };
+    },
+    async completeSimple() {
+      throw new Error('unexpected completeSimple() call');
+    },
+    async complete(_model, context) {
+      assert(Array.isArray(context.tools), 'tools should be passed to pi complete()');
+      assertEqual(context.tools?.[0]?.name, 'auth_status', 'tool name should be sanitized for provider request');
+      return {
+        role: 'assistant',
+        api: 'openai-codex-responses',
+        provider: 'openai-codex',
+        model: 'gpt-5.4',
+        stopReason: 'toolUse',
+        timestamp: Date.now(),
+        usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+        content: [
+          { type: 'toolCall', id: 'call-1', name: 'auth_status', arguments: {} },
+        ],
+      } as any;
+    },
+  });
+
+  const client = createLLMClient({ ...piConfig, authMode: 'codex' });
+  const result = await client.chatWithTools('openai/gpt-5.4', 'sys', 'user', dottedSampleTools);
+
+  assertEqual(result.toolCalls?.[0]?.name, 'auth.status', 'tool call name should map back to canonical form');
+
+  __setPiImplementationsForTest(null);
+});
+
+await test('pi format: throws provider-side errors instead of returning empty output', async () => {
+  __setPiImplementationsForTest({
+    async resolve() {
+      return {
+        model: { id: 'gpt-5.4', provider: 'openai-codex', api: 'openai-codex-responses', name: 'GPT-5.4' } as any,
+        auth: { apiKey: 'codex-access-token', headers: {} },
+      };
+    },
+    async completeSimple() {
+      throw new Error('unexpected completeSimple() call');
+    },
+    async complete() {
+      return {
+        role: 'assistant',
+        api: 'openai-codex-responses',
+        provider: 'openai-codex',
+        model: 'gpt-5.4',
+        stopReason: 'error',
+        errorMessage: 'Invalid tool schema',
+        timestamp: Date.now(),
+        usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+        content: [],
+      } as any;
+    },
+  });
+
+  const client = createLLMClient({ ...piConfig, authMode: 'codex' });
+  let threw = false;
+  try {
+    await client.chatWithTools('openai/gpt-5.4', 'sys', 'user', dottedSampleTools);
+  } catch (e: any) {
+    threw = true;
+    assert(
+      e.message.includes('Invalid tool schema'),
+      'provider-side error message should surface to the caller',
+    );
+  }
+  assert(threw, 'chatWithTools should throw when the provider reports an error');
 
   __setPiImplementationsForTest(null);
 });
@@ -501,6 +594,48 @@ await test('openai format: parses tool_calls response', async () => {
     (result.toolCalls![0].arguments as any).city,
     'NYC',
     'tool call argument city',
+  );
+});
+
+await test('openai format: sanitizes dotted tool names in requests and maps them back in responses', async () => {
+  let capturedBody: any = null;
+
+  globalThis.fetch = mockFetch((_url, init) => {
+    capturedBody = JSON.parse(init.body as string);
+    return {
+      status: 200,
+      body: {
+        choices: [
+          {
+            message: {
+              content: '',
+              tool_calls: [
+                {
+                  function: {
+                    name: 'auth_status',
+                    arguments: '{}',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+  }) as any;
+
+  const client = createLLMClient(openaiConfig);
+  const result = await client.chatWithTools('gpt-4o', 'sys', 'user', dottedSampleTools);
+
+  assertEqual(
+    capturedBody.tools[0].function.name,
+    'auth_status',
+    'dotted tool name should be sanitized in the request body',
+  );
+  assertEqual(
+    result.toolCalls?.[0]?.name,
+    'auth.status',
+    'sanitized tool call names should map back to canonical form',
   );
 });
 

--- a/tests/smoke-llm.ts
+++ b/tests/smoke-llm.ts
@@ -269,6 +269,26 @@ await test('resolveApiKey: codex auth reads browser-login access token from ~/.c
 });
 
 await test('openai format: codex auth bridges through pi with openai provider refs', async () => {
+  const originalHome = process.env.HOME;
+  const dir = await import('node:fs/promises').then(({ mkdtemp, mkdir, writeFile }) => ({ mkdtemp, mkdir, writeFile }));
+  const os = await import('node:os');
+  const path = await import('node:path');
+  const tmpHome = await dir.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-auth-'));
+  const codexDir = path.join(tmpHome, '.codex');
+  await dir.mkdir(codexDir, { recursive: true });
+  const futureExp = Math.floor(Date.now() / 1000) + 3600;
+  const jwt = [
+    Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url'),
+    Buffer.from(JSON.stringify({ exp: futureExp })).toString('base64url'),
+    'sig',
+  ].join('.');
+  await dir.writeFile(
+    path.join(codexDir, 'auth.json'),
+    JSON.stringify({ auth_mode: 'chatgpt', tokens: { access_token: jwt } }),
+    'utf-8',
+  );
+  process.env.HOME = tmpHome;
+
   let capturedModel: string | null = null;
 
   __setPiImplementationsForTest({
@@ -310,6 +330,7 @@ await test('openai format: codex auth bridges through pi with openai provider re
     assertEqual(capturedModel, 'openai/gpt-5.4', 'openai-format codex auth should bridge to pi using provider/model form');
     assertEqual(result.content, 'hello from codex auth', 'codex-auth bridged response should be returned');
   } finally {
+    process.env.HOME = originalHome;
     __setPiImplementationsForTest(null);
   }
 });

--- a/tests/smoke-llm.ts
+++ b/tests/smoke-llm.ts
@@ -5,6 +5,7 @@
 
 import { createLLMClient } from '../src/benchmark/llm/index.js';
 import { __setPiImplementationsForTest } from '../src/benchmark/llm/pi-format.js';
+import { resolveApiKey } from '../src/runtime/pi/auth.js';
 import type { LLMConfig, McpToolDefinition } from '../src/benchmark/types.js';
 
 // ---------------------------------------------------------------------------
@@ -134,10 +135,11 @@ await test('createLLMClient: creates client for anthropic format', () => {
   assert(typeof client.chatWithTools === 'function', 'client.chatWithTools should be a function');
 });
 
-await test('createLLMClient: throws when apiKeyEnv is set but env var is missing', () => {
+await test('createLLMClient: throws when apiKeyEnv is set but env var is missing', async () => {
   let threw = false;
   try {
-    createLLMClient({ ...openaiConfig, apiKeyEnv: '__MISSING_ENV_VAR_XYZ__' });
+    const client = createLLMClient({ ...openaiConfig, apiKeyEnv: '__MISSING_ENV_VAR_XYZ__' });
+    await client.chat('gpt-5.4', 'sys', 'user');
   } catch (e: any) {
     threw = true;
     assert(
@@ -150,15 +152,19 @@ await test('createLLMClient: throws when apiKeyEnv is set but env var is missing
 
 await test('pi format: uses provider/model id and runtime auth override for text chat', async () => {
   let capturedModel: string | null = null;
+  let capturedAuthMode: string | undefined;
+  let capturedApiKeyEnv: string | undefined;
   let capturedApiKey: string | undefined;
 
   __setPiImplementationsForTest({
-    async resolve(modelId, apiKeyOverride) {
+    async resolve(modelId, authOptions) {
       capturedModel = modelId;
-      capturedApiKey = apiKeyOverride;
+      capturedAuthMode = authOptions?.authMode;
+      capturedApiKeyEnv = authOptions?.apiKeyEnv;
+      capturedApiKey = authOptions?.apiKeyOverride;
       return {
         model: { id: 'openai/gpt-5.4', provider: 'openrouter', api: 'openai-completions', name: 'GPT-5.4' } as any,
-        auth: { apiKey: apiKeyOverride, headers: { 'x-test-header': 'yes' } },
+        auth: { apiKey: 'test-key-12345', headers: { 'x-test-header': 'yes' } },
       };
     },
     async completeSimple(_model, context, options) {
@@ -186,7 +192,9 @@ await test('pi format: uses provider/model id and runtime auth override for text
   const result = await client.chat('openrouter/openai/gpt-5.4', 'sys', 'user');
 
   assertEqual(capturedModel, 'openrouter/openai/gpt-5.4', 'model id should be resolved through pi');
-  assertEqual(capturedApiKey, 'test-key-12345', 'api key override should be passed into pi resolution');
+  assertEqual(capturedAuthMode, undefined, 'default auth mode should be passed through as undefined');
+  assertEqual(capturedApiKeyEnv, '__TEST_API_KEY__', 'api key env should be forwarded to pi resolution');
+  assertEqual(capturedApiKey, undefined, 'pi resolution should now read the configured env var itself');
   assertEqual(result.content, 'hello from pi', 'pi text response should be surfaced');
 
   __setPiImplementationsForTest(null);
@@ -229,6 +237,81 @@ await test('pi format: converts tool calls for MCP chat', async () => {
   assertEqual((result.toolCalls?.[0]?.arguments as any).city, 'NYC', 'pi tool call args should be surfaced');
 
   __setPiImplementationsForTest(null);
+});
+
+await test('resolveApiKey: codex auth reads browser-login access token from ~/.codex/auth.json', async () => {
+  const originalHome = process.env.HOME;
+  const dir = await import('node:fs/promises').then(({ mkdtemp, mkdir, writeFile }) => ({ mkdtemp, mkdir, writeFile }));
+  const os = await import('node:os');
+  const path = await import('node:path');
+  const tmpHome = await dir.mkdtemp(path.join(os.tmpdir(), 'codex-auth-'));
+  const codexDir = path.join(tmpHome, '.codex');
+  await dir.mkdir(codexDir, { recursive: true });
+  const futureExp = Math.floor(Date.now() / 1000) + 3600;
+  const jwt = [
+    Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url'),
+    Buffer.from(JSON.stringify({ exp: futureExp })).toString('base64url'),
+    'sig',
+  ].join('.');
+  await dir.writeFile(
+    path.join(codexDir, 'auth.json'),
+    JSON.stringify({ auth_mode: 'chatgpt', tokens: { access_token: jwt } }),
+    'utf-8',
+  );
+  process.env.HOME = tmpHome;
+
+  try {
+    const result = resolveApiKey({ provider: 'openai', authMode: 'codex' });
+    assertEqual(result, jwt, 'browser-login access token should be returned');
+  } finally {
+    process.env.HOME = originalHome;
+  }
+});
+
+await test('openai format: codex auth bridges through pi with openai provider refs', async () => {
+  let capturedModel: string | null = null;
+
+  __setPiImplementationsForTest({
+    async resolve(modelId) {
+      capturedModel = modelId;
+      return {
+        model: { id: 'gpt-5.4', provider: 'openai-codex', api: 'openai-codex-responses', name: 'GPT-5.4' } as any,
+        auth: { apiKey: 'codex-access-token', headers: {} },
+      };
+    },
+    async completeSimple(_model, context, options) {
+      assertEqual(context.systemPrompt, 'sys', 'system prompt passed through');
+      assertEqual((context.messages[0] as any).content, 'user', 'user content passed through');
+      assertEqual(options?.apiKey, 'codex-access-token', 'codex token should flow through pi');
+      return {
+        role: 'assistant',
+        api: 'openai-codex-responses',
+        provider: 'openai-codex',
+        model: 'gpt-5.4',
+        stopReason: 'stop',
+        timestamp: Date.now(),
+        usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+        content: [{ type: 'text', text: 'hello from codex auth' }],
+      } as any;
+    },
+    async complete() {
+      throw new Error('unexpected complete() call');
+    },
+  });
+
+  try {
+    const client = createLLMClient({
+      format: 'openai',
+      baseUrl: 'https://api.openai.com/v1',
+      authMode: 'codex',
+      models: [],
+    });
+    const result = await client.chat('gpt-5.4', 'sys', 'user');
+    assertEqual(capturedModel, 'openai/gpt-5.4', 'openai-format codex auth should bridge to pi using provider/model form');
+    assertEqual(result.content, 'hello from codex auth', 'codex-auth bridged response should be returned');
+  } finally {
+    __setPiImplementationsForTest(null);
+  }
 });
 
 await test('pi format: agent loop feeds tool results back with original tool call ids', async () => {

--- a/tests/smoke-llm.ts
+++ b/tests/smoke-llm.ts
@@ -436,7 +436,7 @@ await test('openai format: codex auth bridges through pi with openai provider re
   }
 });
 
-await test('openai format: codex bridge passes apiKeyOverride (not authMode/apiKeyEnv) to pi call', async () => {
+await test('openai format: codex bridge passes authMode:codex (not apiKeyOverride) to pi call', async () => {
   const originalHome = process.env.HOME;
   const dir = await import('node:fs/promises').then(({ mkdtemp, mkdir, writeFile }) => ({ mkdtemp, mkdir, writeFile }));
   const os = await import('node:os');
@@ -497,9 +497,8 @@ await test('openai format: codex bridge passes apiKeyOverride (not authMode/apiK
     });
     await client.chat('gpt-5.4', 'sys', 'user');
 
-    assertEqual(capturedApiKeyOverride, jwt, 'codex bridge should pass pre-resolved JWT as apiKeyOverride');
-    assert(capturedAuthMode === undefined, `codex bridge should NOT pass authMode to pi (got: ${capturedAuthMode})`);
-    assert(capturedApiKeyEnv === undefined, `codex bridge should NOT pass apiKeyEnv to pi (got: ${capturedApiKeyEnv})`);
+    assertEqual(capturedAuthMode, 'codex', 'codex bridge should pass authMode:codex to pi for correct provider routing');
+    assert(capturedApiKeyOverride === undefined, `codex bridge should NOT pass apiKeyOverride to pi (would break source:'codex' routing signal) (got: ${capturedApiKeyOverride})`);
   } finally {
     if (originalHome === undefined) {
       delete process.env.HOME;
@@ -510,7 +509,7 @@ await test('openai format: codex bridge passes apiKeyOverride (not authMode/apiK
   }
 });
 
-await test('openai format: codex bridge passes apiKeyOverride (not authMode/apiKeyEnv) to pi call for chatWithTools', async () => {
+await test('openai format: codex bridge passes authMode:codex (not apiKeyOverride) to pi call for chatWithTools', async () => {
   const originalHome = process.env.HOME;
   const dir = await import('node:fs/promises').then(({ mkdtemp, mkdir, writeFile }) => ({ mkdtemp, mkdir, writeFile }));
   const os = await import('node:os');
@@ -571,9 +570,8 @@ await test('openai format: codex bridge passes apiKeyOverride (not authMode/apiK
     });
     await client.chatWithTools('gpt-5.4', 'sys', 'user', sampleTools);
 
-    assertEqual(capturedApiKeyOverride, jwt, 'codex bridge should pass pre-resolved JWT as apiKeyOverride (chatWithTools)');
-    assert(capturedAuthMode === undefined, `codex bridge should NOT pass authMode to pi (got: ${capturedAuthMode})`);
-    assert(capturedApiKeyEnv === undefined, `codex bridge should NOT pass apiKeyEnv to pi (got: ${capturedApiKeyEnv})`);
+    assertEqual(capturedAuthMode, 'codex', 'codex bridge should pass authMode:codex to pi for correct provider routing (chatWithTools)');
+    assert(capturedApiKeyOverride === undefined, `codex bridge should NOT pass apiKeyOverride to pi (chatWithTools) (got: ${capturedApiKeyOverride})`);
   } finally {
     if (originalHome === undefined) {
       delete process.env.HOME;
@@ -584,7 +582,7 @@ await test('openai format: codex bridge passes apiKeyOverride (not authMode/apiK
   }
 });
 
-await test('openai format: codex bridge passes apiKeyOverride (not authMode/apiKeyEnv) to pi call for chatAgentLoop', async () => {
+await test('openai format: codex bridge passes authMode:codex (not apiKeyOverride) to pi call for chatAgentLoop', async () => {
   const originalHome = process.env.HOME;
   const dir = await import('node:fs/promises').then(({ mkdtemp, mkdir, writeFile }) => ({ mkdtemp, mkdir, writeFile }));
   const os = await import('node:os');
@@ -646,9 +644,8 @@ await test('openai format: codex bridge passes apiKeyOverride (not authMode/apiK
     const dummyExecutor = async () => 'result';
     await client.chatAgentLoop('gpt-5.4', 'sys', 'user', sampleTools, dummyExecutor);
 
-    assertEqual(capturedApiKeyOverride, jwt, 'codex bridge should pass pre-resolved JWT as apiKeyOverride (chatAgentLoop)');
-    assert(capturedAuthMode === undefined, `codex bridge should NOT pass authMode to pi (got: ${capturedAuthMode})`);
-    assert(capturedApiKeyEnv === undefined, `codex bridge should NOT pass apiKeyEnv to pi (got: ${capturedApiKeyEnv})`);
+    assertEqual(capturedAuthMode, 'codex', 'codex bridge should pass authMode:codex to pi for correct provider routing (chatAgentLoop)');
+    assert(capturedApiKeyOverride === undefined, `codex bridge should NOT pass apiKeyOverride to pi (chatAgentLoop) (got: ${capturedApiKeyOverride})`);
   } finally {
     if (originalHome === undefined) {
       delete process.env.HOME;

--- a/tests/smoke-llm.ts
+++ b/tests/smoke-llm.ts
@@ -428,6 +428,76 @@ await test('openai format: codex auth bridges through pi with openai provider re
   }
 });
 
+await test('openai format: codex bridge passes apiKeyOverride (not authMode/apiKeyEnv) to pi call', async () => {
+  const originalHome = process.env.HOME;
+  const dir = await import('node:fs/promises').then(({ mkdtemp, mkdir, writeFile }) => ({ mkdtemp, mkdir, writeFile }));
+  const os = await import('node:os');
+  const path = await import('node:path');
+  const tmpHome = await dir.mkdtemp(path.join(os.tmpdir(), 'codex-override-auth-'));
+  const codexDir = path.join(tmpHome, '.codex');
+  await dir.mkdir(codexDir, { recursive: true });
+  const futureExp = Math.floor(Date.now() / 1000) + 3600;
+  const jwt = [
+    Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url'),
+    Buffer.from(JSON.stringify({ exp: futureExp })).toString('base64url'),
+    'sig',
+  ].join('.');
+  await dir.writeFile(
+    path.join(codexDir, 'auth.json'),
+    JSON.stringify({ auth_mode: 'chatgpt', tokens: { access_token: jwt } }),
+    'utf-8',
+  );
+  process.env.HOME = tmpHome;
+
+  let capturedAuthMode: string | undefined = 'NOT_SET';
+  let capturedApiKeyEnv: string | undefined = 'NOT_SET';
+  let capturedApiKeyOverride: string | undefined = 'NOT_SET';
+
+  __setPiImplementationsForTest({
+    async resolve(_modelId, authOptions) {
+      capturedAuthMode = authOptions?.authMode;
+      capturedApiKeyEnv = authOptions?.apiKeyEnv;
+      capturedApiKeyOverride = authOptions?.apiKeyOverride;
+      return {
+        model: { id: 'gpt-5.4', provider: 'openai-codex', api: 'openai-codex-responses', name: 'GPT-5.4' } as any,
+        auth: { apiKey: jwt, headers: {} },
+      };
+    },
+    async completeSimple() {
+      return {
+        role: 'assistant',
+        api: 'openai-codex-responses',
+        provider: 'openai-codex',
+        model: 'gpt-5.4',
+        stopReason: 'stop',
+        timestamp: Date.now(),
+        usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+        content: [{ type: 'text', text: 'ok' }],
+      } as any;
+    },
+    async complete() {
+      throw new Error('unexpected complete() call');
+    },
+  });
+
+  try {
+    const client = createLLMClient({
+      format: 'openai',
+      baseUrl: 'https://api.openai.com/v1',
+      authMode: 'codex',
+      models: [],
+    });
+    await client.chat('gpt-5.4', 'sys', 'user');
+
+    assertEqual(capturedApiKeyOverride, jwt, 'codex bridge should pass pre-resolved JWT as apiKeyOverride');
+    assert(capturedAuthMode === undefined, `codex bridge should NOT pass authMode to pi (got: ${capturedAuthMode})`);
+    assert(capturedApiKeyEnv === undefined, `codex bridge should NOT pass apiKeyEnv to pi (got: ${capturedApiKeyEnv})`);
+  } finally {
+    process.env.HOME = originalHome;
+    __setPiImplementationsForTest(null);
+  }
+});
+
 await test('pi format: agent loop feeds tool results back with original tool call ids', async () => {
   const toolCallIds: string[] = [];
   let callCount = 0;

--- a/tests/smoke-llm.ts
+++ b/tests/smoke-llm.ts
@@ -498,6 +498,147 @@ await test('openai format: codex bridge passes apiKeyOverride (not authMode/apiK
   }
 });
 
+await test('openai format: codex bridge passes apiKeyOverride (not authMode/apiKeyEnv) to pi call for chatWithTools', async () => {
+  const originalHome = process.env.HOME;
+  const dir = await import('node:fs/promises').then(({ mkdtemp, mkdir, writeFile }) => ({ mkdtemp, mkdir, writeFile }));
+  const os = await import('node:os');
+  const path = await import('node:path');
+  const tmpHome = await dir.mkdtemp(path.join(os.tmpdir(), 'codex-override-tools-'));
+  const codexDir = path.join(tmpHome, '.codex');
+  await dir.mkdir(codexDir, { recursive: true });
+  const futureExp = Math.floor(Date.now() / 1000) + 3600;
+  const jwt = [
+    Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url'),
+    Buffer.from(JSON.stringify({ exp: futureExp })).toString('base64url'),
+    'sig',
+  ].join('.');
+  await dir.writeFile(
+    path.join(codexDir, 'auth.json'),
+    JSON.stringify({ auth_mode: 'chatgpt', tokens: { access_token: jwt } }),
+    'utf-8',
+  );
+  process.env.HOME = tmpHome;
+
+  let capturedAuthMode: string | undefined = 'NOT_SET';
+  let capturedApiKeyEnv: string | undefined = 'NOT_SET';
+  let capturedApiKeyOverride: string | undefined = 'NOT_SET';
+
+  __setPiImplementationsForTest({
+    async resolve(_modelId, authOptions) {
+      capturedAuthMode = authOptions?.authMode;
+      capturedApiKeyEnv = authOptions?.apiKeyEnv;
+      capturedApiKeyOverride = authOptions?.apiKeyOverride;
+      return {
+        model: { id: 'gpt-5.4', provider: 'openai-codex', api: 'openai-codex-responses', name: 'GPT-5.4' } as any,
+        auth: { apiKey: jwt, headers: {} },
+      };
+    },
+    async completeSimple() {
+      throw new Error('unexpected completeSimple() call');
+    },
+    async complete() {
+      return {
+        role: 'assistant',
+        api: 'openai-codex-responses',
+        provider: 'openai-codex',
+        model: 'gpt-5.4',
+        stopReason: 'stop',
+        timestamp: Date.now(),
+        usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+        content: [{ type: 'text', text: 'ok' }],
+      } as any;
+    },
+  });
+
+  try {
+    const client = createLLMClient({
+      format: 'openai',
+      baseUrl: 'https://api.openai.com/v1',
+      authMode: 'codex',
+      models: [],
+    });
+    await client.chatWithTools('gpt-5.4', 'sys', 'user', sampleTools);
+
+    assertEqual(capturedApiKeyOverride, jwt, 'codex bridge should pass pre-resolved JWT as apiKeyOverride (chatWithTools)');
+    assert(capturedAuthMode === undefined, `codex bridge should NOT pass authMode to pi (got: ${capturedAuthMode})`);
+    assert(capturedApiKeyEnv === undefined, `codex bridge should NOT pass apiKeyEnv to pi (got: ${capturedApiKeyEnv})`);
+  } finally {
+    process.env.HOME = originalHome;
+    __setPiImplementationsForTest(null);
+  }
+});
+
+await test('openai format: codex bridge passes apiKeyOverride (not authMode/apiKeyEnv) to pi call for chatAgentLoop', async () => {
+  const originalHome = process.env.HOME;
+  const dir = await import('node:fs/promises').then(({ mkdtemp, mkdir, writeFile }) => ({ mkdtemp, mkdir, writeFile }));
+  const os = await import('node:os');
+  const path = await import('node:path');
+  const tmpHome = await dir.mkdtemp(path.join(os.tmpdir(), 'codex-override-agent-'));
+  const codexDir = path.join(tmpHome, '.codex');
+  await dir.mkdir(codexDir, { recursive: true });
+  const futureExp = Math.floor(Date.now() / 1000) + 3600;
+  const jwt = [
+    Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url'),
+    Buffer.from(JSON.stringify({ exp: futureExp })).toString('base64url'),
+    'sig',
+  ].join('.');
+  await dir.writeFile(
+    path.join(codexDir, 'auth.json'),
+    JSON.stringify({ auth_mode: 'chatgpt', tokens: { access_token: jwt } }),
+    'utf-8',
+  );
+  process.env.HOME = tmpHome;
+
+  let capturedAuthMode: string | undefined = 'NOT_SET';
+  let capturedApiKeyEnv: string | undefined = 'NOT_SET';
+  let capturedApiKeyOverride: string | undefined = 'NOT_SET';
+
+  __setPiImplementationsForTest({
+    async resolve(_modelId, authOptions) {
+      capturedAuthMode = authOptions?.authMode;
+      capturedApiKeyEnv = authOptions?.apiKeyEnv;
+      capturedApiKeyOverride = authOptions?.apiKeyOverride;
+      return {
+        model: { id: 'gpt-5.4', provider: 'openai-codex', api: 'openai-codex-responses', name: 'GPT-5.4' } as any,
+        auth: { apiKey: jwt, headers: {} },
+      };
+    },
+    async completeSimple() {
+      throw new Error('unexpected completeSimple() call');
+    },
+    async complete() {
+      return {
+        role: 'assistant',
+        api: 'openai-codex-responses',
+        provider: 'openai-codex',
+        model: 'gpt-5.4',
+        stopReason: 'stop',
+        timestamp: Date.now(),
+        usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+        content: [{ type: 'text', text: 'ok' }],
+      } as any;
+    },
+  });
+
+  try {
+    const client = createLLMClient({
+      format: 'openai',
+      baseUrl: 'https://api.openai.com/v1',
+      authMode: 'codex',
+      models: [],
+    });
+    const dummyExecutor = async () => 'result';
+    await client.chatAgentLoop('gpt-5.4', 'sys', 'user', sampleTools, dummyExecutor);
+
+    assertEqual(capturedApiKeyOverride, jwt, 'codex bridge should pass pre-resolved JWT as apiKeyOverride (chatAgentLoop)');
+    assert(capturedAuthMode === undefined, `codex bridge should NOT pass authMode to pi (got: ${capturedAuthMode})`);
+    assert(capturedApiKeyEnv === undefined, `codex bridge should NOT pass apiKeyEnv to pi (got: ${capturedApiKeyEnv})`);
+  } finally {
+    process.env.HOME = originalHome;
+    __setPiImplementationsForTest(null);
+  }
+});
+
 await test('pi format: agent loop feeds tool results back with original tool call ids', async () => {
   const toolCallIds: string[] = [];
   let callCount = 0;

--- a/tests/smoke-llm.ts
+++ b/tests/smoke-llm.ts
@@ -357,7 +357,11 @@ await test('resolveApiKey: codex auth reads browser-login access token from ~/.c
     const result = resolveApiKey({ provider: 'openai', authMode: 'codex' });
     assertEqual(result, jwt, 'browser-login access token should be returned');
   } finally {
-    process.env.HOME = originalHome;
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
   }
 });
 
@@ -423,7 +427,11 @@ await test('openai format: codex auth bridges through pi with openai provider re
     assertEqual(capturedModel, 'openai/gpt-5.4', 'openai-format codex auth should bridge to pi using provider/model form');
     assertEqual(result.content, 'hello from codex auth', 'codex-auth bridged response should be returned');
   } finally {
-    process.env.HOME = originalHome;
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
     __setPiImplementationsForTest(null);
   }
 });
@@ -493,7 +501,11 @@ await test('openai format: codex bridge passes apiKeyOverride (not authMode/apiK
     assert(capturedAuthMode === undefined, `codex bridge should NOT pass authMode to pi (got: ${capturedAuthMode})`);
     assert(capturedApiKeyEnv === undefined, `codex bridge should NOT pass apiKeyEnv to pi (got: ${capturedApiKeyEnv})`);
   } finally {
-    process.env.HOME = originalHome;
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
     __setPiImplementationsForTest(null);
   }
 });
@@ -563,7 +575,11 @@ await test('openai format: codex bridge passes apiKeyOverride (not authMode/apiK
     assert(capturedAuthMode === undefined, `codex bridge should NOT pass authMode to pi (got: ${capturedAuthMode})`);
     assert(capturedApiKeyEnv === undefined, `codex bridge should NOT pass apiKeyEnv to pi (got: ${capturedApiKeyEnv})`);
   } finally {
-    process.env.HOME = originalHome;
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
     __setPiImplementationsForTest(null);
   }
 });
@@ -634,7 +650,11 @@ await test('openai format: codex bridge passes apiKeyOverride (not authMode/apiK
     assert(capturedAuthMode === undefined, `codex bridge should NOT pass authMode to pi (got: ${capturedAuthMode})`);
     assert(capturedApiKeyEnv === undefined, `codex bridge should NOT pass apiKeyEnv to pi (got: ${capturedApiKeyEnv})`);
   } finally {
-    process.env.HOME = originalHome;
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
     __setPiImplementationsForTest(null);
   }
 });


### PR DESCRIPTION
## Summary
- add authMode support for env, codex, and auto credential resolution
- map Codex browser-login tokens from ~/.codex/auth.json to the openai-codex provider
- preserve authMode in generated benchmark configs and omit optimizer-only settings
- update validation, docs, and smoke coverage for Codex auth

## Verification
- npm run typecheck
- npm test
- npx tsx src/cli.ts doctor --config .tmp/codex-auth-smoke/skill-optimizer.json
- npx tsx src/cli.ts run --config .tmp/codex-auth-smoke/skill-optimizer.json