### PR TITLE
Support bundled skill reads in benchmark

### DIFF
--- a/docs/reference/config-schema.md
+++ b/docs/reference/config-schema.md
@@ -11,7 +11,7 @@ Paths in the config are relative to the config file location.
 | `name` | `string` | — | Human-readable project name |
 | `target.surface` | `"sdk" | "cli" | "mcp" | "prompt"` | — | Type of callable surface |
 | `target.repoPath` | `string` | — | Path to the target repo (default ".") |
-| `target.skill` | `string | object` | — | Path to SKILL.md or { source, cache } object |
+| `target.skill` | `string | object` | — | Path to SKILL.md or { source, references, cache } object |
 | `target.discovery.mode` | `"auto" | "manifest"` | — | "auto" = code-first tree-sitter; "manifest" = use provided file only |
 | `target.discovery.sources` | `string[]` | — | Source files to scan for callable methods/commands/tools |
 | `target.discovery.fallbackManifest` | `string` | — | Path to manifest JSON when code-first discovery is incomplete |

--- a/src/benchmark/config.ts
+++ b/src/benchmark/config.ts
@@ -50,7 +50,7 @@ export function loadTasks(tasksPath: string, baseDir?: string): TaskDefinition[]
     throw new Error(`Failed to read tasks: ${resolved}: ${err instanceof Error ? err.message : err}`);
   }
 
-  let parsed: { tasks: Array<{ id?: unknown; prompt?: unknown; expected_actions?: unknown; verify?: unknown; expected_fetches?: unknown; capabilityId?: unknown }> };
+  let parsed: { tasks: Array<{ id?: unknown; prompt?: unknown; expected_actions?: unknown; verify?: unknown; expected_fetches?: unknown; expected_reads?: unknown; capabilityId?: unknown }> };
   try {
     parsed = JSON.parse(raw) as typeof parsed;
   } catch (err) {
@@ -65,7 +65,7 @@ export function loadTasks(tasksPath: string, baseDir?: string): TaskDefinition[]
 }
 
 function normalizeTaskDefinition(
-  task: { id?: unknown; prompt?: unknown; expected_actions?: unknown; verify?: unknown; expected_fetches?: unknown; capabilityId?: unknown },
+  task: { id?: unknown; prompt?: unknown; expected_actions?: unknown; verify?: unknown; expected_fetches?: unknown; expected_reads?: unknown; capabilityId?: unknown },
   resolvedPath: string,
   index: number,
 ): TaskDefinition {
@@ -105,6 +105,15 @@ function normalizeTaskDefinition(
     }
   }
 
+  const rawReads = Array.isArray(task.expected_reads) ? task.expected_reads : undefined;
+  if (rawReads !== undefined) {
+    for (let i = 0; i < rawReads.length; i++) {
+      if (typeof rawReads[i] !== 'string' || !(rawReads[i] as string).trim()) {
+        throw new Error(`Tasks file ${resolvedPath}: task ${task.id} expected_reads[${i}] must be a non-empty string`);
+      }
+    }
+  }
+
   const capabilityId = typeof task.capabilityId === 'string' ? task.capabilityId : undefined;
 
   return {
@@ -113,6 +122,7 @@ function normalizeTaskDefinition(
     expected_actions,
     verify: rawVerify as TaskDefinition['verify'] | undefined,
     expected_fetches: rawFetches as string[] | undefined,
+    expected_reads: rawReads as string[] | undefined,
     ...(capabilityId !== undefined ? { capabilityId } : {}),
   };
 }

