### PR TITLE
fix: strip provider prefix from model ID for direct Anthropic/OpenAI API formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- **benchmark:** Strip provider prefix from model ID when using direct `anthropic` or `openai` formats. Previously, `anthropic/claude-sonnet-4-6` was sent as-is to the Anthropic API, which expects `claude-sonnet-4-6`. The `pi` format is unaffected.
+
 ## 1.0.0 — 2026-04-14
 
 First public release.

--- a/src/benchmark/llm/index.ts
+++ b/src/benchmark/llm/index.ts
@@ -16,6 +16,19 @@ export interface LLMClient {
 }
 
 /**
+ * Strip the provider prefix (e.g. "anthropic/", "openai/") from a model ID
+ * when talking directly to a provider API rather than through a router.
+ *
+ * The config validation requires prefixed IDs like "anthropic/claude-sonnet-4-6",
+ * but the native Anthropic/OpenAI APIs expect just "claude-sonnet-4-6" / "gpt-4o".
+ */
+function stripProviderPrefix(modelId: string): string {
+  const slashIndex = modelId.indexOf('/');
+  if (slashIndex === -1) return modelId;
+  return modelId.slice(slashIndex + 1);
+}
+
+/**
  * Create an LLM client from config.
  */
 export function createLLMClient(config: LLMConfig): LLMClient {
@@ -29,33 +42,41 @@ export function createLLMClient(config: LLMConfig): LLMClient {
 
   const extraHeaders = config.headers ?? {};
 
+  // When format is 'anthropic' or 'openai', we're talking directly to a provider
+  // API that doesn't understand prefixed model IDs like "anthropic/claude-sonnet-4-6".
+  // Strip the prefix so only the bare model name (e.g. "claude-sonnet-4-6") is sent.
+  const shouldStripPrefix = config.format === 'anthropic' || config.format === 'openai';
+
   return {
     async chat(modelId, system, user) {
+      const resolvedModelId = shouldStripPrefix ? stripProviderPrefix(modelId) : modelId;
       if (config.format === 'pi') {
         return chatPi({ timeout, modelId, system, user, apiKeyOverride: apiKey, headers: config.headers });
       }
       if (config.format === 'anthropic') {
-        return chatAnthropic({ baseUrl: baseUrl!, apiKey, timeout, extraHeaders, modelId, system, user });
+        return chatAnthropic({ baseUrl: baseUrl!, apiKey, timeout, extraHeaders, modelId: resolvedModelId, system, user });
       }
-      return chatOpenAI({ baseUrl: baseUrl!, apiKey, timeout, extraHeaders, modelId, system, user });
+      return chatOpenAI({ baseUrl: baseUrl!, apiKey, timeout, extraHeaders, modelId: resolvedModelId, system, user });
     },
     async chatWithTools(modelId, system, user, tools) {
+      const resolvedModelId = shouldStripPrefix ? stripProviderPrefix(modelId) : modelId;
       if (config.format === 'pi') {
         return chatWithToolsPi({ timeout, modelId, system, user, tools, apiKeyOverride: apiKey, headers: config.headers });
       }
       if (config.format === 'anthropic') {
-        return chatWithToolsAnthropic({ baseUrl: baseUrl!, apiKey, timeout, extraHeaders, modelId, system, user, tools });
+        return chatWithToolsAnthropic({ baseUrl: baseUrl!, apiKey, timeout, extraHeaders, modelId: resolvedModelId, system, user, tools });
       }
-      return chatWithToolsOpenAI({ baseUrl: baseUrl!, apiKey, timeout, extraHeaders, modelId, system, user, tools });
+      return chatWithToolsOpenAI({ baseUrl: baseUrl!, apiKey, timeout, extraHeaders, modelId: resolvedModelId, system, user, tools });
     },
     async chatAgentLoop(modelId, system, user, tools, executor, maxTurns = 5) {
+      const resolvedModelId = shouldStripPrefix ? stripProviderPrefix(modelId) : modelId;
       if (config.format === 'pi') {
         return chatAgentLoopPi({ timeout, modelId, system, user, tools, executor, maxTurns, apiKeyOverride: apiKey, headers: config.headers });
       }
       if (config.format === 'anthropic') {
-        return chatAgentLoopAnthropic({ baseUrl: baseUrl!, apiKey, timeout, extraHeaders, modelId, system, user, tools, executor, maxTurns });
+        return chatAgentLoopAnthropic({ baseUrl: baseUrl!, apiKey, timeout, extraHeaders, modelId: resolvedModelId, system, user, tools, executor, maxTurns });
       }
-      return chatAgentLoopOpenAI({ baseUrl: baseUrl!, apiKey, timeout, extraHeaders, modelId, system, user, tools, executor, maxTurns });
+      return chatAgentLoopOpenAI({ baseUrl: baseUrl!, apiKey, timeout, extraHeaders, modelId: resolvedModelId, system, user, tools, executor, maxTurns });
     },
   };
 }

--- a/src/benchmark/llm/index.ts
+++ b/src/benchmark/llm/index.ts
@@ -16,16 +16,18 @@ export interface LLMClient {
 }
 
 /**
- * Strip the provider prefix (e.g. "anthropic/", "openai/") from a model ID
- * when talking directly to a provider API rather than through a router.
+ * Strip the provider prefix from a model ID when talking directly to a provider API.
  *
- * The config validation requires prefixed IDs like "anthropic/claude-sonnet-4-6",
- * but the native Anthropic/OpenAI APIs expect just "claude-sonnet-4-6" / "gpt-4o".
+ * Only strips "anthropic/" and "openai/" prefixes — the prefixes that belong to
+ * direct-API configs. "openrouter/" prefixes are intentionally left intact: they
+ * signal that the ID belongs to format:'pi' (OpenRouter), so encountering one here
+ * means the config is misconfigured and we want a fast, visible API error rather
+ * than silently misrouting the request.
  */
 function stripProviderPrefix(modelId: string): string {
-  const slashIndex = modelId.indexOf('/');
-  if (slashIndex === -1) return modelId;
-  return modelId.slice(slashIndex + 1);
+  if (modelId.startsWith('anthropic/')) return modelId.slice('anthropic/'.length);
+  if (modelId.startsWith('openai/')) return modelId.slice('openai/'.length);
+  return modelId;
 }
 
 /**

--- a/tests/smoke-llm.ts
+++ b/tests/smoke-llm.ts
@@ -592,6 +592,133 @@ await test('anthropic format: converts McpToolDefinition to Anthropic tool forma
 });
 
 // ---------------------------------------------------------------------------
+// Provider prefix stripping for direct API formats
+// ---------------------------------------------------------------------------
+
+await test('anthropic format: strips provider prefix from model ID', async () => {
+  let capturedBody: any = null;
+
+  globalThis.fetch = mockFetch((_url, init) => {
+    capturedBody = JSON.parse(init.body as string);
+    return {
+      status: 200,
+      body: {
+        content: [{ type: 'text', text: 'ok' }],
+      },
+    };
+  }) as any;
+
+  const client = createLLMClient(anthropicConfig);
+  // Pass a prefixed model ID like the config validation requires
+  await client.chat('anthropic/claude-sonnet-4-6', 'system', 'user');
+
+  assert(capturedBody !== null, 'fetch should have been called');
+  assertEqual(
+    capturedBody.model,
+    'claude-sonnet-4-6',
+    'model field should have provider prefix stripped for direct Anthropic API',
+  );
+});
+
+await test('anthropic format: strips provider prefix in chatWithTools', async () => {
+  let capturedBody: any = null;
+
+  globalThis.fetch = mockFetch((_url, init) => {
+    capturedBody = JSON.parse(init.body as string);
+    return {
+      status: 200,
+      body: {
+        content: [{ type: 'text', text: 'no tools needed' }],
+        stop_reason: 'end_turn',
+      },
+    };
+  }) as any;
+
+  const tools: McpToolDefinition[] = [
+    {
+      type: 'function',
+      function: {
+        name: 'test_tool',
+        description: 'A test tool',
+        parameters: { type: 'object', properties: {} },
+      },
+    },
+  ];
+
+  const client = createLLMClient(anthropicConfig);
+  await client.chatWithTools('anthropic/claude-sonnet-4-6', 'system', 'user', tools);
+
+  assert(capturedBody !== null, 'fetch should have been called');
+  assertEqual(
+    capturedBody.model,
+    'claude-sonnet-4-6',
+    'model field should have provider prefix stripped in chatWithTools',
+  );
+});
+
+await test('anthropic format: does not strip when no prefix present', async () => {
+  let capturedBody: any = null;
+
+  globalThis.fetch = mockFetch((_url, init) => {
+    capturedBody = JSON.parse(init.body as string);
+    return {
+      status: 200,
+      body: {
+        content: [{ type: 'text', text: 'ok' }],
+      },
+    };
+  }) as any;
+
+  const client = createLLMClient(anthropicConfig);
+  await client.chat('claude-sonnet-4-6', 'system', 'user');
+
+  assert(capturedBody !== null, 'fetch should have been called');
+  assertEqual(
+    capturedBody.model,
+    'claude-sonnet-4-6',
+    'model field should remain unchanged when no prefix',
+  );
+});
+
+await test('openai format: strips provider prefix from model ID', async () => {
+  let capturedBody: any = null;
+
+  const openaiConfig: LLMConfig = {
+    format: 'openai',
+    baseUrl: 'https://api.openai.com',
+    apiKeyEnv: 'OPENAI_API_KEY',
+    timeout: 5000,
+  };
+
+  globalThis.fetch = mockFetch((_url, init) => {
+    capturedBody = JSON.parse(init.body as string);
+    return {
+      status: 200,
+      body: {
+        choices: [{ message: { role: 'assistant', content: 'ok' } }],
+      },
+    };
+  }) as any;
+
+  // Temporarily set the env var so createLLMClient doesn't throw
+  process.env.OPENAI_API_KEY = 'test-key';
+  const client = createLLMClient(openaiConfig);
+  await client.chat('openai/gpt-4o', 'system', 'user');
+  delete process.env.OPENAI_API_KEY;
+
+  assert(capturedBody !== null, 'fetch should have been called');
+  assertEqual(
+    capturedBody.model,
+    'gpt-4o',
+    'model field should have provider prefix stripped for direct OpenAI API',
+  );
+});
+
+// NOTE: pi format prefix preservation is already covered by existing
+// "pi format: uses provider/model id" tests above. The prefix stripping
+// only applies to anthropic and openai direct formats.
+
+// ---------------------------------------------------------------------------
 // Restore original fetch
 // ---------------------------------------------------------------------------
 

--- a/tests/smoke-llm.ts
+++ b/tests/smoke-llm.ts
@@ -714,6 +714,33 @@ await test('openai format: strips provider prefix from model ID', async () => {
   );
 });
 
+await test('anthropic format: leaves openrouter/-prefixed model ID unchanged', async () => {
+  // openrouter/ IDs belong to format:'pi'. If one appears with format:'anthropic',
+  // the config is misconfigured — we pass it through unchanged so the Anthropic API
+  // returns a fast, visible error rather than silently misrouting the request.
+  let capturedBody: any = null;
+
+  globalThis.fetch = mockFetch((_url, init) => {
+    capturedBody = JSON.parse(init.body as string);
+    return {
+      status: 200,
+      body: {
+        content: [{ type: 'text', text: 'ok' }],
+      },
+    };
+  }) as any;
+
+  const client = createLLMClient(anthropicConfig);
+  await client.chat('openrouter/anthropic/claude-sonnet-4-6', 'system', 'user');
+
+  assert(capturedBody !== null, 'fetch should have been called');
+  assertEqual(
+    capturedBody.model,
+    'openrouter/anthropic/claude-sonnet-4-6',
+    'openrouter/ prefix should be left intact — not silently stripped',
+  );
+});
+
 // NOTE: pi format prefix preservation is already covered by existing
 // "pi format: uses provider/model id" tests above. The prefix stripping
 // only applies to anthropic and openai direct formats.

--- a/tests/smoke-llm.ts
+++ b/tests/smoke-llm.ts
@@ -656,6 +656,42 @@ await test('anthropic format: strips provider prefix in chatWithTools', async ()
   );
 });
 
+await test('anthropic format: strips provider prefix in chatAgentLoop', async () => {
+  let capturedBody: any = null;
+
+  globalThis.fetch = mockFetch((_url, init) => {
+    capturedBody = JSON.parse(init.body as string);
+    return {
+      status: 200,
+      body: {
+        content: [{ type: 'text', text: 'no tools needed' }],
+        stop_reason: 'end_turn',
+      },
+    };
+  }) as any;
+
+  const tools: McpToolDefinition[] = [
+    {
+      type: 'function',
+      function: {
+        name: 'test_tool',
+        description: 'A test tool',
+        parameters: { type: 'object', properties: {} },
+      },
+    },
+  ];
+
+  const client = createLLMClient(anthropicConfig);
+  await client.chatAgentLoop('anthropic/claude-sonnet-4-6', 'system', 'user', tools, async () => 'result');
+
+  assert(capturedBody !== null, 'fetch should have been called');
+  assertEqual(
+    capturedBody.model,
+    'claude-sonnet-4-6',
+    'model field should have provider prefix stripped in chatAgentLoop',
+  );
+});
+
 await test('anthropic format: does not strip when no prefix present', async () => {
   let capturedBody: any = null;
 
@@ -700,11 +736,21 @@ await test('openai format: strips provider prefix from model ID', async () => {
     };
   }) as any;
 
-  // Temporarily set the env var so createLLMClient doesn't throw
+  // Temporarily set the env var so createLLMClient doesn't throw.
+  // Capture and restore the original value so we don't clobber it in CI.
+  const hadOpenAiApiKey = Object.prototype.hasOwnProperty.call(process.env, 'OPENAI_API_KEY');
+  const previousOpenAiApiKey = process.env.OPENAI_API_KEY;
   process.env.OPENAI_API_KEY = 'test-key';
   const client = createLLMClient(openaiConfig);
-  await client.chat('openai/gpt-4o', 'system', 'user');
-  delete process.env.OPENAI_API_KEY;
+  try {
+    await client.chat('openai/gpt-4o', 'system', 'user');
+  } finally {
+    if (hadOpenAiApiKey) {
+      process.env.OPENAI_API_KEY = previousOpenAiApiKey;
+    } else {
+      delete process.env.OPENAI_API_KEY;
+    }
+  }
 
   assert(capturedBody !== null, 'fetch should have been called');
   assertEqual(

--- a/tests/smoke-llm.ts
+++ b/tests/smoke-llm.ts
@@ -724,6 +724,7 @@ await test('openai format: strips provider prefix from model ID', async () => {
     baseUrl: 'https://api.openai.com',
     apiKeyEnv: 'OPENAI_API_KEY',
     timeout: 5000,
+    models: [],
   };
 
   globalThis.fetch = mockFetch((_url, init) => {


### PR DESCRIPTION
## Problem

When using `format: "anthropic"` with `baseUrl: "https://api.anthropic.com"`, the model ID (e.g., `anthropic/claude-sonnet-4-6`) includes a provider prefix that OpenRouter expects but the direct Anthropic API does not.

The Anthropic API returns:
```json
{"type":"error","error":{"type":"not_found_error","message":"model: anthropic/claude-sonnet-4-6"}}
```

The same issue applies to `format: "openai"` with a direct OpenAI baseUrl — the API expects `gpt-4o`, not `openai/gpt-4o`.

## Fix

Added `stripProviderPrefix()` helper in `src/benchmark/llm/index.ts` that strips known direct-provider prefixes (`anthropic/`, `openai/`) before sending model IDs to the respective APIs. Applied consistently across all three call paths (`chat`, `chatWithTools`, `chatAgentLoop`).

`openrouter/` prefixes are intentionally left intact — they signal `format: 'pi'` usage. Encountering an `openrouter/`-prefixed ID on a direct-API format config means the config is misconfigured; passing it through unchanged lets the API return a fast, visible error rather than silently misrouting the request.

The `pi` format is unaffected since `shouldStripPrefix` is false for that format.

## Testing

Before fix:
```
[claude-sonnet-4-6] FAILED: Anthropic API error 404: model: anthropic/claude-sonnet-4-6
```

After fix:
```
[claude-sonnet-4-6] ✅ PASS  recall=1.00
```

Tested with `format: "anthropic"`, `baseUrl: "https://api.anthropic.com"`, model ID `anthropic/claude-sonnet-4-6`.