### PR TITLE
docs: fix repo URL in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for contributing! This project is a small, opinionated tool — changes s
 ## Local workflow
 
 ```bash
-git clone https://github.com/bucurdavid/skill-optimizer
+git clone https://github.com/fastxyz/skill-optimizer
 cd skill-optimizer
 npm install
 npm run typecheck


### PR DESCRIPTION
CONTRIBUTING.md references `bucurdavid/skill-optimizer` but the repo is at `fastxyz/skill-optimizer`.

Fixes #18