--- a/src/benchmark/evaluator.ts
+++ b/src/benchmark/evaluator.ts
@@ -2,6 +2,7 @@ import type {
   ExpectedAction,
   ExtractedCall,
   ActionMatch,
+  CliCommandDefinition,
   TaskDefinition,
   TaskResult,
   ModelConfig,
@@ -163,6 +164,290 @@ function matchExpectedValue(
     match,
   };
   return match;
+}
+
+function normalizeCliArgKey(key: string): string {
+  return key.replace(/^-+/, '').trim();
+}
+
+function getCliRootKey(key: string): string {
+  return normalizeCliArgKey(key).split('.')[0];
+}
+
+function parseCliMaybeJson(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return value;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return value;
+  }
+}
+
+function resolveCliArgValue(
+  args: Record<string, unknown>,
+  key: string,
+  expectedValue?: unknown,
+): unknown {
+  const normalizedKey = normalizeCliArgKey(key);
+  const normalizedArgs: Record<string, unknown> = {};
+  for (const [argKey, value] of Object.entries(args)) {
+    normalizedArgs[normalizeCliArgKey(argKey)] = value;
+  }
+
+  const dotIdx = normalizedKey.indexOf('.');
+  if (dotIdx !== -1) {
+    const root = normalizedKey.slice(0, dotIdx);
+    const pathParts = normalizedKey.slice(dotIdx + 1).split('.').filter(Boolean);
+    let current = normalizedArgs[root] ?? resolveArgValue(args, root, expectedValue);
+    current = parseCliMaybeJson(current);
+    for (const segment of pathParts) {
+      if (!isPlainObject(current)) return undefined;
+      current = current[segment];
+    }
+    return current;
+  }
+
+  return normalizedArgs[normalizedKey] ?? resolveArgValue(args, normalizedKey, expectedValue);
+}
+
+type ArgResult = { expected: string; got: unknown; match: boolean };
+
+type CliArgConstraint =
+  | { kind: 'any' }
+  | { kind: 'nonempty-string' }
+  | { kind: 'exact'; value: unknown }
+  | { kind: 'one-of'; values: unknown[] }
+  | { kind: 'json-object'; requiredKeys?: string[] }
+  | { kind: string; [key: string]: unknown };
+
+function matchCliConstraint(
+  constraint: CliArgConstraint,
+  got: unknown,
+  path: string,
+  argResults: Record<string, ArgResult>,
+): boolean {
+  let match = false;
+  switch (constraint.kind) {
+    case 'any':
+      match = got !== undefined;
+      break;
+    case 'nonempty-string':
+      match = typeof got === 'string' && got.trim().length > 0;
+      break;
+    case 'exact':
+      match = matchArgValue(constraint.value, got);
+      break;
+    case 'one-of':
+      match = Array.isArray(constraint.values) && constraint.values.some((value) => matchArgValue(value, got));
+      break;
+    case 'json-object': {
+      const parsed = parseCliMaybeJson(got);
+      const requiredKeys = Array.isArray(constraint.requiredKeys) ? constraint.requiredKeys : [];
+      match = isPlainObject(parsed) && requiredKeys.every((key) => Object.prototype.hasOwnProperty.call(parsed, key));
+      break;
+    }
+    default:
+      return matchExpectedValue(constraint, got, path, argResults);
+  }
+
+  argResults[path] = {
+    expected: stringifyExpected(constraint),
+    got,
+    match,
+  };
+  return match;
+}
+
+function getExpectedCliRequired(expected: ExpectedAction): string[] {
+  const cli = (expected as { cli?: { required?: unknown } }).cli;
+  return Array.isArray(cli?.required) ? cli.required.filter((value): value is string => typeof value === 'string') : [];
+}
+
+function findCliCommandDefinition(
+  cliCommands: readonly CliCommandDefinition[] | undefined,
+  method: string,
+): CliCommandDefinition | undefined {
+  return cliCommands?.find((command) => command.command === method);
+}
+
+function buildCliAllowedOptionSet(commandDef?: CliCommandDefinition): Set<string> | null {
+  if (!commandDef?.options || commandDef.options.length === 0) return null;
+  const allowed = new Set<string>();
+  for (const option of commandDef.options) {
+    allowed.add(normalizeCliArgKey(option.name));
+    for (const alias of option.aliases ?? []) {
+      allowed.add(normalizeCliArgKey(alias));
+    }
+  }
+  return allowed;
+}
+
+function evaluateCliArgs(
+  expected: ExpectedAction,
+  found: ExtractedCall,
+  commandDef?: CliCommandDefinition,
+): { allArgsMatch: boolean; argResults: Record<string, ArgResult> } {
+  const argResults: Record<string, ArgResult> = {};
+  let allArgsMatch = true;
+  const allowedOptions = buildCliAllowedOptionSet(commandDef);
+
+  if (allowedOptions) {
+    for (const [key, value] of Object.entries(found.args)) {
+      if (key === 'env' || key.startsWith('_positional_')) continue;
+      const normalized = normalizeCliArgKey(key);
+      if (!allowedOptions.has(normalized)) {
+        allArgsMatch = false;
+        argResults[`unsupported.${normalized}`] = {
+          expected: 'supported option',
+          got: value,
+          match: false,
+        };
+      }
+    }
+  }
+
+  const requiredKeys = new Set<string>();
+  for (const required of getExpectedCliRequired(expected)) {
+    requiredKeys.add(getCliRootKey(required));
+  }
+  if (expected.args) {
+    for (const key of Object.keys(expected.args)) {
+      requiredKeys.add(getCliRootKey(key));
+    }
+  }
+
+  for (const requiredKey of requiredKeys) {
+    const got = resolveCliArgValue(found.args, requiredKey);
+    const match = got !== undefined;
+    argResults[`required.${requiredKey}`] = {
+      expected: '<present>',
+      got,
+      match,
+    };
+    if (!match) allArgsMatch = false;
+  }
+
+  for (const [key, expectedValue] of Object.entries(expected.args ?? {})) {
+    const got = resolveCliArgValue(found.args, key, expectedValue);
+    const isConstraint = isPlainObject(expectedValue) && typeof expectedValue.kind === 'string';
+    const match = isConstraint
+      ? matchCliConstraint(expectedValue as CliArgConstraint, got, key, argResults)
+      : matchExpectedValue(expectedValue, got, key, argResults);
+    if (!match) allArgsMatch = false;
+  }
+
+  return { allArgsMatch, argResults };
+}
+
+function matchCliActions(
+  expectedActions: ExpectedAction[],
+  extractedCalls: ExtractedCall[],
+  cliCommands?: readonly CliCommandDefinition[],
+): ActionMatch[] {
+  const usedIndices = new Set<number>();
+
+  return expectedActions.map((expected) => {
+    const expectedMethod = getExpectedActionName(expected);
+    const hasExpectedArgs =
+      Object.keys(expected.args ?? {}).length > 0 ||
+      getExpectedCliRequired(expected).length > 0;
+
+    if (hasExpectedArgs) {
+      let perfectMatchIndex = -1;
+      for (let i = 0; i < extractedCalls.length; i++) {
+        if (usedIndices.has(i)) continue;
+        const candidate = extractedCalls[i];
+        if (candidate.method !== expectedMethod) continue;
+        const commandDef = findCliCommandDefinition(cliCommands, expectedMethod);
+        const { allArgsMatch } = evaluateCliArgs(expected, candidate, commandDef);
+        if (allArgsMatch) {
+          perfectMatchIndex = i;
+          break;
+        }
+      }
+
+      if (perfectMatchIndex !== -1) {
+        usedIndices.add(perfectMatchIndex);
+        const found = extractedCalls[perfectMatchIndex];
+        const commandDef = findCliCommandDefinition(cliCommands, expectedMethod);
+        const { argResults } = evaluateCliArgs(expected, found, commandDef);
+        return {
+          expected,
+          found,
+          methodFound: true,
+          argsCorrect: true,
+          matched: true,
+          argResults,
+        } satisfies ActionMatch;
+      }
+
+      let fallbackIndex = -1;
+      for (let i = 0; i < extractedCalls.length; i++) {
+        if (usedIndices.has(i)) continue;
+        if (extractedCalls[i].method === expectedMethod) {
+          fallbackIndex = i;
+          break;
+        }
+      }
+
+      if (fallbackIndex === -1) {
+        return {
+          expected,
+          found: null,
+          methodFound: false,
+          argsCorrect: false,
+          matched: false,
+        } satisfies ActionMatch;
+      }
+
+      usedIndices.add(fallbackIndex);
+      const found = extractedCalls[fallbackIndex];
+      const commandDef = findCliCommandDefinition(cliCommands, expectedMethod);
+      const { allArgsMatch, argResults } = evaluateCliArgs(expected, found, commandDef);
+      return {
+        expected,
+        found,
+        methodFound: true,
+        argsCorrect: allArgsMatch,
+        matched: allArgsMatch,
+        argResults,
+      } satisfies ActionMatch;
+    }
+
+    let foundIndex = -1;
+    for (let i = 0; i < extractedCalls.length; i++) {
+      if (usedIndices.has(i)) continue;
+      if (extractedCalls[i].method === expectedMethod) {
+        foundIndex = i;
+        break;
+      }
+    }
+
+    if (foundIndex === -1) {
+      return {
+        expected,
+        found: null,
+        methodFound: false,
+        argsCorrect: false,
+        matched: false,
+      } satisfies ActionMatch;
+    }
+
+    usedIndices.add(foundIndex);
+    const found = extractedCalls[foundIndex];
+    const commandDef = findCliCommandDefinition(cliCommands, expectedMethod);
+    const { allArgsMatch, argResults } = evaluateCliArgs(expected, found, commandDef);
+    return {
+      expected,
+      found,
+      methodFound: true,
+      argsCorrect: allArgsMatch,
+      matched: allArgsMatch,
+      argResults,
+    } satisfies ActionMatch;
+  });
 }
 
 // ── Tool matching ──────────────────────────────────────────────────────────
@@ -419,6 +704,7 @@ export function evaluateTask(params: {
   knownMethods: Set<string>;
   bindings?: Map<string, string>;  // variable → source function/class from extractor
   surface: 'sdk' | 'cli' | 'mcp' | 'prompt';
+  cliCommands?: readonly CliCommandDefinition[];
 }): TaskResult {
   const {
     task,
@@ -431,6 +717,7 @@ export function evaluateTask(params: {
     knownMethods,
     bindings,
     surface,
+    cliCommands,
   } = params;
 
   let extractedCalls = params.extractedCalls;
@@ -439,7 +726,9 @@ export function evaluateTask(params: {
     extractedCalls = resolveCallsFromBindings(extractedCalls, bindings, expectedActions);
   }
 
-  const actionMatches = matchActions(expectedActions, extractedCalls);
+  const actionMatches = surface === 'cli'
+    ? matchCliActions(expectedActions, extractedCalls, cliCommands)
+    : matchActions(expectedActions, extractedCalls);
 
   const codePatternResults: Record<string, boolean> = {};
   let allCodePatternsPass = true;

--- a/src/benchmark/prompts.ts
+++ b/src/benchmark/prompts.ts
@@ -7,6 +7,7 @@ interface PromptOptions {
   agentic?: boolean;
   shell?: 'bash' | 'sh';
   sdkLanguage?: SdkLanguage;
+  companionSkillPaths?: string[];
 }
 
 const SDK_LANGUAGE_LABELS: Record<SdkLanguage, string> = {
@@ -33,8 +34,15 @@ export function buildSystemPrompt(
   sdkName: string,
   options: PromptOptions,
 ): string {
+  const companionPaths = options.companionSkillPaths ?? [];
+  const companionSection = companionPaths.length > 0
+    ? `\n\nCompanion skill files available:\n${companionPaths.map((p) => `- ${p}`).join('\n')}`
+    : '';
+  const companionToolGuidance = companionPaths.length > 0
+    ? '\nWhen tools are available, use `skill_read(path)` to read these companion files by exact path.'
+    : '';
   const guidanceSection = skill
-    ? `\n\nOptional guidance context (SKILL.md):\n--- GUIDANCE ---\n${skill.content}\n--- END GUIDANCE ---`
+    ? `\n\nOptional guidance context (SKILL.md):\n--- GUIDANCE ---\n${skill.content}\n--- END GUIDANCE ---${companionSection}${companionToolGuidance}`
     : '';
 
   if (options.surface === 'prompt') {

--- a/src/benchmark/read-evaluator.ts
+++ b/src/benchmark/read-evaluator.ts
@@ -1,0 +1,33 @@
+export interface ReadEvaluationResult {
+  passed: boolean;
+  recall: number;
+  precision: number;
+  matched: string[];
+  missing: string[];
+  extra: string[];
+  actual: string[];
+}
+
+export function evaluateExpectedReads(expectedReads: string[], actualReads: string[]): ReadEvaluationResult {
+  const expectedSet = new Set(expectedReads);
+  const actualSet = new Set(actualReads);
+
+  const matched = [...expectedSet].filter((path) => actualSet.has(path));
+  const missing = [...expectedSet].filter((path) => !actualSet.has(path));
+  const extra = [...actualSet].filter((path) => !expectedSet.has(path));
+
+  const recall = expectedSet.size === 0 ? 1.0 : matched.length / expectedSet.size;
+  const precision = actualSet.size === 0
+    ? (expectedSet.size === 0 ? 1.0 : 0.0)
+    : matched.length / actualSet.size;
+
+  return {
+    passed: missing.length === 0,
+    recall,
+    precision,
+    matched,
+    missing,
+    extra,
+    actual: actualReads,
+  };
+}

--- a/src/benchmark/runner.ts
+++ b/src/benchmark/runner.ts
@@ -10,6 +10,7 @@ import type {
   ExtractedCall,
   MethodCoverage,
   SkillVersion,
+  FetchedSkill,
   ModelSummary,
   TaskSummary,
   ToolExecutor,
@@ -28,6 +29,7 @@ import { buildSystemPrompt, buildTaskPrompt } from './prompts.js';
 import { evaluatePromptResponse } from './prompt-evaluator.js';
 import { resolveCriteriaForTask } from './prompt-criteria.js';
 import { discoverPromptCapabilitiesWithSections } from '../project/discover-prompt.js';
+import { evaluateExpectedReads } from './read-evaluator.js';
 
 function buildWebFetchTool(): McpToolDefinition {
   return {
@@ -39,6 +41,23 @@ function buildWebFetchTool(): McpToolDefinition {
         type: 'object',
         properties: { url: { type: 'string', description: 'Path to the reference document' } },
         required: ['url'],
+      },
+    },
+  };
+}
+
+function buildSkillReadTool(): McpToolDefinition {
+  return {
+    type: 'function',
+    function: {
+      name: 'skill_read',
+      description: 'Read a bundled companion skill file by its path.',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: { type: 'string', description: 'Companion skill file path exactly as listed in the prompt' },
+        },
+        required: ['path'],
       },
     },
   };
@@ -71,6 +90,42 @@ function createReferenceExecutor(baseUrl: string, allowedPaths: string[]): { exe
     } catch (err) { return `Error: ${err instanceof Error ? err.message : String(err)}`; }
   };
   return { executor, fetchedPaths: fetched };
+}
+
+export function createSkillReadExecutor(
+  references: FetchedSkill['references'] | undefined,
+): { executor: ToolExecutor; readPaths: string[] } {
+  const reads: string[] = [];
+  const byPath = new Map<string, string>();
+  for (const ref of references ?? []) {
+    byPath.set(ref.path, ref.content);
+  }
+
+  const executor: ToolExecutor = async (name, args) => {
+    if (name !== 'skill_read') return `Error: Unknown tool "${name}"`;
+    const rawPath = String(args.path ?? '');
+    const requestedPath = rawPath.trim();
+    if (!requestedPath) return 'Error: Missing required argument "path"';
+    if (requestedPath.includes('..')) return 'Error: Path traversal is not allowed';
+    const content = byPath.get(requestedPath);
+    if (!content) {
+      return `Error: Companion skill path "${requestedPath}" not found. Available: ${[...byPath.keys()].join(', ')}`;
+    }
+    reads.push(requestedPath);
+    return content;
+  };
+
+  return { executor, readPaths: reads };
+}
+
+function combineExecutors(executors: ToolExecutor[]): ToolExecutor {
+  return async (name, args) => {
+    for (const executor of executors) {
+      const result = await executor(name, args);
+      if (!result.startsWith('Error: Unknown tool')) return result;
+    }
+    return `Error: Unknown tool "${name}"`;
+  };
 }
 
 function formatMcpResponseContent(
@@ -187,11 +242,14 @@ export async function runBenchmark(options: RunnerOptions = {}): Promise<Benchma
   }
 
 
+  const hasWebReferences = Boolean(config.agentic?.references);
+  const hasExpectedReads = tasks.some((task) => (task.expected_reads?.length ?? 0) > 0);
   const promptOptions = {
     surface: config.surface,
-    agentic: Boolean(config.agentic),
+    agentic: hasWebReferences || hasExpectedReads,
     shell: config.cli?.shell,
     sdkLanguage: config.sdk?.language,
+    companionSkillPaths: skill?.references?.map((ref) => ref.path) ?? [],
   };
   const systemPrompt = buildSystemPrompt(skill, config.name, promptOptions);
   console.log(`[prompt] Surface: ${config.surface}`);
@@ -238,18 +296,53 @@ export async function runBenchmark(options: RunnerOptions = {}): Promise<Benchma
       let error: string | undefined;
       let llmResponse;
       let fetchedPaths: string[] = [];
+      let readPaths: string[] = [];
+
+      const taskHasExpectedReads = Array.isArray(task.expected_reads) && task.expected_reads.length > 0;
+      const shouldUseAgentLoop = hasWebReferences || taskHasExpectedReads;
+
+      if (taskHasExpectedReads && config.surface === 'mcp') {
+        throw new Error(
+          `Task "${task.id}" uses expected_reads, which is not supported for MCP benchmarks because it can interfere with structured MCP tool-call evaluation.`,
+        );
+      }
+
+      if (taskHasExpectedReads && (skill?.references?.length ?? 0) === 0) {
+        throw new Error(
+          `Task "${task.id}" uses expected_reads, but no bundled skill references are available. Configure target.skill.references with local files.`,
+        );
+      }
 
       const start = Date.now();
       try {
-        if (config.agentic) {
-          const ref = createReferenceExecutor(
-            config.agentic.references.baseUrl, config.agentic.references.allowedPaths,
-          );
+        if (shouldUseAgentLoop) {
+          const tools: McpToolDefinition[] = [];
+          const executors: ToolExecutor[] = [];
+
+          if (config.agentic?.references) {
+            const ref = createReferenceExecutor(
+              config.agentic.references.baseUrl, config.agentic.references.allowedPaths,
+            );
+            tools.push(buildWebFetchTool());
+            executors.push(ref.executor);
+            fetchedPaths = ref.fetchedPaths;
+          }
+
+          if (taskHasExpectedReads) {
+            const reader = createSkillReadExecutor(skill?.references);
+            tools.push(buildSkillReadTool());
+            executors.push(reader.executor);
+            readPaths = reader.readPaths;
+          }
+
+          if (tools.length === 0 || executors.length === 0) {
+            throw new Error('Agent loop requested without any configured tools');
+          }
+
           llmResponse = await client.chatAgentLoop(
             model.id, systemPrompt, buildTaskPrompt(task, promptOptions),
-            [buildWebFetchTool()], ref.executor, config.agentic.maxTurns ?? 5,
+            tools, combineExecutors(executors), config.agentic?.maxTurns ?? 5,
           );
-          fetchedPaths = ref.fetchedPaths;
         } else if (config.surface === 'mcp' && mcpToolDefs) {
           llmResponse = await client.chatWithTools(
             model.id,
@@ -360,7 +453,8 @@ export async function runBenchmark(options: RunnerOptions = {}): Promise<Benchma
         knownMethods,
         bindings,
         surface: config.surface,
-      });
+        ...(cliCommands ? { cliCommands } : {}),
+      } as Parameters<typeof evaluateTask>[0]);
 
       // Prompt surface: replace vacuous tool-recall with per-capability content score.
       if (config.surface === 'prompt') {
@@ -392,7 +486,7 @@ export async function runBenchmark(options: RunnerOptions = {}): Promise<Benchma
         }
       }
 
-      if (config.agentic && task.expected_fetches) {
+      if (config.agentic?.references && task.expected_fetches) {
         const actualFetches = fetchedPaths;
         const expectedSet = new Set(task.expected_fetches);
         const actualSet = new Set(actualFetches);
@@ -403,6 +497,20 @@ export async function runBenchmark(options: RunnerOptions = {}): Promise<Benchma
         taskResult.metrics.taskPassed = taskResult.metrics.taskPassed && taskResult.metrics.fetchRecall === 1.0;
         const fetchStatus = taskResult.metrics.fetchRecall === 1.0 ? 'correct' : 'WRONG';
         console.log(`  [${slug}] Fetched: [${actualFetches.join(', ')}] (${fetchStatus})`);
+      }
+
+      if (task.expected_reads) {
+        const readEval = evaluateExpectedReads(task.expected_reads, readPaths);
+        taskResult.metrics.readPassed = readEval.passed;
+        taskResult.metrics.readRecall = readEval.recall;
+        taskResult.metrics.readPrecision = readEval.precision;
+        taskResult.metrics.matchedReads = readEval.matched;
+        taskResult.metrics.missingReads = readEval.missing;
+        taskResult.metrics.extraReads = readEval.extra;
+        taskResult.metrics.actualReads = readEval.actual;
+        taskResult.metrics.taskPassed = taskResult.metrics.taskPassed && readEval.passed;
+        const readStatus = readEval.passed ? 'correct' : 'MISSING_REQUIRED';
+        console.log(`  [${slug}] Reads: [${readEval.actual.join(', ')}] (${readStatus})`);
       }
 
       const status = taskResult.metrics.taskPassed ? '✅ PASS' : '❌ FAIL';

--- a/src/benchmark/skill-fetcher.ts
+++ b/src/benchmark/skill-fetcher.ts
@@ -1,5 +1,5 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, isAbsolute, relative, resolve } from 'node:path';
 import type { FetchedSkill, SkillConfig, SkillVersion } from './types.js';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -26,6 +26,32 @@ function writeCache(cachePath: string, result: FetchedSkill): void {
   const cacheDir = resolve(cachePath, '..');
   mkdirSync(cacheDir, { recursive: true });
   writeFileSync(cachePath, JSON.stringify(result, null, 2), 'utf-8');
+}
+
+function isRemoteSkillSource(source: string): boolean {
+  return source.startsWith('github:') || source.startsWith('https://') || source.startsWith('http://');
+}
+
+function normalizePathForPrompt(pathValue: string): string {
+  return pathValue.replace(/\\/g, '/');
+}
+
+function isAncestorOrSame(parent: string, child: string): boolean {
+  const rel = relative(parent, child);
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+}
+
+function getCommonDirectory(paths: string[]): string {
+  if (paths.length === 0) return process.cwd();
+  let common = paths[0]!;
+  for (const current of paths.slice(1)) {
+    while (!isAncestorOrSame(common, current)) {
+      const next = dirname(common);
+      if (next === common) break;
+      common = next;
+    }
+  }
+  return common;
 }
 
 // ── GitHub source ──────────────────────────────────────────────────────────
@@ -192,6 +218,67 @@ function fetchFromFile(source: string): FetchedSkill {
   return { version, content };
 }
 
+function fetchFromFileWithReferences(skillConfig: SkillConfig): FetchedSkill {
+  const source = skillConfig.source;
+  const references = skillConfig.references ?? [];
+  const resolved = resolve(process.cwd(), source);
+
+  if (!existsSync(resolved)) {
+    throw new Error(`Skill file not found: ${resolved} (from source: "${source}")`);
+  }
+
+  console.log(`[skill] Reading skill from file: ${resolved}`);
+
+  let content: string;
+  try {
+    content = readFileSync(resolved, 'utf-8');
+  } catch (err) {
+    throw new Error(`Failed to read skill file ${resolved}: ${err instanceof Error ? err.message : err}`);
+  }
+
+  const resolvedReferenceFiles = references.map((referenceSource) => {
+    const resolvedReference = resolve(process.cwd(), referenceSource);
+    if (!existsSync(resolvedReference)) {
+      throw new Error(`Skill reference file not found: ${resolvedReference} (from source: "${referenceSource}")`);
+    }
+    let referenceContent: string;
+    try {
+      referenceContent = readFileSync(resolvedReference, 'utf-8');
+    } catch (err) {
+      throw new Error(`Failed to read skill reference file ${resolvedReference}: ${err instanceof Error ? err.message : err}`);
+    }
+    return {
+      source: referenceSource,
+      resolvedPath: resolvedReference,
+      content: referenceContent,
+    };
+  });
+
+  const commonDirectory = getCommonDirectory([
+    dirname(resolved),
+    ...resolvedReferenceFiles.map((ref) => dirname(ref.resolvedPath)),
+  ]);
+
+  const frozenReferences = resolvedReferenceFiles.map((ref) => ({
+    path: normalizePathForPrompt(relative(commonDirectory, ref.resolvedPath)),
+    source: ref.source,
+    content: ref.content,
+  }));
+
+  const version: SkillVersion = {
+    source,
+    commitSha: 'local',
+    ref: 'file',
+    fetchedAt: new Date().toISOString(),
+  };
+
+  return {
+    version,
+    content,
+    references: frozenReferences,
+  };
+}
+
 // ── Public API ─────────────────────────────────────────────────────────────
 
 /**
@@ -210,11 +297,18 @@ export async function fetchSkill(skillConfig: SkillConfig | undefined): Promise<
   const source = skillConfig.source;
   const useCache = skillConfig.cache !== false;
 
+  if (isRemoteSkillSource(source) && (skillConfig.references?.length ?? 0) > 0) {
+    throw new Error('target.skill.references is only supported for local file-based target.skill.source values');
+  }
+
   if (source.startsWith('github:')) {
     return fetchFromGitHub(source, useCache);
   } else if (source.startsWith('https://') || source.startsWith('http://')) {
     return fetchFromUrl(source, useCache);
   } else {
+    if ((skillConfig.references?.length ?? 0) > 0) {
+      return fetchFromFileWithReferences(skillConfig);
+    }
     return fetchFromFile(source);
   }
 }

--- a/src/benchmark/types.ts
+++ b/src/benchmark/types.ts
@@ -74,6 +74,7 @@ export interface McpSurfaceConfig {
 
 export interface SkillConfig {
   source: string;                  // "github:org/repo/path", "./file.md", "https://url"
+  references?: string[];           // local companion markdown/text files
   cache?: boolean;                 // default true
 }
 
@@ -92,7 +93,7 @@ export interface OutputConfig {
 }
 
 export interface AgenticConfig {
-  references: {
+  references?: {
     baseUrl: string;
     allowedPaths: string[];
   };
@@ -126,6 +127,11 @@ export interface SkillVersion {
 export interface FetchedSkill {
   version: SkillVersion;
   content: string;
+  references?: Array<{
+    path: string;
+    source: string;
+    content: string;
+  }>;
 }
 
 // === Task Definition (loaded from tasks.json) ===
@@ -133,6 +139,9 @@ export interface FetchedSkill {
 export interface ExpectedAction {
   name: string;                    // Unified action name (SDK method, CLI command, or MCP tool)
   args?: Record<string, unknown>;  // expected arg values (supports nested objects/arrays, strings, regexes, sentinels)
+  cli?: {
+    required?: string[];
+  };
 }
 
 export interface TaskVerification {
@@ -145,6 +154,7 @@ export interface TaskDefinition {
   expected_actions: ExpectedAction[];
   verify?: TaskVerification[];
   expected_fetches?: string[];
+  expected_reads?: string[];
   capabilityId?: string;
 }
 
@@ -202,6 +212,13 @@ export interface TaskResult {
     fetchRecall?: number;
     fetchPrecision?: number;
     actualFetches?: string[];
+    readPassed?: boolean;
+    readRecall?: number;
+    readPrecision?: number;
+    matchedReads?: string[];
+    missingReads?: string[];
+    extraReads?: string[];
+    actualReads?: string[];
   };
   llmLatencyMs: number;
   tokenUsage?: TokenUsage;

--- a/src/project/resolve.ts
+++ b/src/project/resolve.ts
@@ -16,14 +16,23 @@ const DEFAULT_PER_MODEL_FLOOR = 0.6;
 const DEFAULT_TARGET_WEIGHTED_AVERAGE = 0.7;
 const DEFAULT_REPORT_CONTEXT_MAX_BYTES = 16_000;
 
+function isRemoteSkillSource(source: string): boolean {
+  return source.startsWith('github:') || source.startsWith('https://') || source.startsWith('http://');
+}
+
+function resolveSkillSource(configDir: string, source: string): string {
+  return isRemoteSkillSource(source) ? source : resolve(configDir, source);
+}
+
 export function resolveProjectConfig(config: ProjectConfig, configPath: string): ResolvedProjectConfig {
   const configDir = dirname(configPath);
   const skill = config.target.skill
     ? typeof config.target.skill === 'string'
-      ? { source: resolve(configDir, config.target.skill), cache: true }
+      ? { source: resolveSkillSource(configDir, config.target.skill), cache: true }
       : {
           ...config.target.skill,
-          source: resolve(configDir, config.target.skill.source),
+          source: resolveSkillSource(configDir, config.target.skill.source),
+          references: config.target.skill.references?.map((ref) => resolveSkillSource(configDir, ref)),
           cache: config.target.skill.cache ?? true,
         }
     : undefined;

--- a/src/project/schema.ts
+++ b/src/project/schema.ts
@@ -40,8 +40,12 @@ const TargetConfigSchema = z.object({
   repoPath: z.string().optional().describe('Path to the target repo (default ".")'),
   skill: z.union([
     z.string(),
-    z.object({ source: z.string(), cache: z.boolean().optional() }),
-  ]).optional().describe('Path to SKILL.md or { source, cache } object'),
+    z.object({
+      source: z.string(),
+      references: z.array(z.string()).optional(),
+      cache: z.boolean().optional(),
+    }),
+  ]).optional().describe('Path to SKILL.md or { source, references, cache } object'),
   discovery: DiscoveryConfigSchema.optional().describe('How to discover callable actions'),
   sdk: SdkConfigSchema.optional().describe('SDK-specific config'),
   cli: CliConfigSchema.optional().describe('CLI-specific config'),

--- a/src/project/validate.ts
+++ b/src/project/validate.ts
@@ -27,6 +27,9 @@ export async function checkConfig(
 ): Promise<Issue[]> {
   const issues: Issue[] = [];
 
+  const isRemoteSkillSource = (source: string): boolean =>
+    source.startsWith('github:') || source.startsWith('https://') || source.startsWith('http://');
+
   function err(code: string, field: string, message: string, hint?: string): void {
     issues.push({ code, severity: 'error', field, message, hint, fixable: false });
   }
@@ -53,6 +56,27 @@ export async function checkConfig(
     const skillSource = typeof target.skill === 'string' ? target.skill : target.skill?.source;
     if (!skillSource || typeof skillSource !== 'string') {
       err('invalid-skill', 'target.skill', '"target.skill" must be a path string or { source } object');
+    }
+    if (target.skill && typeof target.skill === 'object' && target.skill.references !== undefined) {
+      if (!Array.isArray(target.skill.references)) {
+        err('invalid-skill-references', 'target.skill.references', '"target.skill.references" must be an array of non-empty strings');
+      } else {
+        for (let i = 0; i < target.skill.references.length; i++) {
+          const ref = target.skill.references[i];
+          if (typeof ref !== 'string' || ref.trim() === '') {
+            err('invalid-skill-reference-entry', `target.skill.references[${i}]`, 'Each skill reference must be a non-empty string');
+          }
+        }
+      }
+
+      if (typeof skillSource === 'string' && isRemoteSkillSource(skillSource) && target.skill.references.length > 0) {
+        err(
+          'remote-skill-references-unsupported',
+          'target.skill.references',
+          '"target.skill.references" is only supported when "target.skill.source" is a local file path',
+          'Use a local target.skill.source when configuring references',
+        );
+      }
     }
   }
 
@@ -296,7 +320,7 @@ export async function checkConfig(
   // Check: target.skill file exists (skip for remote sources — github: / https: / http:)
   if (target.skill !== undefined) {
     const skillSource = typeof target.skill === 'string' ? target.skill : target.skill.source;
-    const isRemoteSkill = skillSource.startsWith('github:') || skillSource.startsWith('https://') || skillSource.startsWith('http://');
+    const isRemoteSkill = isRemoteSkillSource(skillSource);
     if (skillSource && !isRemoteSkill) {
       const absSkill = isAbsolute(skillSource) ? skillSource : resolve(configDir, skillSource);
       if (!existsSync(absSkill)) {
@@ -306,6 +330,22 @@ export async function checkConfig(
           hint: `Create SKILL.md at that path or update target.skill`,
           fixable: false,
         });
+      }
+    }
+
+    const skillReferences = typeof target.skill === 'object' ? target.skill.references : undefined;
+    if (Array.isArray(skillReferences)) {
+      for (let i = 0; i < skillReferences.length; i++) {
+        const ref = skillReferences[i]!;
+        const absRef = isAbsolute(ref) ? ref : resolve(configDir, ref);
+        if (!existsSync(absRef)) {
+          issues.push({
+            code: 'skill-reference-missing', severity: 'error', field: `target.skill.references[${i}]`,
+            message: `skill reference does not exist: ${absRef}`,
+            hint: 'Create the file or update target.skill.references',
+            fixable: false,
+          });
+        }
       }
     }
   }

--- a/tests/smoke-cli.ts
+++ b/tests/smoke-cli.ts
@@ -1,10 +1,14 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import { extractShellBlock, parseShellCommands, extractFromCliMarkdown } from '../src/benchmark/extractors/cli-extractor.js';
 import { extract } from '../src/benchmark/extractors/index.js';
 import { loadCliCommands } from '../src/benchmark/config.js';
+import { evaluateTask } from '../src/benchmark/evaluator.js';
+import { createSkillReadExecutor } from '../src/benchmark/runner.js';
+import { evaluateExpectedReads } from '../src/benchmark/read-evaluator.js';
+import { fetchSkill } from '../src/benchmark/skill-fetcher.js';
 import type { BenchmarkConfig, LLMResponse } from '../src/benchmark/types.js';
 
 let passed = 0;
@@ -307,6 +311,193 @@ await test('loadCliCommands: rejects entries without command', () => {
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+await test('fetchSkill loads local companion skill references', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'skill-optimizer-skill-'));
+  try {
+    const mainDir = join(dir, 'gws-drive');
+    const sharedDir = join(dir, 'gws-shared');
+    mkdirSync(mainDir, { recursive: true });
+    mkdirSync(sharedDir, { recursive: true });
+
+    const mainPath = join(mainDir, 'SKILL.md');
+    const sharedPath = join(sharedDir, 'SKILL.md');
+
+    writeFileSync(mainPath, '# Main skill\n', 'utf-8');
+    writeFileSync(sharedPath, '# Shared skill\nExpected shared companion text\n', 'utf-8');
+
+    const fetched = await fetchSkill({
+      source: mainPath,
+      references: [sharedPath],
+      cache: false,
+    } as any);
+
+    assert(fetched !== null, 'fetchSkill should return skill content');
+    const references = (fetched as any).references as Array<{ path: string; content: string }>;
+    assertEqual(references.length, 1, 'one local reference should be loaded');
+    assertEqual(references[0].path, 'gws-shared/SKILL.md', 'reference path should be slash-normalized and stable');
+    assert(references[0].content.includes('Expected shared companion text'), 'shared reference content should be loaded');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+await test('skill_read serves only frozen allowed skill references', async () => {
+  const built = (createSkillReadExecutor as any)([
+    {
+      path: 'gws-shared/SKILL.md',
+      source: '/tmp/gws-shared/SKILL.md',
+      content: 'Expected shared reference body',
+    },
+  ]);
+  const executor = typeof built === 'function' ? built : built.executor;
+  const reads: string[] = built.reads ?? built.successfulReads ?? built.readPaths ?? [];
+
+  const ok = await executor('skill_read', { path: 'gws-shared/SKILL.md' });
+  assert(String(ok).includes('Expected shared reference body'), 'skill_read should return allowed reference content');
+  assertEqual(reads.length, 1, 'successful read should be recorded');
+  assertEqual(reads[0], 'gws-shared/SKILL.md', 'successful read path should be tracked');
+
+  const leadingSlash = await executor('skill_read', { path: '/gws-shared/SKILL.md' });
+  assert(String(leadingSlash).startsWith('Error:'), 'leading slash variant should not match configured path');
+  assertEqual(reads.length, 1, 'unconfigured leading slash variant must not be recorded as successful');
+
+  const denied = await executor('skill_read', { path: '../secret.md' });
+  assert(String(denied).startsWith('Error:'), 'path traversal read should be rejected');
+  assertEqual(reads.length, 1, 'rejected read must not be recorded as successful');
+});
+
+await test('expected_reads pass/fail helper', () => {
+  const pass = (evaluateExpectedReads as any)(['a.md', 'b.md'], ['a.md', 'b.md', 'extra.md']);
+  assertEqual(pass.passed, true, 'extra reads should still pass expected read coverage');
+  assertEqual(pass.extra.length, 1, 'extra read should be reported');
+  assertEqual(pass.extra[0], 'extra.md', 'reported extra read should match actual extra path');
+
+  const fail = (evaluateExpectedReads as any)(['a.md', 'b.md'], ['a.md']);
+  assertEqual(fail.passed, false, 'missing expected read should fail');
+  assertEqual(fail.missing.length, 1, 'missing expected read should be reported');
+  assertEqual(fail.missing[0], 'b.md', 'missing read should identify b.md');
+});
+
+await test('CLI required flag normalization passes with mixed required forms', () => {
+  const task = {
+    id: 'cli-required-normalization',
+    prompt: 'List permissions',
+    expected_actions: [
+      {
+        name: 'gws drive permissions list',
+        args: {
+          params: { kind: 'nonempty-string' },
+          'page-all': true,
+        },
+        cli: { required: ['--params', '--page-all'] },
+      },
+    ],
+  } as any;
+
+  const extractedCalls = parseShellCommands(
+    'gws drive permissions list --params "{\"fileId\":\"FILE_ID\"}" --page-all',
+    ['gws drive permissions list'],
+  );
+
+  const taskResult = evaluateTask({
+    task,
+    model: { id: 'm', name: 'm', tier: 'low' },
+    generatedCode: 'gws drive permissions list --params "{\"fileId\":\"FILE_ID\"}" --page-all',
+    rawResponse: 'ok',
+    extractedCalls,
+    llmLatencyMs: 1,
+    knownMethods: new Set(['gws drive permissions list']),
+    surface: 'cli',
+    cliCommands: [
+      {
+        command: 'gws drive permissions list',
+        options: [
+          { name: 'params', takesValue: true },
+          { name: 'page-all', takesValue: false },
+        ],
+      },
+    ],
+  } as any);
+
+  assertEqual(taskResult.metrics.taskPassed, true, 'required CLI flags should be normalized and pass');
+});
+
+await test('CLI rejects unsupported extra flag', () => {
+  const task = {
+    id: 'cli-extra-flag-rejected',
+    prompt: 'Label something',
+    expected_actions: [
+      {
+        name: 'gws drive permissions list',
+        args: {},
+      },
+    ],
+  } as any;
+
+  const extractedCalls = parseShellCommands(
+    'gws drive permissions list --bogus true',
+    ['gws drive permissions list'],
+  );
+
+  const taskResult = evaluateTask({
+    task,
+    model: { id: 'm', name: 'm', tier: 'low' },
+    generatedCode: 'gws drive permissions list --bogus true',
+    rawResponse: 'ok',
+    extractedCalls,
+    llmLatencyMs: 1,
+    knownMethods: new Set(['gws drive permissions list']),
+    surface: 'cli',
+    cliCommands: [
+      {
+        command: 'gws drive permissions list',
+        options: [{ name: 'label', takesValue: true }],
+      },
+    ],
+  } as any);
+
+  assertEqual(taskResult.metrics.taskPassed, false, 'unsupported CLI option should fail task evaluation');
+});
+
+await test('CLI validates nested JSON flag constraints', () => {
+  const task = {
+    id: 'cli-nested-json-constraints',
+    prompt: 'List permissions with page size',
+    expected_actions: [
+      {
+        name: 'gws drive permissions list',
+        args: {
+          'params.pageSize': { kind: 'exact', value: 5 },
+        },
+      },
+    ],
+  } as any;
+
+  const extractedCalls = parseShellCommands(
+    'gws drive permissions list --params \'{"pageSize":5}\'',
+    ['gws drive permissions list'],
+  );
+
+  const taskResult = evaluateTask({
+    task,
+    model: { id: 'm', name: 'm', tier: 'low' },
+    generatedCode: 'gws drive permissions list --params \'{"pageSize":5}\'',
+    rawResponse: 'ok',
+    extractedCalls,
+    llmLatencyMs: 1,
+    knownMethods: new Set(['gws drive permissions list']),
+    surface: 'cli',
+    cliCommands: [
+      {
+        command: 'gws drive permissions list',
+        options: [{ name: 'params', takesValue: true }],
+      },
+    ],
+  } as any);
+
+  assertEqual(taskResult.metrics.taskPassed, true, 'nested JSON constraints should be validated from --params payload');
 });
 
 console.log(`\n${passed} passed, ${failed} failed\n`);


### PR DESCRIPTION
## Summary
- Add configured companion skill reads via skill_read.
- Add expected_reads scoring and stricter CLI arg evaluation.

## Test
- npx tsx tests/smoke-cli.ts