### PR TITLE
Support bundled skill reads and CLI arg evaluation

### DIFF
--- a/docs/reference/config-schema.md
+++ b/docs/reference/config-schema.md
@@ -11,7 +11,7 @@ Paths in the config are relative to the config file location.
 | `name` | `string` | — | Human-readable project name |
 | `target.surface` | `"sdk" | "cli" | "mcp" | "prompt"` | — | Type of callable surface |
 | `target.repoPath` | `string` | — | Path to the target repo (default ".") |
-| `target.skill` | `string | object` | — | Path to SKILL.md or { source, cache } object |
+| `target.skill` | `string | object` | — | Path to SKILL.md or { source, references, cache } object |
 | `target.discovery.mode` | `"auto" | "manifest"` | — | "auto" = code-first tree-sitter; "manifest" = use provided file only |
 | `target.discovery.sources` | `string[]` | — | Source files to scan for callable methods/commands/tools |
 | `target.discovery.fallbackManifest` | `string` | — | Path to manifest JSON when code-first discovery is incomplete |

--- a/src/benchmark/config.ts
+++ b/src/benchmark/config.ts
@@ -137,7 +137,7 @@ function normalizeExpectedAction(
     throw new Error(`Tasks file ${resolvedPath}: task ${taskIndex} action ${actionIndex} must be an object`);
   }
 
-  const candidate = rawAction as { name?: unknown; args?: unknown };
+  const candidate = rawAction as { name?: unknown; args?: unknown; cli?: unknown };
   const name = typeof candidate.name === 'string' ? candidate.name : null;
 
   if (!name || name.trim() === '') {
@@ -148,10 +148,33 @@ function normalizeExpectedAction(
     throw new Error(`Tasks file ${resolvedPath}: task ${taskIndex} action ${actionIndex} args must be an object when present`);
   }
 
+  const cli = normalizeExpectedActionCli(candidate.cli, resolvedPath, taskIndex, actionIndex);
+
   return {
     name,
     args: (candidate.args as Record<string, unknown> | undefined) ?? {},
+    ...(cli ? { cli } : {}),
   };
+}
+
+function normalizeExpectedActionCli(
+  rawCli: unknown,
+  resolvedPath: string,
+  taskIndex: number,
+  actionIndex: number,
+): ExpectedAction['cli'] | undefined {
+  if (rawCli === undefined) return undefined;
+  if (!rawCli || typeof rawCli !== 'object' || Array.isArray(rawCli)) {
+    throw new Error(`Tasks file ${resolvedPath}: task ${taskIndex} action ${actionIndex} cli must be an object when present`);
+  }
+
+  const required = (rawCli as { required?: unknown }).required;
+  if (required === undefined) return {};
+  if (!Array.isArray(required) || required.some((entry) => typeof entry !== 'string' || entry.trim() === '')) {
+    throw new Error(`Tasks file ${resolvedPath}: task ${taskIndex} action ${actionIndex} cli.required must be an array of non-empty strings`);
+  }
+
+  return { required: [...required] as string[] };
 }
 
 /**

--- a/src/benchmark/config.ts
+++ b/src/benchmark/config.ts
@@ -50,7 +50,7 @@ export function loadTasks(tasksPath: string, baseDir?: string): TaskDefinition[]
     throw new Error(`Failed to read tasks: ${resolved}: ${err instanceof Error ? err.message : err}`);
   }
 
-  let parsed: { tasks: Array<{ id?: unknown; prompt?: unknown; expected_actions?: unknown; verify?: unknown; expected_fetches?: unknown; capabilityId?: unknown }> };
+  let parsed: { tasks: Array<{ id?: unknown; prompt?: unknown; expected_actions?: unknown; verify?: unknown; expected_fetches?: unknown; expected_reads?: unknown; capabilityId?: unknown }> };
   try {
     parsed = JSON.parse(raw) as typeof parsed;
   } catch (err) {
@@ -65,7 +65,7 @@ export function loadTasks(tasksPath: string, baseDir?: string): TaskDefinition[]
 }
 
 function normalizeTaskDefinition(
-  task: { id?: unknown; prompt?: unknown; expected_actions?: unknown; verify?: unknown; expected_fetches?: unknown; capabilityId?: unknown },
+  task: { id?: unknown; prompt?: unknown; expected_actions?: unknown; verify?: unknown; expected_fetches?: unknown; expected_reads?: unknown; capabilityId?: unknown },
   resolvedPath: string,
   index: number,
 ): TaskDefinition {
@@ -105,6 +105,15 @@ function normalizeTaskDefinition(
     }
   }
 
+  const rawReads = Array.isArray(task.expected_reads) ? task.expected_reads : undefined;
+  if (rawReads !== undefined) {
+    for (let i = 0; i < rawReads.length; i++) {
+      if (typeof rawReads[i] !== 'string' || !(rawReads[i] as string).trim()) {
+        throw new Error(`Tasks file ${resolvedPath}: task ${task.id} expected_reads[${i}] must be a non-empty string`);
+      }
+    }
+  }
+
   const capabilityId = typeof task.capabilityId === 'string' ? task.capabilityId : undefined;
 
   return {
@@ -113,6 +122,7 @@ function normalizeTaskDefinition(
     expected_actions,
     verify: rawVerify as TaskDefinition['verify'] | undefined,
     expected_fetches: rawFetches as string[] | undefined,
+    expected_reads: rawReads as string[] | undefined,
     ...(capabilityId !== undefined ? { capabilityId } : {}),
   };
 }

--- a/src/benchmark/evaluator.ts
+++ b/src/benchmark/evaluator.ts
@@ -2,6 +2,7 @@ import type {
   ExpectedAction,
   ExtractedCall,
   ActionMatch,
+  CliCommandDefinition,
   TaskDefinition,
   TaskResult,
   ModelConfig,
@@ -163,6 +164,290 @@ function matchExpectedValue(
     match,
   };
   return match;
+}
+
+function normalizeCliArgKey(key: string): string {
+  return key.replace(/^-+/, '').trim();
+}
+
+function getCliRootKey(key: string): string {
+  return normalizeCliArgKey(key).split('.')[0];
+}
+
+function parseCliMaybeJson(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return value;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return value;
+  }
+}
+
+function resolveCliArgValue(
+  args: Record<string, unknown>,
+  key: string,
+  expectedValue?: unknown,
+): unknown {
+  const normalizedKey = normalizeCliArgKey(key);
+  const normalizedArgs: Record<string, unknown> = {};
+  for (const [argKey, value] of Object.entries(args)) {
+    normalizedArgs[normalizeCliArgKey(argKey)] = value;
+  }
+
+  const dotIdx = normalizedKey.indexOf('.');
+  if (dotIdx !== -1) {
+    const root = normalizedKey.slice(0, dotIdx);
+    const pathParts = normalizedKey.slice(dotIdx + 1).split('.').filter(Boolean);
+    let current = normalizedArgs[root] ?? resolveArgValue(args, root, expectedValue);
+    current = parseCliMaybeJson(current);
+    for (const segment of pathParts) {
+      if (!isPlainObject(current)) return undefined;
+      current = current[segment];
+    }
+    return current;
+  }
+
+  return normalizedArgs[normalizedKey] ?? resolveArgValue(args, normalizedKey, expectedValue);
+}
+
+type ArgResult = { expected: string; got: unknown; match: boolean };
+
+type CliArgConstraint =
+  | { kind: 'any' }
+  | { kind: 'nonempty-string' }
+  | { kind: 'exact'; value: unknown }
+  | { kind: 'one-of'; values: unknown[] }
+  | { kind: 'json-object'; requiredKeys?: string[] }
+  | { kind: string; [key: string]: unknown };
+
+function matchCliConstraint(
+  constraint: CliArgConstraint,
+  got: unknown,
+  path: string,
+  argResults: Record<string, ArgResult>,
+): boolean {
+  let match = false;
+  switch (constraint.kind) {
+    case 'any':
+      match = got !== undefined;
+      break;
+    case 'nonempty-string':
+      match = typeof got === 'string' && got.trim().length > 0;
+      break;
+    case 'exact':
+      match = matchArgValue(constraint.value, got);
+      break;
+    case 'one-of':
+      match = Array.isArray(constraint.values) && constraint.values.some((value) => matchArgValue(value, got));
+      break;
+    case 'json-object': {
+      const parsed = parseCliMaybeJson(got);
+      const requiredKeys = Array.isArray(constraint.requiredKeys) ? constraint.requiredKeys : [];
+      match = isPlainObject(parsed) && requiredKeys.every((key) => Object.prototype.hasOwnProperty.call(parsed, key));
+      break;
+    }
+    default:
+      return matchExpectedValue(constraint, got, path, argResults);
+  }
+
+  argResults[path] = {
+    expected: stringifyExpected(constraint),
+    got,
+    match,
+  };
+  return match;
+}
+
+function getExpectedCliRequired(expected: ExpectedAction): string[] {
+  const cli = (expected as { cli?: { required?: unknown } }).cli;
+  return Array.isArray(cli?.required) ? cli.required.filter((value): value is string => typeof value === 'string') : [];
+}
+
+function findCliCommandDefinition(
+  cliCommands: readonly CliCommandDefinition[] | undefined,
+  method: string,
+): CliCommandDefinition | undefined {
+  return cliCommands?.find((command) => command.command === method);
+}
+
+function buildCliAllowedOptionSet(commandDef?: CliCommandDefinition): Set<string> | null {
+  if (!commandDef?.options || commandDef.options.length === 0) return null;
+  const allowed = new Set<string>();
+  for (const option of commandDef.options) {
+    allowed.add(normalizeCliArgKey(option.name));
+    for (const alias of option.aliases ?? []) {
+      allowed.add(normalizeCliArgKey(alias));
+    }
+  }
+  return allowed;
+}
+
+function evaluateCliArgs(
+  expected: ExpectedAction,
+  found: ExtractedCall,
+  commandDef?: CliCommandDefinition,
+): { allArgsMatch: boolean; argResults: Record<string, ArgResult> } {
+  const argResults: Record<string, ArgResult> = {};
+  let allArgsMatch = true;
+  const allowedOptions = buildCliAllowedOptionSet(commandDef);
+
+  if (allowedOptions) {
+    for (const [key, value] of Object.entries(found.args)) {
+      if (key === 'env' || key.startsWith('_positional_')) continue;
+      const normalized = normalizeCliArgKey(key);
+      if (!allowedOptions.has(normalized)) {
+        allArgsMatch = false;
+        argResults[`unsupported.${normalized}`] = {
+          expected: 'supported option',
+          got: value,
+          match: false,
+        };
+      }
+    }
+  }
+
+  const requiredKeys = new Set<string>();
+  for (const required of getExpectedCliRequired(expected)) {
+    requiredKeys.add(getCliRootKey(required));
+  }
+  if (expected.args) {
+    for (const key of Object.keys(expected.args)) {
+      requiredKeys.add(getCliRootKey(key));
+    }
+  }
+
+  for (const requiredKey of requiredKeys) {
+    const got = resolveCliArgValue(found.args, requiredKey);
+    const match = got !== undefined;
+    argResults[`required.${requiredKey}`] = {
+      expected: '<present>',
+      got,
+      match,
+    };
+    if (!match) allArgsMatch = false;
+  }
+
+  for (const [key, expectedValue] of Object.entries(expected.args ?? {})) {
+    const got = resolveCliArgValue(found.args, key, expectedValue);
+    const isConstraint = isPlainObject(expectedValue) && typeof expectedValue.kind === 'string';
+    const match = isConstraint
+      ? matchCliConstraint(expectedValue as CliArgConstraint, got, key, argResults)
+      : matchExpectedValue(expectedValue, got, key, argResults);
+    if (!match) allArgsMatch = false;
+  }
+
+  return { allArgsMatch, argResults };
+}
+
+function matchCliActions(
+  expectedActions: ExpectedAction[],
+  extractedCalls: ExtractedCall[],
+  cliCommands?: readonly CliCommandDefinition[],
+): ActionMatch[] {
+  const usedIndices = new Set<number>();
+
+  return expectedActions.map((expected) => {
+    const expectedMethod = getExpectedActionName(expected);
+    const hasExpectedArgs =
+      Object.keys(expected.args ?? {}).length > 0 ||
+      getExpectedCliRequired(expected).length > 0;
+
+    if (hasExpectedArgs) {
+      let perfectMatchIndex = -1;
+      for (let i = 0; i < extractedCalls.length; i++) {
+        if (usedIndices.has(i)) continue;
+        const candidate = extractedCalls[i];
+        if (candidate.method !== expectedMethod) continue;
+        const commandDef = findCliCommandDefinition(cliCommands, expectedMethod);
+        const { allArgsMatch } = evaluateCliArgs(expected, candidate, commandDef);
+        if (allArgsMatch) {
+          perfectMatchIndex = i;
+          break;
+        }
+      }
+
+      if (perfectMatchIndex !== -1) {
+        usedIndices.add(perfectMatchIndex);
+        const found = extractedCalls[perfectMatchIndex];
+        const commandDef = findCliCommandDefinition(cliCommands, expectedMethod);
+        const { argResults } = evaluateCliArgs(expected, found, commandDef);
+        return {
+          expected,
+          found,
+          methodFound: true,
+          argsCorrect: true,
+          matched: true,
+          argResults,
+        } satisfies ActionMatch;
+      }
+
+      let fallbackIndex = -1;
+      for (let i = 0; i < extractedCalls.length; i++) {
+        if (usedIndices.has(i)) continue;
+        if (extractedCalls[i].method === expectedMethod) {
+          fallbackIndex = i;
+          break;
+        }
+      }
+
+      if (fallbackIndex === -1) {
+        return {
+          expected,
+          found: null,
+          methodFound: false,
+          argsCorrect: false,
+          matched: false,
+        } satisfies ActionMatch;
+      }
+
+      usedIndices.add(fallbackIndex);
+      const found = extractedCalls[fallbackIndex];
+      const commandDef = findCliCommandDefinition(cliCommands, expectedMethod);
+      const { allArgsMatch, argResults } = evaluateCliArgs(expected, found, commandDef);
+      return {
+        expected,
+        found,
+        methodFound: true,
+        argsCorrect: allArgsMatch,
+        matched: allArgsMatch,
+        argResults,
+      } satisfies ActionMatch;
+    }
+
+    let foundIndex = -1;
+    for (let i = 0; i < extractedCalls.length; i++) {
+      if (usedIndices.has(i)) continue;
+      if (extractedCalls[i].method === expectedMethod) {
+        foundIndex = i;
+        break;
+      }
+    }
+
+    if (foundIndex === -1) {
+      return {
+        expected,
+        found: null,
+        methodFound: false,
+        argsCorrect: false,
+        matched: false,
+      } satisfies ActionMatch;
+    }
+
+    usedIndices.add(foundIndex);
+    const found = extractedCalls[foundIndex];
+    const commandDef = findCliCommandDefinition(cliCommands, expectedMethod);
+    const { allArgsMatch, argResults } = evaluateCliArgs(expected, found, commandDef);
+    return {
+      expected,
+      found,
+      methodFound: true,
+      argsCorrect: allArgsMatch,
+      matched: allArgsMatch,
+      argResults,
+    } satisfies ActionMatch;
+  });
 }
 
 // ── Tool matching ──────────────────────────────────────────────────────────
@@ -419,6 +704,7 @@ export function evaluateTask(params: {
   knownMethods: Set<string>;
   bindings?: Map<string, string>;  // variable → source function/class from extractor
   surface: 'sdk' | 'cli' | 'mcp' | 'prompt';
+  cliCommands?: readonly CliCommandDefinition[];
 }): TaskResult {
   const {
     task,
@@ -431,6 +717,7 @@ export function evaluateTask(params: {
     knownMethods,
     bindings,
     surface,
+    cliCommands,
   } = params;
 
   let extractedCalls = params.extractedCalls;
@@ -439,7 +726,9 @@ export function evaluateTask(params: {
     extractedCalls = resolveCallsFromBindings(extractedCalls, bindings, expectedActions);
   }
 
-  const actionMatches = matchActions(expectedActions, extractedCalls);
+  const actionMatches = surface === 'cli'
+    ? matchCliActions(expectedActions, extractedCalls, cliCommands)
+    : matchActions(expectedActions, extractedCalls);
 
   const codePatternResults: Record<string, boolean> = {};
   let allCodePatternsPass = true;

--- a/src/benchmark/prompts.ts
+++ b/src/benchmark/prompts.ts
@@ -7,6 +7,7 @@ interface PromptOptions {
   agentic?: boolean;
   shell?: 'bash' | 'sh';
   sdkLanguage?: SdkLanguage;
+  companionSkillPaths?: string[];
 }
 
 const SDK_LANGUAGE_LABELS: Record<SdkLanguage, string> = {
@@ -33,8 +34,15 @@ export function buildSystemPrompt(
   sdkName: string,
   options: PromptOptions,
 ): string {
+  const companionPaths = options.companionSkillPaths ?? [];
+  const companionSection = companionPaths.length > 0
+    ? `\n\nCompanion skill files available:\n${companionPaths.map((p) => `- ${p}`).join('\n')}`
+    : '';
+  const companionToolGuidance = companionPaths.length > 0
+    ? '\nWhen tools are available, use `skill_read(path)` to read these companion files by exact path.'
+    : '';
   const guidanceSection = skill
-    ? `\n\nOptional guidance context (SKILL.md):\n--- GUIDANCE ---\n${skill.content}\n--- END GUIDANCE ---`
+    ? `\n\nOptional guidance context (SKILL.md):\n--- GUIDANCE ---\n${skill.content}\n--- END GUIDANCE ---${companionSection}${companionToolGuidance}`
     : '';
 
   if (options.surface === 'prompt') {

--- a/src/benchmark/prompts.ts
+++ b/src/benchmark/prompts.ts
@@ -47,9 +47,10 @@ export function buildSystemPrompt(
 
   if (options.surface === 'prompt') {
     // For prompt surface, the skill IS the system prompt.
-    // If skill content is available, use it directly; otherwise use a generic wrapper.
+    // Keep SKILL.md as the main system prompt, but append bundled references
+    // so the model knows what companion files it can read with skill_read(path).
     if (skill) {
-      return skill.content;
+      return `${skill.content}${companionSection}${companionToolGuidance}`;
     }
     return `You are a helpful assistant for ${sdkName}. Follow the instructions and complete the task.`;
   }

--- a/src/benchmark/read-evaluator.ts
+++ b/src/benchmark/read-evaluator.ts
@@ -1,0 +1,33 @@
+export interface ReadEvaluationResult {
+  passed: boolean;
+  recall: number;
+  precision: number;
+  matched: string[];
+  missing: string[];
+  extra: string[];
+  actual: string[];
+}
+
+export function evaluateExpectedReads(expectedReads: string[], actualReads: string[]): ReadEvaluationResult {
+  const expectedSet = new Set(expectedReads);
+  const actualSet = new Set(actualReads);
+
+  const matched = [...expectedSet].filter((path) => actualSet.has(path));
+  const missing = [...expectedSet].filter((path) => !actualSet.has(path));
+  const extra = [...actualSet].filter((path) => !expectedSet.has(path));
+
+  const recall = expectedSet.size === 0 ? 1.0 : matched.length / expectedSet.size;
+  const precision = actualSet.size === 0
+    ? (expectedSet.size === 0 ? 1.0 : 0.0)
+    : matched.length / actualSet.size;
+
+  return {
+    passed: missing.length === 0,
+    recall,
+    precision,
+    matched,
+    missing,
+    extra,
+    actual: actualReads,
+  };
+}

--- a/src/benchmark/runner.ts
+++ b/src/benchmark/runner.ts
@@ -221,7 +221,12 @@ export async function runBenchmark(options: RunnerOptions = {}): Promise<Benchma
   }
 
   const skillConfig = options.skillOverride
-    ? { ...(config.skill ?? {}), source: options.skillOverride, cache: false } as typeof config.skill
+    ? {
+        ...(config.skill ?? {}),
+        source: options.skillOverride,
+        referenceBaseSource: config.skill?.source,
+        cache: false,
+      } as typeof config.skill
     : config.skill;
   const skill = await fetchSkill(options.noCache
     ? { ...skillConfig, cache: false } as typeof skillConfig

--- a/src/benchmark/runner.ts
+++ b/src/benchmark/runner.ts
@@ -10,6 +10,7 @@ import type {
   ExtractedCall,
   MethodCoverage,
   SkillVersion,
+  FetchedSkill,
   ModelSummary,
   TaskSummary,
   ToolExecutor,
@@ -28,6 +29,7 @@ import { buildSystemPrompt, buildTaskPrompt } from './prompts.js';
 import { evaluatePromptResponse } from './prompt-evaluator.js';
 import { resolveCriteriaForTask } from './prompt-criteria.js';
 import { discoverPromptCapabilitiesWithSections } from '../project/discover-prompt.js';
+import { evaluateExpectedReads } from './read-evaluator.js';
 
 function buildWebFetchTool(): McpToolDefinition {
   return {
@@ -39,6 +41,23 @@ function buildWebFetchTool(): McpToolDefinition {
         type: 'object',
         properties: { url: { type: 'string', description: 'Path to the reference document' } },
         required: ['url'],
+      },
+    },
+  };
+}
+
+function buildSkillReadTool(): McpToolDefinition {
+  return {
+    type: 'function',
+    function: {
+      name: 'skill_read',
+      description: 'Read a bundled companion skill file by its path.',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: { type: 'string', description: 'Companion skill file path exactly as listed in the prompt' },
+        },
+        required: ['path'],
       },
     },
   };
@@ -71,6 +90,42 @@ function createReferenceExecutor(baseUrl: string, allowedPaths: string[]): { exe
     } catch (err) { return `Error: ${err instanceof Error ? err.message : String(err)}`; }
   };
   return { executor, fetchedPaths: fetched };
+}
+
+export function createSkillReadExecutor(
+  references: FetchedSkill['references'] | undefined,
+): { executor: ToolExecutor; readPaths: string[] } {
+  const reads: string[] = [];
+  const byPath = new Map<string, string>();
+  for (const ref of references ?? []) {
+    byPath.set(ref.path, ref.content);
+  }
+
+  const executor: ToolExecutor = async (name, args) => {
+    if (name !== 'skill_read') return `Error: Unknown tool "${name}"`;
+    const rawPath = String(args.path ?? '');
+    const requestedPath = rawPath.trim();
+    if (!requestedPath) return 'Error: Missing required argument "path"';
+    if (requestedPath.includes('..')) return 'Error: Path traversal is not allowed';
+    const content = byPath.get(requestedPath);
+    if (!content) {
+      return `Error: Companion skill path "${requestedPath}" not found. Available: ${[...byPath.keys()].join(', ')}`;
+    }
+    reads.push(requestedPath);
+    return content;
+  };
+
+  return { executor, readPaths: reads };
+}
+
+function combineExecutors(executors: ToolExecutor[]): ToolExecutor {
+  return async (name, args) => {
+    for (const executor of executors) {
+      const result = await executor(name, args);
+      if (!result.startsWith('Error: Unknown tool')) return result;
+    }
+    return `Error: Unknown tool "${name}"`;
+  };
 }
 
 function formatMcpResponseContent(
@@ -187,11 +242,14 @@ export async function runBenchmark(options: RunnerOptions = {}): Promise<Benchma
   }
 
 
+  const hasWebReferences = Boolean(config.agentic?.references);
+  const hasExpectedReads = tasks.some((task) => (task.expected_reads?.length ?? 0) > 0);
   const promptOptions = {
     surface: config.surface,
-    agentic: Boolean(config.agentic),
+    agentic: hasWebReferences || hasExpectedReads,
     shell: config.cli?.shell,
     sdkLanguage: config.sdk?.language,
+    companionSkillPaths: skill?.references?.map((ref) => ref.path) ?? [],
   };
   const systemPrompt = buildSystemPrompt(skill, config.name, promptOptions);
   console.log(`[prompt] Surface: ${config.surface}`);
@@ -238,18 +296,53 @@ export async function runBenchmark(options: RunnerOptions = {}): Promise<Benchma
       let error: string | undefined;
       let llmResponse;
       let fetchedPaths: string[] = [];
+      let readPaths: string[] = [];
+
+      const taskHasExpectedReads = Array.isArray(task.expected_reads) && task.expected_reads.length > 0;
+      const shouldUseAgentLoop = hasWebReferences || taskHasExpectedReads;
+
+      if (taskHasExpectedReads && config.surface === 'mcp') {
+        throw new Error(
+          `Task "${task.id}" uses expected_reads, which is not supported for MCP benchmarks because it can interfere with structured MCP tool-call evaluation.`,
+        );
+      }
+
+      if (taskHasExpectedReads && (skill?.references?.length ?? 0) === 0) {
+        throw new Error(
+          `Task "${task.id}" uses expected_reads, but no bundled skill references are available. Configure target.skill.references with local files.`,
+        );
+      }
 
       const start = Date.now();
       try {
-        if (config.agentic) {
-          const ref = createReferenceExecutor(
-            config.agentic.references.baseUrl, config.agentic.references.allowedPaths,
-          );
+        if (shouldUseAgentLoop) {
+          const tools: McpToolDefinition[] = [];
+          const executors: ToolExecutor[] = [];
+
+          if (config.agentic?.references) {
+            const ref = createReferenceExecutor(
+              config.agentic.references.baseUrl, config.agentic.references.allowedPaths,
+            );
+            tools.push(buildWebFetchTool());
+            executors.push(ref.executor);
+            fetchedPaths = ref.fetchedPaths;
+          }
+
+          if (taskHasExpectedReads) {
+            const reader = createSkillReadExecutor(skill?.references);
+            tools.push(buildSkillReadTool());
+            executors.push(reader.executor);
+            readPaths = reader.readPaths;
+          }
+
+          if (tools.length === 0 || executors.length === 0) {
+            throw new Error('Agent loop requested without any configured tools');
+          }
+
           llmResponse = await client.chatAgentLoop(
             model.id, systemPrompt, buildTaskPrompt(task, promptOptions),
-            [buildWebFetchTool()], ref.executor, config.agentic.maxTurns ?? 5,
+            tools, combineExecutors(executors), config.agentic?.maxTurns ?? 5,
           );
-          fetchedPaths = ref.fetchedPaths;
         } else if (config.surface === 'mcp' && mcpToolDefs) {
           llmResponse = await client.chatWithTools(
             model.id,
@@ -360,7 +453,8 @@ export async function runBenchmark(options: RunnerOptions = {}): Promise<Benchma
         knownMethods,
         bindings,
         surface: config.surface,
-      });
+        ...(cliCommands ? { cliCommands } : {}),
+      } as Parameters<typeof evaluateTask>[0]);
 
       // Prompt surface: replace vacuous tool-recall with per-capability content score.
       if (config.surface === 'prompt') {
@@ -392,7 +486,7 @@ export async function runBenchmark(options: RunnerOptions = {}): Promise<Benchma
         }
       }
 
-      if (config.agentic && task.expected_fetches) {
+      if (config.agentic?.references && task.expected_fetches) {
         const actualFetches = fetchedPaths;
         const expectedSet = new Set(task.expected_fetches);
         const actualSet = new Set(actualFetches);
@@ -403,6 +497,20 @@ export async function runBenchmark(options: RunnerOptions = {}): Promise<Benchma
         taskResult.metrics.taskPassed = taskResult.metrics.taskPassed && taskResult.metrics.fetchRecall === 1.0;
         const fetchStatus = taskResult.metrics.fetchRecall === 1.0 ? 'correct' : 'WRONG';
         console.log(`  [${slug}] Fetched: [${actualFetches.join(', ')}] (${fetchStatus})`);
+      }
+
+      if (task.expected_reads) {
+        const readEval = evaluateExpectedReads(task.expected_reads, readPaths);
+        taskResult.metrics.readPassed = readEval.passed;
+        taskResult.metrics.readRecall = readEval.recall;
+        taskResult.metrics.readPrecision = readEval.precision;
+        taskResult.metrics.matchedReads = readEval.matched;
+        taskResult.metrics.missingReads = readEval.missing;
+        taskResult.metrics.extraReads = readEval.extra;
+        taskResult.metrics.actualReads = readEval.actual;
+        taskResult.metrics.taskPassed = taskResult.metrics.taskPassed && readEval.passed;
+        const readStatus = readEval.passed ? 'correct' : 'MISSING_REQUIRED';
+        console.log(`  [${slug}] Reads: [${readEval.actual.join(', ')}] (${readStatus})`);
       }
 
       const status = taskResult.metrics.taskPassed ? '✅ PASS' : '❌ FAIL';

--- a/src/benchmark/runner.ts
+++ b/src/benchmark/runner.ts
@@ -30,6 +30,7 @@ import { evaluatePromptResponse } from './prompt-evaluator.js';
 import { resolveCriteriaForTask } from './prompt-criteria.js';
 import { discoverPromptCapabilitiesWithSections } from '../project/discover-prompt.js';
 import { evaluateExpectedReads } from './read-evaluator.js';
+import { normalizePathForPrompt } from '../project/skill-references.js';
 
 function buildWebFetchTool(): McpToolDefinition {
   return {
@@ -96,26 +97,48 @@ export function createSkillReadExecutor(
   references: FetchedSkill['references'] | undefined,
 ): { executor: ToolExecutor; readPaths: string[] } {
   const reads: string[] = [];
-  const byPath = new Map<string, string>();
+  const referenceLookup = new Map<string, { content: string; canonicalPath: string }>();
   for (const ref of references ?? []) {
-    byPath.set(ref.path, ref.content);
+    referenceLookup.set(normalizePathForPrompt(ref.path), { content: ref.content, canonicalPath: ref.path });
+    for (const alias of ref.aliases ?? []) {
+      referenceLookup.set(normalizePathForPrompt(alias), { content: ref.content, canonicalPath: ref.path });
+    }
   }
 
   const executor: ToolExecutor = async (name, args) => {
     if (name !== 'skill_read') return `Error: Unknown tool "${name}"`;
     const rawPath = String(args.path ?? '');
-    const requestedPath = rawPath.trim();
+    const requestedPath = normalizePathForPrompt(rawPath.trim());
     if (!requestedPath) return 'Error: Missing required argument "path"';
-    if (requestedPath.includes('..')) return 'Error: Path traversal is not allowed';
-    const content = byPath.get(requestedPath);
-    if (!content) {
-      return `Error: Companion skill path "${requestedPath}" not found. Available: ${[...byPath.keys()].join(', ')}`;
+    const resolved = referenceLookup.get(requestedPath) ?? findSkillReadSuffixMatch(requestedPath, references ?? []);
+    if (!resolved) {
+      return `Error: Companion skill path "${requestedPath}" not found. Available: ${[...referenceLookup.keys()].join(', ')}`;
     }
-    reads.push(requestedPath);
-    return content;
+    reads.push(resolved.canonicalPath);
+    return resolved.content;
   };
 
   return { executor, readPaths: reads };
+}
+
+function findSkillReadSuffixMatch(
+  requestedPath: string,
+  references: NonNullable<FetchedSkill['references']>,
+): { content: string; canonicalPath: string } | undefined {
+  const matches = references.filter((reference) => {
+    const canonical = normalizePathForPrompt(reference.path);
+    const source = normalizePathForPrompt(reference.source);
+    const canonicalSuffixMatch =
+      requestedPath !== `/${canonical}` && requestedPath.endsWith(`/${canonical}`);
+    const sourceSuffixMatch =
+      requestedPath !== `/${source}` && requestedPath.endsWith(`/${source}`);
+    return requestedPath === source || canonicalSuffixMatch || sourceSuffixMatch;
+  });
+  if (matches.length !== 1) return undefined;
+  return {
+    content: matches[0]!.content,
+    canonicalPath: matches[0]!.path,
+  };
 }
 
 function combineExecutors(executors: ToolExecutor[]): ToolExecutor {
@@ -158,6 +181,8 @@ export interface RunnerOptions {
    * one committed in the target repo.
    */
   skillOverride?: string;
+  /** Local optimized companion references paired with their stable skill_read paths. */
+  skillReferenceOverrides?: Array<{ source: string; promptPath: string; baseSource?: string }>;
 }
 
 /**
@@ -224,6 +249,9 @@ export async function runBenchmark(options: RunnerOptions = {}): Promise<Benchma
     ? {
         ...(config.skill ?? {}),
         source: options.skillOverride,
+        references: options.skillReferenceOverrides?.map((reference) => reference.source) ?? config.skill?.references,
+        referenceBaseSources: options.skillReferenceOverrides?.map((reference) => reference.baseSource ?? reference.source),
+        referencePromptPaths: options.skillReferenceOverrides?.map((reference) => reference.promptPath),
         referenceBaseSource: config.skill?.source,
         cache: false,
       } as typeof config.skill

--- a/src/benchmark/skill-fetcher.ts
+++ b/src/benchmark/skill-fetcher.ts
@@ -222,6 +222,7 @@ function fetchFromFileWithReferences(skillConfig: SkillConfig): FetchedSkill {
   const source = skillConfig.source;
   const references = skillConfig.references ?? [];
   const resolved = resolve(process.cwd(), source);
+  const referenceBaseResolved = resolve(process.cwd(), skillConfig.referenceBaseSource ?? source);
 
   if (!existsSync(resolved)) {
     throw new Error(`Skill file not found: ${resolved} (from source: "${source}")`);
@@ -255,7 +256,7 @@ function fetchFromFileWithReferences(skillConfig: SkillConfig): FetchedSkill {
   });
 
   const commonDirectory = getCommonDirectory([
-    dirname(resolved),
+    dirname(referenceBaseResolved),
     ...resolvedReferenceFiles.map((ref) => dirname(ref.resolvedPath)),
   ]);
 

--- a/src/benchmark/skill-fetcher.ts
+++ b/src/benchmark/skill-fetcher.ts
@@ -1,6 +1,11 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
-import { dirname, isAbsolute, relative, resolve } from 'node:path';
+import { dirname, relative, resolve } from 'node:path';
 import type { FetchedSkill, SkillConfig, SkillVersion } from './types.js';
+import {
+  buildSkillReferenceAliases,
+  getCommonDirectory,
+  normalizePathForPrompt,
+} from '../project/skill-references.js';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -30,28 +35,6 @@ function writeCache(cachePath: string, result: FetchedSkill): void {
 
 function isRemoteSkillSource(source: string): boolean {
   return source.startsWith('github:') || source.startsWith('https://') || source.startsWith('http://');
-}
-
-function normalizePathForPrompt(pathValue: string): string {
-  return pathValue.replace(/\\/g, '/');
-}
-
-function isAncestorOrSame(parent: string, child: string): boolean {
-  const rel = relative(parent, child);
-  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
-}
-
-function getCommonDirectory(paths: string[]): string {
-  if (paths.length === 0) return process.cwd();
-  let common = paths[0]!;
-  for (const current of paths.slice(1)) {
-    while (!isAncestorOrSame(common, current)) {
-      const next = dirname(common);
-      if (next === common) break;
-      common = next;
-    }
-  }
-  return common;
 }
 
 // ── GitHub source ──────────────────────────────────────────────────────────
@@ -193,27 +176,8 @@ async function fetchFromUrl(source: string, useCache: boolean): Promise<FetchedS
  * Read skill from local filesystem: "./path" or "/absolute/path"
  */
 function fetchFromFile(source: string): FetchedSkill {
-  const resolved = resolve(process.cwd(), source);
-
-  if (!existsSync(resolved)) {
-    throw new Error(`Skill file not found: ${resolved} (from source: "${source}")`);
-  }
-
-  console.log(`[skill] Reading skill from file: ${resolved}`);
-
-  let content: string;
-  try {
-    content = readFileSync(resolved, 'utf-8');
-  } catch (err) {
-    throw new Error(`Failed to read skill file ${resolved}: ${err instanceof Error ? err.message : err}`);
-  }
-
-  const version: SkillVersion = {
-    source,
-    commitSha: 'local',
-    ref: 'file',
-    fetchedAt: new Date().toISOString(),
-  };
+  const { content } = readLocalSkillFile(source);
+  const version = buildLocalFileVersion(source);
 
   return { version, content };
 }
@@ -221,62 +185,90 @@ function fetchFromFile(source: string): FetchedSkill {
 function fetchFromFileWithReferences(skillConfig: SkillConfig): FetchedSkill {
   const source = skillConfig.source;
   const references = skillConfig.references ?? [];
-  const resolved = resolve(process.cwd(), source);
-  const referenceBaseResolved = resolve(process.cwd(), skillConfig.referenceBaseSource ?? source);
+  const referenceBaseSources = skillConfig.referenceBaseSources ?? references;
+  const { resolvedPath: resolvedSkillPath, content } = readLocalSkillFile(source);
+  const resolvedBaseSkillPath = resolve(process.cwd(), skillConfig.referenceBaseSource ?? source);
 
-  if (!existsSync(resolved)) {
-    throw new Error(`Skill file not found: ${resolved} (from source: "${source}")`);
-  }
-
-  console.log(`[skill] Reading skill from file: ${resolved}`);
-
-  let content: string;
-  try {
-    content = readFileSync(resolved, 'utf-8');
-  } catch (err) {
-    throw new Error(`Failed to read skill file ${resolved}: ${err instanceof Error ? err.message : err}`);
-  }
-
-  const resolvedReferenceFiles = references.map((referenceSource) => {
-    const resolvedReference = resolve(process.cwd(), referenceSource);
-    if (!existsSync(resolvedReference)) {
-      throw new Error(`Skill reference file not found: ${resolvedReference} (from source: "${referenceSource}")`);
-    }
-    let referenceContent: string;
-    try {
-      referenceContent = readFileSync(resolvedReference, 'utf-8');
-    } catch (err) {
-      throw new Error(`Failed to read skill reference file ${resolvedReference}: ${err instanceof Error ? err.message : err}`);
-    }
+  const referenceFiles = references.map((referenceSource, index) => {
+    const baseSource = referenceBaseSources[index] ?? referenceSource;
+    const { resolvedPath: resolvedReferencePath, content: referenceContent } = readLocalReferenceFile(referenceSource);
+    const resolvedBaseReferencePath = resolve(process.cwd(), baseSource);
     return {
       source: referenceSource,
-      resolvedPath: resolvedReference,
+      resolvedPath: resolvedReferencePath,
+      resolvedBasePath: resolvedBaseReferencePath,
       content: referenceContent,
     };
   });
 
   const commonDirectory = getCommonDirectory([
-    dirname(referenceBaseResolved),
-    ...resolvedReferenceFiles.map((ref) => dirname(ref.resolvedPath)),
+    dirname(resolvedBaseSkillPath),
+    ...referenceFiles.map((ref) => dirname(ref.resolvedPath)),
   ]);
 
-  const frozenReferences = resolvedReferenceFiles.map((ref) => ({
-    path: normalizePathForPrompt(relative(commonDirectory, ref.resolvedPath)),
+  const frozenReferences = referenceFiles.map((ref, index) => ({
+    path: skillConfig.referencePromptPaths?.[index] !== undefined
+      ? normalizePathForPrompt(skillConfig.referencePromptPaths[index]!)
+      : normalizePathForPrompt(relative(commonDirectory, ref.resolvedPath)),
     source: ref.source,
     content: ref.content,
+    aliases: buildSkillReferenceAliases(
+      resolvedSkillPath,
+      ref.resolvedPath,
+      resolvedBaseSkillPath,
+      ref.resolvedBasePath,
+      skillConfig.referencePromptPaths?.[index],
+    ),
   }));
 
-  const version: SkillVersion = {
-    source,
-    commitSha: 'local',
-    ref: 'file',
-    fetchedAt: new Date().toISOString(),
-  };
+  const version = buildLocalFileVersion(source);
 
   return {
     version,
     content,
     references: frozenReferences,
+  };
+}
+
+function readLocalSkillFile(source: string): { resolvedPath: string; content: string } {
+  const resolvedPath = resolve(process.cwd(), source);
+  if (!existsSync(resolvedPath)) {
+    throw new Error(`Skill file not found: ${resolvedPath} (from source: "${source}")`);
+  }
+
+  console.log(`[skill] Reading skill from file: ${resolvedPath}`);
+  return {
+    resolvedPath,
+    content: readLocalTextFile(resolvedPath, 'skill file'),
+  };
+}
+
+function readLocalReferenceFile(source: string): { resolvedPath: string; content: string } {
+  const resolvedPath = resolve(process.cwd(), source);
+  if (!existsSync(resolvedPath)) {
+    throw new Error(`Skill reference file not found: ${resolvedPath} (from source: "${source}")`);
+  }
+
+  return {
+    resolvedPath,
+    content: readLocalTextFile(resolvedPath, 'skill reference file'),
+  };
+}
+
+function readLocalTextFile(resolvedPath: string, label: string): string {
+  try {
+    return readFileSync(resolvedPath, 'utf-8');
+  } catch (err) {
+    throw new Error(`Failed to read ${label} ${resolvedPath}: ${err instanceof Error ? err.message : err}`);
+  }
+}
+
+function buildLocalFileVersion(source: string): SkillVersion {
+  return {
+    source,
+    commitSha: 'local',
+    ref: 'file',
+    fetchedAt: new Date().toISOString(),
   };
 }
 

--- a/src/benchmark/skill-fetcher.ts
+++ b/src/benchmark/skill-fetcher.ts
@@ -1,5 +1,5 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, isAbsolute, relative, resolve } from 'node:path';
 import type { FetchedSkill, SkillConfig, SkillVersion } from './types.js';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -26,6 +26,32 @@ function writeCache(cachePath: string, result: FetchedSkill): void {
   const cacheDir = resolve(cachePath, '..');
   mkdirSync(cacheDir, { recursive: true });
   writeFileSync(cachePath, JSON.stringify(result, null, 2), 'utf-8');
+}
+
+function isRemoteSkillSource(source: string): boolean {
+  return source.startsWith('github:') || source.startsWith('https://') || source.startsWith('http://');
+}
+
+function normalizePathForPrompt(pathValue: string): string {
+  return pathValue.replace(/\\/g, '/');
+}
+
+function isAncestorOrSame(parent: string, child: string): boolean {
+  const rel = relative(parent, child);
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+}
+
+function getCommonDirectory(paths: string[]): string {
+  if (paths.length === 0) return process.cwd();
+  let common = paths[0]!;
+  for (const current of paths.slice(1)) {
+    while (!isAncestorOrSame(common, current)) {
+      const next = dirname(common);
+      if (next === common) break;
+      common = next;
+    }
+  }
+  return common;
 }
 
 // ── GitHub source ──────────────────────────────────────────────────────────
@@ -192,6 +218,67 @@ function fetchFromFile(source: string): FetchedSkill {
   return { version, content };
 }
 
+function fetchFromFileWithReferences(skillConfig: SkillConfig): FetchedSkill {
+  const source = skillConfig.source;
+  const references = skillConfig.references ?? [];
+  const resolved = resolve(process.cwd(), source);
+
+  if (!existsSync(resolved)) {
+    throw new Error(`Skill file not found: ${resolved} (from source: "${source}")`);
+  }
+
+  console.log(`[skill] Reading skill from file: ${resolved}`);
+
+  let content: string;
+  try {
+    content = readFileSync(resolved, 'utf-8');
+  } catch (err) {
+    throw new Error(`Failed to read skill file ${resolved}: ${err instanceof Error ? err.message : err}`);
+  }
+
+  const resolvedReferenceFiles = references.map((referenceSource) => {
+    const resolvedReference = resolve(process.cwd(), referenceSource);
+    if (!existsSync(resolvedReference)) {
+      throw new Error(`Skill reference file not found: ${resolvedReference} (from source: "${referenceSource}")`);
+    }
+    let referenceContent: string;
+    try {
+      referenceContent = readFileSync(resolvedReference, 'utf-8');
+    } catch (err) {
+      throw new Error(`Failed to read skill reference file ${resolvedReference}: ${err instanceof Error ? err.message : err}`);
+    }
+    return {
+      source: referenceSource,
+      resolvedPath: resolvedReference,
+      content: referenceContent,
+    };
+  });
+
+  const commonDirectory = getCommonDirectory([
+    dirname(resolved),
+    ...resolvedReferenceFiles.map((ref) => dirname(ref.resolvedPath)),
+  ]);
+
+  const frozenReferences = resolvedReferenceFiles.map((ref) => ({
+    path: normalizePathForPrompt(relative(commonDirectory, ref.resolvedPath)),
+    source: ref.source,
+    content: ref.content,
+  }));
+
+  const version: SkillVersion = {
+    source,
+    commitSha: 'local',
+    ref: 'file',
+    fetchedAt: new Date().toISOString(),
+  };
+
+  return {
+    version,
+    content,
+    references: frozenReferences,
+  };
+}
+
 // ── Public API ─────────────────────────────────────────────────────────────
 
 /**
@@ -210,11 +297,18 @@ export async function fetchSkill(skillConfig: SkillConfig | undefined): Promise<
   const source = skillConfig.source;
   const useCache = skillConfig.cache !== false;
 
+  if (isRemoteSkillSource(source) && (skillConfig.references?.length ?? 0) > 0) {
+    throw new Error('target.skill.references is only supported for local file-based target.skill.source values');
+  }
+
   if (source.startsWith('github:')) {
     return fetchFromGitHub(source, useCache);
   } else if (source.startsWith('https://') || source.startsWith('http://')) {
     return fetchFromUrl(source, useCache);
   } else {
+    if ((skillConfig.references?.length ?? 0) > 0) {
+      return fetchFromFileWithReferences(skillConfig);
+    }
     return fetchFromFile(source);
   }
 }

--- a/src/benchmark/types.ts
+++ b/src/benchmark/types.ts
@@ -75,6 +75,7 @@ export interface McpSurfaceConfig {
 export interface SkillConfig {
   source: string;                  // "github:org/repo/path", "./file.md", "https://url"
   references?: string[];           // local companion markdown/text files
+  referenceBaseSource?: string;     // internal: original skill source when benchmarking a local optimized copy
   cache?: boolean;                 // default true
 }
 

--- a/src/benchmark/types.ts
+++ b/src/benchmark/types.ts
@@ -76,6 +76,8 @@ export interface SkillConfig {
   source: string;                  // "github:org/repo/path", "./file.md", "https://url"
   references?: string[];           // local companion markdown/text files
   referenceBaseSource?: string;     // internal: original skill source when benchmarking a local optimized copy
+  referenceBaseSources?: string[];  // internal: original companion sources when benchmarking local optimized copies
+  referencePromptPaths?: string[];  // internal: stable skill_read paths for optimized local reference copies
   cache?: boolean;                 // default true
 }
 
@@ -132,6 +134,7 @@ export interface FetchedSkill {
     path: string;
     source: string;
     content: string;
+    aliases?: string[];
   }>;
 }
 

--- a/src/benchmark/types.ts
+++ b/src/benchmark/types.ts
@@ -74,6 +74,7 @@ export interface McpSurfaceConfig {
 
 export interface SkillConfig {
   source: string;                  // "github:org/repo/path", "./file.md", "https://url"
+  references?: string[];           // local companion markdown/text files
   cache?: boolean;                 // default true
 }
 
@@ -92,7 +93,7 @@ export interface OutputConfig {
 }
 
 export interface AgenticConfig {
-  references: {
+  references?: {
     baseUrl: string;
     allowedPaths: string[];
   };
@@ -126,6 +127,11 @@ export interface SkillVersion {
 export interface FetchedSkill {
   version: SkillVersion;
   content: string;
+  references?: Array<{
+    path: string;
+    source: string;
+    content: string;
+  }>;
 }
 
 // === Task Definition (loaded from tasks.json) ===
@@ -133,6 +139,9 @@ export interface FetchedSkill {
 export interface ExpectedAction {
   name: string;                    // Unified action name (SDK method, CLI command, or MCP tool)
   args?: Record<string, unknown>;  // expected arg values (supports nested objects/arrays, strings, regexes, sentinels)
+  cli?: {
+    required?: string[];
+  };
 }
 
 export interface TaskVerification {
@@ -145,6 +154,7 @@ export interface TaskDefinition {
   expected_actions: ExpectedAction[];
   verify?: TaskVerification[];
   expected_fetches?: string[];
+  expected_reads?: string[];
   capabilityId?: string;
 }
 
@@ -202,6 +212,13 @@ export interface TaskResult {
     fetchRecall?: number;
     fetchPrecision?: number;
     actualFetches?: string[];
+    readPassed?: boolean;
+    readRecall?: number;
+    readPrecision?: number;
+    matchedReads?: string[];
+    missingReads?: string[];
+    extraReads?: string[];
+    actualReads?: string[];
   };
   llmLatencyMs: number;
   tokenUsage?: TokenUsage;

--- a/src/optimizer/benchmark-adapter.ts
+++ b/src/optimizer/benchmark-adapter.ts
@@ -10,6 +10,8 @@ interface BenchmarkAdapterRunOptions {
   verdictPolicy?: { perModelFloor: number; targetWeightedAverage: number };
   /** Override the skill source for this benchmark run (local versioned copy). */
   skillOverride?: string;
+  /** Override companion skill reference files while preserving stable skill_read paths. */
+  skillReferenceOverrides?: Array<{ source: string; promptPath: string; baseSource?: string }>;
 }
 
 interface BenchmarkAdapterRunResult {
@@ -25,7 +27,13 @@ export function createBenchmarkAdapter(): {
       const runOutputDir = resolve(opts.outputDir, opts.label);
       mkdirSync(runOutputDir, { recursive: true });
 
-      const report = await runBenchmark({ configPath, outputDir: runOutputDir, verdictPolicy: opts.verdictPolicy, skillOverride: opts.skillOverride });
+      const report = await runBenchmark({
+        configPath,
+        outputDir: runOutputDir,
+        verdictPolicy: opts.verdictPolicy,
+        skillOverride: opts.skillOverride,
+        skillReferenceOverrides: opts.skillReferenceOverrides,
+      });
       return {
         report,
         reportPath: resolve(runOutputDir, 'report.json'),

--- a/src/optimizer/loop.ts
+++ b/src/optimizer/loop.ts
@@ -1,5 +1,5 @@
 import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
-import { isAbsolute, join, relative, resolve } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
 
 import { analyzeFailures } from './failure-analysis.js';
 import { accept } from '../benchmark/scoring.js';
@@ -9,6 +9,7 @@ import type {
   MutationCandidate,
   OptimizeIteration,
   OptimizeLoopDependencies,
+  LocalSkillReference,
   OptimizeManifest,
   OptimizeResult,
   ResolvedOptimizeManifest,
@@ -34,11 +35,16 @@ export async function runOptimizeLoop(
   // All subsequent iterations mutate a local versioned copy — the target repo
   // is never written to. Each accepted iteration produces skill-v{N}.md.
   let currentBestSkillPath: string | undefined;
+  let currentBestSkillReferences: LocalSkillReference[] = [];
   if (resolvedManifest.skillPath && existsSync(resolvedManifest.skillPath)) {
     const v0Path = join(outputDir, 'skill-v0.md');
     copyFileSync(resolvedManifest.skillPath, v0Path);
     currentBestSkillPath = v0Path;
+    currentBestSkillReferences = copySkillReferences(resolvedManifest.skillReferences ?? [], outputDir, 0);
     console.log(`[optimize] Skill baseline copied to ${v0Path}`);
+    if (currentBestSkillReferences.length > 0) {
+      console.log(`[optimize] Skill references copied: ${currentBestSkillReferences.map((ref) => ref.promptPath).join(', ')}`);
+    }
   }
 
   let generation: TaskGenerationResult | undefined;
@@ -78,6 +84,7 @@ export async function runOptimizeLoop(
     label: 'baseline',
     verdictPolicy,
     skillOverride: currentBestSkillPath,
+    skillReferenceOverrides: toSkillReferenceOverrides(currentBestSkillReferences),
   });
   const baselineReport = baselineResult.report;
   let bestReport = baselineResult.report;
@@ -106,12 +113,14 @@ export async function runOptimizeLoop(
     }
     let candidate: MutationCandidate | null = null;
 
-    // Prepare a versioned local skill file for this iteration.
+    // Prepare a versioned local skill bundle for this iteration.
     // The mutation writes here; the benchmark reads from here.
     let localSkillPath: string | undefined;
+    let localSkillReferences: LocalSkillReference[] = [];
     if (currentBestSkillPath) {
       localSkillPath = join(outputDir, `skill-v${index}.md`);
       copyFileSync(currentBestSkillPath, localSkillPath);
+      localSkillReferences = copyIterationSkillReferences(currentBestSkillReferences, outputDir, index);
     }
 
     try {
@@ -123,6 +132,7 @@ export async function runOptimizeLoop(
         failureBuckets,
         reportPath: lastReportPath,
         localSkillPath,
+        localSkillReferences,
       });
       if (candidate.toolActivity && candidate.toolActivity.length > 0) {
         console.log('[optimize] Orchestrator tool activity:');
@@ -138,6 +148,7 @@ export async function runOptimizeLoop(
       }
 
       let changedFiles = await getChangedFiles(deps, resolvedManifest, candidate, localSkillPath);
+      const editableFiles = getEditableFiles(candidate, localSkillPath, localSkillReferences);
       console.log(
         `[optimize] Changed files: ${changedFiles.length > 0 ? changedFiles.join(', ') : '(none)'}`,
       );
@@ -158,6 +169,7 @@ export async function runOptimizeLoop(
         accepted: false,
         summary: candidate.summary,
         changedFiles,
+        ...(editableFiles ? { editableFiles } : {}),
         validation,
         scoreBefore: bestReport.summary.overallPassRate,
         delta: 0,
@@ -169,9 +181,7 @@ export async function runOptimizeLoop(
           `[optimize] Validation failed: ${validation.commands.map((command) => command.stderr || command.command).join(' | ')}`,
         );
         console.log('[optimize] Restoring checkpoint.');
-        await deps.repo.restoreCheckpoint(resolvedManifest.targetRepo, acceptedCheckpoint);
-        iterations.push(iteration);
-        await deps.ledger.record({ type: 'iteration', iteration });
+        await restoreAndRecordIteration(deps, resolvedManifest, acceptedCheckpoint, iterations, iteration);
         continue;
       }
 
@@ -183,9 +193,7 @@ export async function runOptimizeLoop(
       if (postValidationScopeValidation) {
         console.log('[optimize] Validation introduced out-of-scope changes. Restoring checkpoint.');
         iteration.validation = postValidationScopeValidation;
-        await deps.repo.restoreCheckpoint(resolvedManifest.targetRepo, acceptedCheckpoint);
-        iterations.push(iteration);
-        await deps.ledger.record({ type: 'iteration', iteration });
+        await restoreAndRecordIteration(deps, resolvedManifest, acceptedCheckpoint, iterations, iteration);
         continue;
       }
 
@@ -196,9 +204,7 @@ export async function runOptimizeLoop(
           'surface-invariant',
           'stable-surface mode rejects callable surface changes; switch to surface-changing mode to allow them',
         );
-        await deps.repo.restoreCheckpoint(resolvedManifest.targetRepo, acceptedCheckpoint);
-        iterations.push(iteration);
-        await deps.ledger.record({ type: 'iteration', iteration });
+        await restoreAndRecordIteration(deps, resolvedManifest, acceptedCheckpoint, iterations, iteration);
         continue;
       }
       if (surfaceChanged && resolvedManifest.optimizer.mode === 'surface-changing') {
@@ -224,6 +230,7 @@ export async function runOptimizeLoop(
           label: `epoch-${index + 1}-baseline`,
           verdictPolicy,
           skillOverride: localSkillPath,
+          skillReferenceOverrides: toSkillReferenceOverrides(localSkillReferences),
         });
         iteration.accepted = true;
         iteration.scoreAfter = epochBaseline.report.summary.overallPassRate;
@@ -233,6 +240,7 @@ export async function runOptimizeLoop(
         lastReportPath = epochBaseline.reportPath;
         if (localSkillPath) {
           currentBestSkillPath = localSkillPath;
+          currentBestSkillReferences = localSkillReferences;
         } else {
           acceptedCheckpoint = await deps.repo.updateAcceptedCheckpoint(
             resolvedManifest.targetRepo,
@@ -246,8 +254,7 @@ export async function runOptimizeLoop(
           `[optimize] Started new epoch baseline at ${(bestReport.summary.overallPassRate * 100).toFixed(1)}% ` +
             `(report: ${epochBaseline.reportPath}).`,
         );
-        iterations.push(iteration);
-        await deps.ledger.record({ type: 'iteration', iteration });
+        await recordIteration(deps, iterations, iteration);
         continue;
       }
 
@@ -257,6 +264,7 @@ export async function runOptimizeLoop(
         label: `iteration-${index}`,
         verdictPolicy,
         skillOverride: localSkillPath,
+        skillReferenceOverrides: toSkillReferenceOverrides(localSkillReferences),
       });
       const candidateReport = candidateResult.report;
       changedFiles = await getChangedFiles(deps, resolvedManifest, candidate, localSkillPath);
@@ -267,9 +275,7 @@ export async function runOptimizeLoop(
       if (postBenchmarkScopeValidation) {
         console.log('[optimize] Benchmark rerun introduced out-of-scope changes. Restoring checkpoint.');
         iteration.validation = postBenchmarkScopeValidation;
-        await deps.repo.restoreCheckpoint(resolvedManifest.targetRepo, acceptedCheckpoint);
-        iterations.push(iteration);
-        await deps.ledger.record({ type: 'iteration', iteration });
+        await restoreAndRecordIteration(deps, resolvedManifest, acceptedCheckpoint, iterations, iteration);
         continue;
       }
 
@@ -296,6 +302,7 @@ export async function runOptimizeLoop(
         );
         if (localSkillPath) {
           currentBestSkillPath = localSkillPath;
+          currentBestSkillReferences = localSkillReferences;
         } else {
           acceptedCheckpoint = await deps.repo.updateAcceptedCheckpoint(
             resolvedManifest.targetRepo,
@@ -319,8 +326,7 @@ export async function runOptimizeLoop(
         consecutiveStableIterations += 1;
       }
 
-      iterations.push(iteration);
-      await deps.ledger.record({ type: 'iteration', iteration });
+      await recordIteration(deps, iterations, iteration);
 
       if (consecutiveStableIterations >= resolvedManifest.optimizer.stabilityWindow) {
         console.log(
@@ -458,22 +464,54 @@ function normalizeRelativePath(path: string): string {
   return path.replace(/^\.\//, '').replace(/^\/+/, '').replace(/\/+$/, '');
 }
 
+async function restoreAndRecordIteration(
+  deps: OptimizeLoopDependencies,
+  manifest: ResolvedOptimizeManifest,
+  acceptedCheckpoint: string,
+  iterations: OptimizeIteration[],
+  iteration: OptimizeIteration,
+): Promise<void> {
+  await deps.repo.restoreCheckpoint(manifest.targetRepo, acceptedCheckpoint);
+  await recordIteration(deps, iterations, iteration);
+}
+
+async function recordIteration(
+  deps: OptimizeLoopDependencies,
+  iterations: OptimizeIteration[],
+  iteration: OptimizeIteration,
+): Promise<void> {
+  iterations.push(iteration);
+  await deps.ledger.record({ type: 'iteration', iteration });
+}
+
 async function getChangedFiles(
   deps: OptimizeLoopDependencies,
   manifest: ResolvedOptimizeManifest,
   candidate: MutationCandidate,
   localSkillPath?: string,
 ): Promise<string[]> {
-  // In local-skill mode the changed file lives outside the target repo, so git
-  // status will never list it. Return the skill path directly so logs and
-  // iteration metadata correctly reflect what the agent wrote.
+  // In local-skill mode the mutation candidate reports the exact local bundle
+  // files that actually changed. Git status will not list them because they are
+  // outside the target repo.
   if (localSkillPath) {
-    return [localSkillPath];
+    return [...candidate.changedFiles];
   }
   const changedFiles = deps.repo.listChangedFiles
     ? deps.repo.listChangedFiles(manifest.targetRepo)
     : [...candidate.changedFiles];
   return (await changedFiles).filter((file) => !isFrameworkArtifactPath(file, manifest));
+}
+
+function getEditableFiles(
+  candidate: MutationCandidate,
+  localSkillPath?: string,
+  localSkillReferences: LocalSkillReference[] = [],
+): string[] | undefined {
+  if (candidate.editableFiles && candidate.editableFiles.length > 0) {
+    return [...candidate.editableFiles];
+  }
+  if (!localSkillPath) return undefined;
+  return [localSkillPath, ...localSkillReferences.map((reference) => reference.localPath)];
 }
 
 function isFrameworkArtifactPath(file: string, manifest: ResolvedOptimizeManifest): boolean {
@@ -496,6 +534,7 @@ function resolveManifest(manifest: OptimizeManifest | ResolvedOptimizeManifest):
   return {
     benchmarkConfig: unresolved.benchmarkConfig,
     skillPath: (unresolved as Partial<ResolvedOptimizeManifest>).skillPath,
+    skillReferences: (unresolved as Partial<ResolvedOptimizeManifest>).skillReferences,
     targetRepo: {
       ...unresolved.targetRepo,
       surfacePaths: unresolved.targetRepo.surfacePaths ?? [],
@@ -527,6 +566,51 @@ function resolveManifest(manifest: OptimizeManifest | ResolvedOptimizeManifest):
         }
       : undefined,
   };
+}
+
+function copyIterationSkillReferences(
+  currentReferences: LocalSkillReference[],
+  outputDir: string,
+  iteration: number,
+): LocalSkillReference[] {
+  return currentReferences.map((reference) =>
+    copySkillReference(reference, reference.localPath, outputDir, iteration),
+  );
+}
+
+function copySkillReferences(
+  references: Array<{ source: string; promptPath: string }>,
+  outputDir: string,
+  version: number,
+): LocalSkillReference[] {
+  return references.map((reference) => copySkillReference(reference, reference.source, outputDir, version));
+}
+
+function copySkillReference(
+  reference: { source: string; promptPath: string },
+  sourcePath: string,
+  outputDir: string,
+  version: number,
+): LocalSkillReference {
+  const localPath = getSkillReferenceVersionPath(outputDir, version, reference.promptPath);
+  mkdirSync(dirname(localPath), { recursive: true });
+  copyFileSync(sourcePath, localPath);
+  return { ...reference, localPath };
+}
+
+function getSkillReferenceVersionPath(outputDir: string, version: number, promptPath: string): string {
+  return join(outputDir, `references-v${version}`, normalizeRelativePath(promptPath));
+}
+
+function toSkillReferenceOverrides(
+  references: LocalSkillReference[],
+): Array<{ source: string; promptPath: string; baseSource: string }> | undefined {
+  if (references.length === 0) return undefined;
+  return references.map((reference) => ({
+    source: reference.localPath,
+    promptPath: reference.promptPath,
+    baseSource: reference.source,
+  }));
 }
 
 function deriveCleanIgnorePaths(targetRepoPath: string, outputDir?: string): string[] {

--- a/src/optimizer/mutation/pi-coding.ts
+++ b/src/optimizer/mutation/pi-coding.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
-import { dirname, basename } from 'node:path';
+import { dirname, basename, relative } from 'node:path';
 import type { AgentMessage } from '@mariozechner/pi-agent-core';
 import type { MutationCandidate, MutationContext } from '../types.js';
 import { collectGitChangedFiles } from './git-changes.js';
@@ -23,8 +23,11 @@ export class PiCodingMutationExecutor {
       ? dirname(context.localSkillPath)
       : context.manifest.targetRepo.path;
 
-    // Snapshot the skill file before mutation so we can detect no-ops.
-    const beforeHash = context.localSkillPath ? hashFile(context.localSkillPath) : null;
+    const localSkillBundle = getLocalSkillBundleEntries(context);
+    const localSkillBundlePaths = localSkillBundle.map((file) => file.absolutePath);
+    // Snapshot the local skill bundle before mutation so we can detect no-ops and
+    // report which bundle files actually changed.
+    const beforeHashes = context.localSkillPath ? hashFiles(localSkillBundlePaths) : null;
 
     const { session } = await createCodingOrchestratorSession({
       cwd: agentCwd,
@@ -58,14 +61,15 @@ export class PiCodingMutationExecutor {
     }
 
     // Detect no-op: agent ran but the file content did not change.
-    const afterHash = context.localSkillPath ? hashFile(context.localSkillPath) : null;
-    if (beforeHash !== null && afterHash !== null && beforeHash === afterHash) {
-      console.warn('[mutation] WARNING: skill file content is identical before and after mutation');
+    const afterHashes = context.localSkillPath ? hashFiles(localSkillBundlePaths) : null;
+    if (beforeHashes !== null && afterHashes !== null && hashesEqual(beforeHashes, afterHashes)) {
+      console.warn('[mutation] WARNING: local skill bundle content is identical before and after mutation');
     }
 
-    // Local skill file: return the path directly; git detection only applies to target-repo mutations.
+    // Local skill bundle: report only files whose contents actually changed.
+    // Keep the editable bundle separately for logs/iteration metadata.
     const changedFiles = context.localSkillPath
-      ? [context.localSkillPath]
+      ? diffHashedFiles(beforeHashes, afterHashes)
       : await collectGitChangedFiles(context.manifest.targetRepo.path);
     const summary = assistantText
       ?? context.failureBuckets[0]?.kind
@@ -74,16 +78,16 @@ export class PiCodingMutationExecutor {
     return {
       summary,
       changedFiles,
+      ...(context.localSkillPath ? { editableFiles: localSkillBundlePaths } : {}),
       toolActivity,
     };
   }
 }
 
 function buildMutationPrompt(context: MutationContext): string {
-  // If we have a local skill path, that's the only file the agent should edit.
-  // The path is absolute so the agent can find it regardless of cwd.
+  const localSkillBundle = getLocalSkillBundleEntries(context);
   const allowedPaths = context.localSkillPath
-    ? `- ${basename(context.localSkillPath)}  (in current working directory)`
+    ? localSkillBundle.map((file) => `- ${file.displayPath} (${file.role})`).join('\n')
     : context.manifest.targetRepo.allowedPaths.map((p) => `- ${p}`).join('\n');
   const feedbackCtx = buildMutationContext(
     context.currentReport,
@@ -105,24 +109,24 @@ function buildMutationPrompt(context: MutationContext): string {
       ].join('\n')
     : '';
 
-  const skillFileName = context.localSkillPath ? basename(context.localSkillPath) : null;
-  const skillPreamble = skillFileName
+  const skillPreamble = context.localSkillPath
     ? [
-        `Improve the skill documentation file: ${skillFileName}`,
-        '(This file is in your current working directory.)',
+        '<task>',
+        'Improve the local skill documentation bundle for benchmark performance.',
+        'The bundle may include a primary skill file and companion reference files that compose the skill.',
+        'Benchmark models will read these same local files after your edits.',
+        '</task>',
         '',
-        'IMPORTANT: Read the file first, then make surgical edits.',
-        '- Do NOT rewrite or replace the file — patch only the sections that are weak or missing.',
-        '- Preserve every command/action that is already documented and passing.',
-        '- The skill must continue to cover ALL commands in the surface, not just the failing ones.',
-        '- Add or expand only the sections that address the benchmark failures below.',
+        '<editable_files>',
+        ...localSkillBundle.map((file) => `- ${file.displayPath}: ${file.role}`),
+        '</editable_files>',
       ].join('\n')
     : 'Improve this repository for LLM usability based on benchmark feedback.';
 
   return [
     skillPreamble,
     '',
-    'Constraints:',
+    '<constraints>',
     '- The benchmark tool schema is frozen. Do not modify benchmark tool definitions, expected tool APIs, or benchmark task contracts.',
     '- Only edit files under these allowed paths:',
     allowedPaths,
@@ -131,20 +135,63 @@ function buildMutationPrompt(context: MutationContext): string {
     '- Prefer the smallest change that improves agent usability.',
     '- If the tool names are cryptic, you may introduce a friendly alias glossary in the docs (for example, "get_ticket -> get_tkt") without changing the actual schema.',
     '- Make the docs explicit about what each parameter means and which values are allowed.',
+    '- Read the relevant editable file(s) first, then make surgical edits. Do not rewrite or replace whole files.',
+    '- Preserve every command/action that is already documented and passing.',
+    '- The skill bundle must continue to cover ALL commands in the surface, not just the failing ones.',
+    '</constraints>',
     '',
+    '<file_selection_guidance>',
+    '- Put product- or surface-specific guidance in the primary skill file.',
+    '- Put shared conventions, auth, global flags, output formatting, quoting, and cross-surface parameter patterns in companion reference files when they exist.',
+    '- If a failure comes from a shared rule used by multiple skills, edit the companion reference instead of duplicating that rule in the primary skill.',
+    '- If a failure is specific to one resource, method, command, or API concept, edit the primary skill near that topic.',
+    '- Avoid duplicating the same guidance in multiple files unless the benchmark evidence shows the model misses the companion reference.',
+    '- If you mention a companion skill file in markdown, prefer the exact logical path shown above so prompts, tasks, and reads stay consistent.',
+    '</file_selection_guidance>',
+    '',
+    '<benchmark_context>',
     `Current overall pass rate: ${context.currentReport.summary.overallPassRate.toFixed(3)}`,
     reportContext
       ? 'Use the following persisted benchmark details as the primary source of truth:'
       : 'Fallback failure summary (use this only because no persisted report context is available):',
     reportContext ?? fallbackFailureSummary,
+    '</benchmark_context>',
     '',
     skillWritingSection,
+    '<final_self_check>',
+    'Before finishing, verify:',
+    '- Edited the most appropriate file(s) in the allowed skill bundle.',
+    '- Did not modify target repo source files, benchmark tasks, or tool schemas.',
+    '- Added concrete, reusable guidance rather than overfitting to one task wording.',
+    '- Avoided conflicting or duplicated instructions across primary and companion files.',
+    '</final_self_check>',
     'Make the changes directly in the repo and stop when the changes are applied.',
     'In your final response, explain in 2-4 concise bullet points:',
     '- what you changed',
     '- why it should improve model tool use',
     '- any remaining weak spots you still see',
   ].join('\n');
+}
+
+function getLocalSkillBundleEntries(context: MutationContext): Array<{
+  absolutePath: string;
+  displayPath: string;
+  role: string;
+}> {
+  if (!context.localSkillPath) return [];
+  const root = dirname(context.localSkillPath);
+  return [
+    {
+      absolutePath: context.localSkillPath,
+      displayPath: basename(context.localSkillPath),
+      role: 'primary skill file',
+    },
+    ...(context.localSkillReferences ?? []).map((reference) => ({
+      absolutePath: reference.localPath,
+      displayPath: relative(root, reference.localPath),
+      role: `companion reference exposed to benchmark models as skill_read("${reference.promptPath}")`,
+    })),
+  ];
 }
 
 function extractLatestAssistantText(messages: AgentMessage[]): string | null {
@@ -207,10 +254,32 @@ function extractToolActivity(messages: AgentMessage[]): string[] {
   return lines;
 }
 
-function hashFile(filePath: string): string | null {
+function hashFiles(files: string[]): Map<string, string> | null {
+  const hashes = new Map<string, string>();
+
   try {
-    return createHash('sha256').update(readFileSync(filePath)).digest('hex');
+    for (const file of files) {
+      hashes.set(file, createHash('sha256').update(readFileSync(file)).digest('hex'));
+    }
+    return hashes;
   } catch {
     return null;
   }
+}
+
+function hashesEqual(before: Map<string, string>, after: Map<string, string>): boolean {
+  if (before.size !== after.size) return false;
+  for (const [file, hash] of before) {
+    if (after.get(file) !== hash) return false;
+  }
+  return true;
+}
+
+function diffHashedFiles(before: Map<string, string> | null, after: Map<string, string> | null): string[] {
+  if (!before || !after) return [];
+  const changed: string[] = [];
+  for (const [file, hash] of after) {
+    if (before.get(file) !== hash) changed.push(file);
+  }
+  return changed;
 }

--- a/src/optimizer/types.ts
+++ b/src/optimizer/types.ts
@@ -52,6 +52,8 @@ export interface ResolvedOptimizeManifest {
   benchmarkConfig: string;
   /** Absolute path to the source SKILL.md in the target repo, if it is a local file. */
   skillPath?: string;
+  /** Companion skill references that compose the skill and may be versioned locally. */
+  skillReferences?: Array<{ source: string; promptPath: string }>;
   targetRepo: {
     path: string;
     surface: BenchmarkSurface;
@@ -97,7 +99,14 @@ export interface FailureBucket {
 export interface MutationCandidate {
   summary: string;
   changedFiles: string[];
+  editableFiles?: string[];
   toolActivity?: string[];
+}
+
+export interface LocalSkillReference {
+  source: string;
+  localPath: string;
+  promptPath: string;
 }
 
 export interface ValidationCommandResult {
@@ -118,6 +127,7 @@ export interface OptimizeIteration {
   accepted: boolean;
   summary: string;
   changedFiles: string[];
+  editableFiles?: string[];
   validation: ValidationResult;
   scoreBefore: number;
   scoreAfter?: number;
@@ -147,13 +157,21 @@ export interface MutationContext {
    * executor must write its changes to this path instead of the target repo.
    */
   localSkillPath?: string;
+  /** Local editable copies of companion references for this iteration. */
+  localSkillReferences?: LocalSkillReference[];
 }
 
 export interface OptimizeLoopDependencies {
   benchmark: {
     run(
       configPath: string,
-      opts: { outputDir: string; label: string; verdictPolicy?: { perModelFloor: number; targetWeightedAverage: number }; skillOverride?: string },
+      opts: {
+        outputDir: string;
+        label: string;
+        verdictPolicy?: { perModelFloor: number; targetWeightedAverage: number };
+        skillOverride?: string;
+        skillReferenceOverrides?: Array<{ source: string; promptPath: string; baseSource?: string }>;
+      },
     ): Promise<{ report: BenchmarkReport; reportPath: string }>;
   };
   repo: {

--- a/src/project/adapters.ts
+++ b/src/project/adapters.ts
@@ -3,6 +3,7 @@ import type { ResolvedOptimizeManifest } from '../optimizer/types.js';
 import type { ResolvedProjectConfig } from './types.js';
 import { parseModelRef } from './types.js';
 import { buildMcpToolDefinitionsFromSnapshot, buildSurfaceSnapshot } from './snapshot.js';
+import { buildCanonicalSkillReferenceEntries } from './skill-references.js';
 
 export function toBenchmarkConfig(project: ResolvedProjectConfig): BenchmarkConfig {
   const surfaceSnapshot = buildSurfaceSnapshot(project);
@@ -53,6 +54,9 @@ export function toOptimizeManifest(project: ResolvedProjectConfig): ResolvedOpti
   return {
     benchmarkConfig: project.configPath,
     skillPath,
+    skillReferences: skillPath && project.target.skill?.references
+      ? buildCanonicalSkillReferenceEntries(skillPath, project.target.skill.references)
+      : undefined,
     targetRepo: {
       path: project.target.repoPath,
       surface: project.target.surface,

--- a/src/project/resolve.ts
+++ b/src/project/resolve.ts
@@ -16,14 +16,23 @@ const DEFAULT_PER_MODEL_FLOOR = 0.6;
 const DEFAULT_TARGET_WEIGHTED_AVERAGE = 0.7;
 const DEFAULT_REPORT_CONTEXT_MAX_BYTES = 16_000;
 
+function isRemoteSkillSource(source: string): boolean {
+  return source.startsWith('github:') || source.startsWith('https://') || source.startsWith('http://');
+}
+
+function resolveSkillSource(configDir: string, source: string): string {
+  return isRemoteSkillSource(source) ? source : resolve(configDir, source);
+}
+
 export function resolveProjectConfig(config: ProjectConfig, configPath: string): ResolvedProjectConfig {
   const configDir = dirname(configPath);
   const skill = config.target.skill
     ? typeof config.target.skill === 'string'
-      ? { source: resolve(configDir, config.target.skill), cache: true }
+      ? { source: resolveSkillSource(configDir, config.target.skill), cache: true }
       : {
           ...config.target.skill,
-          source: resolve(configDir, config.target.skill.source),
+          source: resolveSkillSource(configDir, config.target.skill.source),
+          references: config.target.skill.references?.map((ref) => resolveSkillSource(configDir, ref)),
           cache: config.target.skill.cache ?? true,
         }
     : undefined;

--- a/src/project/schema.ts
+++ b/src/project/schema.ts
@@ -40,8 +40,12 @@ const TargetConfigSchema = z.object({
   repoPath: z.string().optional().describe('Path to the target repo (default ".")'),
   skill: z.union([
     z.string(),
-    z.object({ source: z.string(), cache: z.boolean().optional() }),
-  ]).optional().describe('Path to SKILL.md or { source, cache } object'),
+    z.object({
+      source: z.string(),
+      references: z.array(z.string()).optional(),
+      cache: z.boolean().optional(),
+    }),
+  ]).optional().describe('Path to SKILL.md or { source, references, cache } object'),
   discovery: DiscoveryConfigSchema.optional().describe('How to discover callable actions'),
   sdk: SdkConfigSchema.optional().describe('SDK-specific config'),
   cli: CliConfigSchema.optional().describe('CLI-specific config'),

--- a/src/project/skill-references.ts
+++ b/src/project/skill-references.ts
@@ -1,0 +1,69 @@
+import { dirname, isAbsolute, relative } from 'node:path';
+
+export interface SkillReferencePathEntry {
+  source: string;
+  promptPath: string;
+  baseSource?: string;
+}
+
+function isAncestorOrSame(parent: string, child: string): boolean {
+  const rel = relative(parent, child);
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+}
+
+export function normalizePathForPrompt(pathValue: string): string {
+  return pathValue.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+/g, '/').replace(/\/$/, '');
+}
+
+export function getCommonDirectory(paths: string[]): string {
+  if (paths.length === 0) return process.cwd();
+  let common = paths[0]!;
+  for (const current of paths.slice(1)) {
+    while (!isAncestorOrSame(common, current)) {
+      const next = dirname(common);
+      if (next === common) break;
+      common = next;
+    }
+  }
+  return common;
+}
+
+export function buildCanonicalSkillReferenceEntries(
+  skillPath: string,
+  references: string[],
+): SkillReferencePathEntry[] {
+  const commonDirectory = getCommonDirectory([
+    dirname(skillPath),
+    ...references.map((reference) => dirname(reference)),
+  ]);
+
+  return references.map((reference) => ({
+    source: reference,
+    promptPath: normalizePathForPrompt(relative(commonDirectory, reference)),
+  }));
+}
+
+export function buildSkillReferenceAliases(
+  skillPath: string,
+  referencePath: string,
+  baseSkillPath: string,
+  baseReferencePath: string,
+  promptPath?: string,
+): string[] {
+  const aliases = new Set<string>();
+  const candidates = [
+    referencePath,
+    baseReferencePath,
+    relative(dirname(skillPath), referencePath),
+    relative(dirname(baseSkillPath), baseReferencePath),
+  ];
+
+  for (const candidate of candidates) {
+    const normalized = normalizePathForPrompt(candidate);
+    if (normalized && normalized !== '.' && normalized !== promptPath) {
+      aliases.add(normalized);
+    }
+  }
+
+  return [...aliases];
+}

--- a/src/project/validate.ts
+++ b/src/project/validate.ts
@@ -27,6 +27,9 @@ export async function checkConfig(
 ): Promise<Issue[]> {
   const issues: Issue[] = [];
 
+  const isRemoteSkillSource = (source: string): boolean =>
+    source.startsWith('github:') || source.startsWith('https://') || source.startsWith('http://');
+
   function err(code: string, field: string, message: string, hint?: string): void {
     issues.push({ code, severity: 'error', field, message, hint, fixable: false });
   }
@@ -53,6 +56,27 @@ export async function checkConfig(
     const skillSource = typeof target.skill === 'string' ? target.skill : target.skill?.source;
     if (!skillSource || typeof skillSource !== 'string') {
       err('invalid-skill', 'target.skill', '"target.skill" must be a path string or { source } object');
+    }
+    if (target.skill && typeof target.skill === 'object' && target.skill.references !== undefined) {
+      if (!Array.isArray(target.skill.references)) {
+        err('invalid-skill-references', 'target.skill.references', '"target.skill.references" must be an array of non-empty strings');
+      } else {
+        for (let i = 0; i < target.skill.references.length; i++) {
+          const ref = target.skill.references[i];
+          if (typeof ref !== 'string' || ref.trim() === '') {
+            err('invalid-skill-reference-entry', `target.skill.references[${i}]`, 'Each skill reference must be a non-empty string');
+          }
+        }
+      }
+
+      if (typeof skillSource === 'string' && isRemoteSkillSource(skillSource) && target.skill.references.length > 0) {
+        err(
+          'remote-skill-references-unsupported',
+          'target.skill.references',
+          '"target.skill.references" is only supported when "target.skill.source" is a local file path',
+          'Use a local target.skill.source when configuring references',
+        );
+      }
     }
   }
 
@@ -296,7 +320,7 @@ export async function checkConfig(
   // Check: target.skill file exists (skip for remote sources — github: / https: / http:)
   if (target.skill !== undefined) {
     const skillSource = typeof target.skill === 'string' ? target.skill : target.skill.source;
-    const isRemoteSkill = skillSource.startsWith('github:') || skillSource.startsWith('https://') || skillSource.startsWith('http://');
+    const isRemoteSkill = isRemoteSkillSource(skillSource);
     if (skillSource && !isRemoteSkill) {
       const absSkill = isAbsolute(skillSource) ? skillSource : resolve(configDir, skillSource);
       if (!existsSync(absSkill)) {
@@ -306,6 +330,22 @@ export async function checkConfig(
           hint: `Create SKILL.md at that path or update target.skill`,
           fixable: false,
         });
+      }
+    }
+
+    const skillReferences = typeof target.skill === 'object' ? target.skill.references : undefined;
+    if (Array.isArray(skillReferences)) {
+      for (let i = 0; i < skillReferences.length; i++) {
+        const ref = skillReferences[i]!;
+        const absRef = isAbsolute(ref) ? ref : resolve(configDir, ref);
+        if (!existsSync(absRef)) {
+          issues.push({
+            code: 'skill-reference-missing', severity: 'error', field: `target.skill.references[${i}]`,
+            message: `skill reference does not exist: ${absRef}`,
+            hint: 'Create the file or update target.skill.references',
+            fixable: false,
+          });
+        }
       }
     }
   }

--- a/src/tasks/discover.ts
+++ b/src/tasks/discover.ts
@@ -1,6 +1,5 @@
-import { readFileSync } from 'node:fs';
-
 import { buildSurfaceSnapshot, loadProjectConfig } from '../project/index.js';
+import { fetchSkill } from '../benchmark/skill-fetcher.js';
 
 import type { DiscoveredTaskSurface } from './types.js';
 
@@ -12,8 +11,14 @@ export async function discoverTaskSurface(configPath: string): Promise<Discovere
   }
 
   let skillMarkdown: string;
+  let skillReferences: DiscoveredTaskSurface['skillReferences'];
   try {
-    skillMarkdown = readFileSync(skillPath, 'utf-8');
+    const skill = await fetchSkill(project.target.skill);
+    if (!skill) {
+      throw new Error('fetchSkill returned no content');
+    }
+    skillMarkdown = skill.content;
+    skillReferences = skill.references;
   } catch (error) {
     throw new Error(`Could not read skill markdown from ${skillPath}: ${error instanceof Error ? error.message : String(error)}`);
   }
@@ -22,6 +27,7 @@ export async function discoverTaskSurface(configPath: string): Promise<Discovere
     project,
     skillMarkdown,
     skillPath,
+    skillReferences,
     snapshot: buildSurfaceSnapshot(project),
   };
 }

--- a/src/tasks/freeze.ts
+++ b/src/tasks/freeze.ts
@@ -37,6 +37,7 @@ export function freezeTaskArtifacts(params: FreezeTaskArtifactsParams): FrozenTa
       repoPath: params.project.target.repoPath,
       skill: {
         source: params.project.target.skill.source,
+        references: params.project.target.skill.references,
         cache: params.project.target.skill.cache,
       },
       discovery: params.project.target.discovery,

--- a/src/tasks/generate.ts
+++ b/src/tasks/generate.ts
@@ -6,6 +6,8 @@ import type { ActionDefinition } from '../actions/types.js';
 import { computeUncovered, buildRetryPrompt, computeCoverage } from './coverage.js';
 import type { DiscoveredTaskSurface, GeneratedTask, TaskGeneratorConfig, TaskGeneratorDeps } from './types.js';
 
+type SnapshotAction = DiscoveredTaskSurface['snapshot']['actions'][number];
+
 // Derive a stable task ID from the expected action names.
 // Action names are surface-stable (they come from discovered code, not LLM free-form output),
 // so the same surface produces the same IDs across regenerations.
@@ -20,9 +22,10 @@ export async function generateCandidateTasks(
   deps: TaskGeneratorDeps,
 ): Promise<GeneratedTask[]> {
   const system = [
-    `You generate ${surface.snapshot.surface.toUpperCase()} benchmark tasks.`,
-    'Output strict JSON only with no markdown and no extra prose.',
-    'Never invent action names or arguments that are not present in the provided discovered surface snapshot.',
+    'You are an expert benchmark dataset designer for LLM tool-selection evals.',
+    `Design ${surface.snapshot.surface.toUpperCase()} tasks that are realistic, discriminative, and automatically scorable.`,
+    'Return strict JSON only: no markdown, no code fences, no explanatory prose.',
+    'Use only action names, capability ids, and argument keys present in the supplied surface snapshot.',
   ].join(' ');
 
   const prompt = buildPrompt(surface, config);
@@ -43,89 +46,309 @@ function buildPrompt(surface: DiscoveredTaskSurface, config: TaskGeneratorConfig
   const referenceContext = buildReferenceContext(surface);
 
   if (surface.snapshot.surface === 'prompt') {
-    const capKeys = surface.snapshot.actions.map((a) => a.name);
-    return [
-      'Generate benchmark evaluation tasks for a prompt/skill document.',
-      'These tasks will be evaluated by content quality, not action matching.',
-      '',
-      'Return a JSON object with EXACTLY this shape:',
-      '{"tasks":[{"id":"string","prompt":"string","expected_actions":[],"capabilityId":"string"}]}',
-      '',
-      'RULES:',
-      '- Each task has EXACTLY four keys: id, prompt, expected_actions, capabilityId.',
-      '- expected_actions MUST always be an empty array [].',
-      '- id: short snake_case identifier (e.g. "deploy_service_to_staging").',
-      '- prompt: ask the model to perform a realistic task from the skill.',
-      '- capabilityId: set to the action key of the discovered capability this task exercises.',
-      `- Valid capabilityId values: ${capKeys.join(', ')}.`,
-      '- Every task MUST have a capabilityId from the valid list above — no other values are accepted.',
-      `- Produce at most ${clampedMax} tasks. Seed: ${config.seed}.`,
-      '',
-      'Full SKILL.md:',
-      '---BEGIN SKILL---',
-      surface.skillMarkdown,
-      '---END SKILL---',
-      referenceContext,
-      '',
-      'Discovered prompt surface snapshot (capabilities for reference):',
-      '---BEGIN SURFACE SNAPSHOT---',
-      JSON.stringify(surface.snapshot, null, 2),
-      '---END SURFACE SNAPSHOT---',
-    ].join('\n');
+    return buildPromptSurfacePrompt(surface, clampedMax, config.seed, referenceContext);
   }
 
+  return buildCallableSurfacePrompt(surface, clampedMax, config.seed, referenceContext);
+}
+
+function buildCallableSurfacePrompt(
+  surface: DiscoveredTaskSurface,
+  clampedMax: number,
+  seed: number,
+  referenceContext: string,
+): string {
   return [
+    '<task>',
     `Generate benchmark tasks for a ${surface.snapshot.surface} callable surface.`,
+    'Each task is a user-facing prompt plus the exact gold action trace that should satisfy it.',
+    'The benchmark is static: generate only task data, never executable code or shell commands.',
+    '</task>',
     '',
+    '<context>',
+    '<skill_document path="SKILL.md">',
+    surface.skillMarkdown,
+    '</skill_document>',
+    referenceContext,
+    `<surface_snapshot surface="${surface.snapshot.surface}">`,
+    JSON.stringify(surface.snapshot, null, 2),
+    '</surface_snapshot>',
+    '</context>',
+    '',
+    '<objective>',
+    `Produce at most ${clampedMax} tasks. Seed for deterministic variety: ${seed}.`,
+    'Optimize for benchmark signal: tasks should expose whether a model can identify the right callable action and arguments from skill/docs context.',
+    '</objective>',
+    '',
+    '<dataset_quality_bar>',
+    '- Write realistic user requests, not action-name wrappers. The prompt should sound like a real user goal.',
+    '- Include a balanced mix of happy path, edge/constraint, prerequisite/read-dependent, and multi-step tasks when the surface supports them.',
+    '- Prefer concrete values over placeholders: names, ids, dates, paths, addresses, filters, limits, or options.',
+    '- Make each task automatically scorable from expected_actions; avoid vague outcomes that require human judgment.',
+    '- Cover different actions and argument combinations. Do not generate near-duplicates with only cosmetic wording changes.',
+    '- Keep expected_actions minimal: include exactly the call(s) needed, in the order a correct model should perform them.',
+    '- Do not ask for behavior outside the surface snapshot, external services, hidden state, or execution of generated code.',
+    '</dataset_quality_bar>',
+    '',
+    '<surface_specific_rules>',
+    ...surfaceSpecificRules(surface.snapshot.surface),
+    '</surface_specific_rules>',
+    '',
+    '<output_schema>',
     'Return a JSON object with EXACTLY this shape and no other keys:',
     '{"tasks":[{"id":"string","prompt":"string","expected_actions":[{"name":"string","args":{"key":"value"}}]}]}',
     'Optional when a task requires a companion skill file: add "expected_reads":["exact/reference/path.md"].',
+    '</output_schema>',
     '',
-    'STRICT SCHEMA RULES - violations cause test failures:',
+    '<field_rules>',
     '- Each task object has id, prompt, expected_actions, and may include expected_reads.',
-    '- Do NOT add keys like: cli_command, instruction, action, description, expected_outcome, expected_args, source, steps, calls.',
-    '- expected_actions is an ARRAY of objects, each with exactly two keys: name and args.',
-    '- name is the action name string (e.g. "account create", "network list").',
-    '- args is a flat object of key-value argument pairs (e.g. {"name": "my-wallet"}).',
-    '- expected_reads must use exact paths from the Companion skill references section when the task requires them.',
+    '- Do not add keys like cli_command, instruction, action, description, expected_outcome, expected_args, source, steps, or calls.',
+    '- expected_actions is an array of objects. Each object has exactly name and args.',
+    '- name must exactly match an action name from <surface_snapshot>. Preserve spaces, dots, dashes, underscores, and casing.',
+    '- args must include every required argument from the action definition.',
+    '- args keys must exactly match argument names from that action definition. Do not invent aliases.',
+    '- args values should be concrete and type-appropriate. Use nested JSON only when the argument itself expects structured JSON.',
+    '- expected_actions must never be empty for callable surfaces.',
+    '- expected_reads may only contain exact paths listed in <companion_skill_references>. Do not use ../ paths, leading slashes, or inferred aliases.',
+    '</field_rules>',
     '',
-    `Task count limit: produce at most ${clampedMax} tasks.`,
-    `Seed for deterministic variety: ${config.seed}.`,
-    'Variety requirement: include a mix of simple, medium, and multi-step tasks using different actions and argument combinations.',
+    '<good_examples>',
+    buildCallableExamples(surface),
+    '</good_examples>',
     '',
-    'Additional rules:',
-    '1) Use ONLY action names that exist in the provided discovered surface snapshot.',
-    '2) For each expected_actions entry, args keys MUST match discovered action argument names.',
-    '3) Include required params in args when an action marks them as required.',
-    '4) expected_actions must never be empty.',
+    '<bad_patterns_to_avoid>',
+    '- A task that names an action but omits required args.',
+    '- A prompt that says "call create_wallet" instead of describing the user goal.',
+    '- expected_reads for a file that is not listed in <companion_skill_references>.',
+    '- Extra schema keys that the loader will ignore or reject.',
+    '</bad_patterns_to_avoid>',
     '',
-    'Full SKILL.md:',
-    '---BEGIN SKILL---',
+    '<final_self_check>',
+    'Before responding, silently verify every task against this checklist:',
+    '- JSON parses as one object with a top-level tasks array.',
+    `- tasks.length <= ${clampedMax}.`,
+    '- Every action name appears exactly in <surface_snapshot>.',
+    '- Every args key appears exactly under that action in <surface_snapshot>.',
+    '- Every required arg is present.',
+    '- Every expected_reads path, if any, appears exactly in <companion_skill_references>.',
+    '- Prompts are realistic, concrete, and not near-duplicates.',
+    'If any check fails, fix the JSON before returning it. Return the JSON only.',
+    '</final_self_check>',
+  ].join('\n');
+}
+
+function buildPromptSurfacePrompt(
+  surface: DiscoveredTaskSurface,
+  clampedMax: number,
+  seed: number,
+  referenceContext: string,
+): string {
+  const capKeys = surface.snapshot.actions.map((a) => a.name);
+
+  return [
+    '<task>',
+    'Generate benchmark evaluation tasks for a prompt/skill document.',
+    'These tasks will be evaluated by content quality against the specific capability they exercise, not by action matching.',
+    '</task>',
+    '',
+    '<context>',
+    '<skill_document path="SKILL.md">',
     surface.skillMarkdown,
-    '---END SKILL---',
+    '</skill_document>',
     referenceContext,
-    '',
-    `Discovered ${surface.snapshot.surface} surface snapshot:`,
-    '---BEGIN SURFACE SNAPSHOT---',
+    '<surface_snapshot surface="prompt">',
     JSON.stringify(surface.snapshot, null, 2),
-    '---END SURFACE SNAPSHOT---',
+    '</surface_snapshot>',
+    '</context>',
+    '',
+    '<objective>',
+    `Produce at most ${clampedMax} tasks. Seed for deterministic variety: ${seed}.`,
+    'Optimize for benchmark signal: tasks should reveal whether a model follows the skill instructions for one discovered capability.',
+    '</objective>',
+    '',
+    '<dataset_quality_bar>',
+    '- Write realistic user requests that exercise the skill, not meta-prompts about the benchmark.',
+    '- Include concrete inputs and success criteria the response can be judged against.',
+    '- Cover different valid capabilityId values when possible. Avoid near-duplicate prompts.',
+    '- Include harder cases when the skill supports them: ambiguous input, constraints, formatting requirements, or missing context that the skill explains how to handle.',
+    '- Do not ask for tools, APIs, files, or actions outside the skill document and discovered capabilities.',
+    '</dataset_quality_bar>',
+    '',
+    '<prompt_surface_rules>',
+    '- expected_actions must always be [].',
+    '- capabilityId must exactly match one discovered capability key.',
+    `- Valid capabilityId values: ${capKeys.join(', ')}.`,
+    '- Each task should primarily exercise one capabilityId so scoring is attributable.',
+    '</prompt_surface_rules>',
+    '',
+    '<output_schema>',
+    'Return a JSON object with EXACTLY this shape and no other keys:',
+    '{"tasks":[{"id":"string","prompt":"string","expected_actions":[],"capabilityId":"string"}]}',
+    '</output_schema>',
+    '',
+    '<field_rules>',
+    '- Each task has exactly four keys: id, prompt, expected_actions, capabilityId.',
+    '- id is a short snake_case identifier.',
+    '- prompt is a realistic user request from the skill domain.',
+    '- expected_actions must be an empty array [].',
+    '- capabilityId must be one of the valid values above.',
+    '</field_rules>',
+    '',
+    '<good_examples>',
+    buildPromptSurfaceExamples(surface),
+    '</good_examples>',
+    '',
+    '<final_self_check>',
+    'Before responding, silently verify every task against this checklist:',
+    '- JSON parses as one object with a top-level tasks array.',
+    `- tasks.length <= ${clampedMax}.`,
+    '- expected_actions is [] for every task.',
+    '- every capabilityId appears exactly in the valid list.',
+    '- prompts are concrete, realistic, and not near-duplicates.',
+    'If any check fails, fix the JSON before returning it. Return the JSON only.',
+    '</final_self_check>',
   ].join('\n');
 }
 
 function buildReferenceContext(surface: DiscoveredTaskSurface): string {
   const references = surface.skillReferences ?? [];
-  if (references.length === 0) return '';
+  if (references.length === 0) {
+    return [
+      '<companion_skill_references>',
+      'No companion skill references are configured for this benchmark.',
+      '</companion_skill_references>',
+    ].join('\n');
+  }
 
   return [
-    '',
+    '<companion_skill_references>',
     'Companion skill references available at benchmark runtime via skill_read(path):',
     'If generated tasks depend on these companion instructions, include expected_reads with the exact path.',
+    'Only these exact paths are valid. Do not infer relative aliases, parent-directory paths, or leading-slash paths.',
     ...references.flatMap((reference) => [
       `---BEGIN REFERENCE path="${reference.path}"---`,
       reference.content,
       '---END REFERENCE---',
     ]),
+    '</companion_skill_references>',
   ].join('\n');
+}
+
+function surfaceSpecificRules(surface: DiscoveredTaskSurface['snapshot']['surface']): string[] {
+  if (surface === 'cli') {
+    return [
+      '- expected_actions.name is the canonical command path from the snapshot, not the full shell command string.',
+      '- args keys are canonical option or positional names from the snapshot. Include required flags/options as args.',
+      '- User prompts may mention desired flags or output formats naturally, but do not invent unsupported flags.',
+    ];
+  }
+
+  if (surface === 'sdk') {
+    return [
+      '- expected_actions.name is the SDK method/function name from the snapshot.',
+      '- args keys are method parameter names from the snapshot.',
+      '- User prompts should describe developer intent, not paste implementation code unless the skill is code-oriented.',
+    ];
+  }
+
+  if (surface === 'mcp') {
+    return [
+      '- expected_actions.name is the MCP tool name from the snapshot.',
+      '- args keys are tool input fields from the snapshot.',
+      '- User prompts should describe the external task the tool performs, not mention internal benchmark mechanics.',
+    ];
+  }
+
+  return [];
+}
+
+function buildCallableExamples(surface: DiscoveredTaskSurface): string {
+  const first = surface.snapshot.actions[0];
+  if (!first) return '{"tasks":[]}';
+
+  const tasks: Array<Record<string, unknown>> = [
+    {
+      id: 'example_single_action',
+      prompt: `${describeAction(first)} using concrete user-provided values.`,
+      expected_actions: [buildExampleAction(first)],
+    },
+  ];
+
+  const second = surface.snapshot.actions.find((action) => action.name !== first.name);
+  if (second) {
+    tasks.push({
+      id: 'example_multi_step',
+      prompt: `${describeAction(first)}, then ${describeAction(second)} for the same user request.`,
+      expected_actions: [buildExampleAction(first), buildExampleAction(second)],
+    });
+  }
+
+  const firstReference = surface.skillReferences?.[0]?.path;
+  if (firstReference) {
+    tasks.push({
+      id: 'example_reference_required',
+      prompt: `${describeAction(first)} after applying the companion instructions from ${firstReference}.`,
+      expected_reads: [firstReference],
+      expected_actions: [buildExampleAction(first)],
+    });
+  }
+
+  return JSON.stringify({ tasks }, null, 2);
+}
+
+function buildPromptSurfaceExamples(surface: DiscoveredTaskSurface): string {
+  const first = surface.snapshot.actions[0];
+  const second = surface.snapshot.actions.find((action) => action.name !== first?.name);
+  const tasks = [
+    {
+      id: 'example_prompt_capability',
+      prompt: first ? `${describeAction(first)} for the concrete input supplied by the user.` : 'Perform one concrete skill capability for the user input.',
+      expected_actions: [],
+      capabilityId: first?.name ?? 'capability_id_from_snapshot',
+    },
+  ];
+
+  if (second) {
+    tasks.push({
+      id: 'example_second_capability',
+      prompt: `${describeAction(second)} with explicit formatting constraints.`,
+      expected_actions: [],
+      capabilityId: second.name,
+    });
+  }
+
+  return JSON.stringify({ tasks }, null, 2);
+}
+
+function buildExampleAction(action: SnapshotAction): { name: string; args: Record<string, unknown> } {
+  const required = action.args.filter((arg) => arg.required);
+  const selectedArgs = required.length > 0 ? required : action.args.slice(0, 1);
+  return {
+    name: action.name,
+    args: Object.fromEntries(selectedArgs.map((arg) => [arg.name, sampleValueForArg(arg)])),
+  };
+}
+
+function sampleValueForArg(arg: SnapshotAction['args'][number]): unknown {
+  const name = arg.name.toLowerCase();
+  const schemaType = typeof arg.schema?.type === 'string' ? arg.schema.type : undefined;
+  const type = (arg.type ?? schemaType ?? '').toLowerCase();
+
+  if (type === 'number' || type === 'integer') return 5;
+  if (type === 'boolean') return true;
+  if (type === 'array') return [`sample-${arg.name}`];
+  if (type === 'object') return { value: `sample-${arg.name}` };
+  if (name.includes('email')) return 'user@example.com';
+  if (name === 'id' || name.endsWith('id') || name.includes('_id') || name.includes('-id')) return `${arg.name}-123`;
+  if (name.includes('address')) return '0x123';
+  if (name.includes('limit') || name.includes('page') || name.includes('count')) return 5;
+  return `sample-${arg.name}`;
+}
+
+function describeAction(action: SnapshotAction): string {
+  const description = action.description?.trim().replace(/[.\s]+$/, '');
+  if (description) return description;
+  return action.name.replace(/[_.:-]+/g, ' ');
 }
 
 function stripCodeFence(raw: string): string {

--- a/src/tasks/generate.ts
+++ b/src/tasks/generate.ts
@@ -40,6 +40,7 @@ export async function generateCandidateTasks(
 
 function buildPrompt(surface: DiscoveredTaskSurface, config: TaskGeneratorConfig): string {
   const clampedMax = Math.max(1, Math.floor(config.maxTasks));
+  const referenceContext = buildReferenceContext(surface);
 
   if (surface.snapshot.surface === 'prompt') {
     const capKeys = surface.snapshot.actions.map((a) => a.name);
@@ -64,6 +65,7 @@ function buildPrompt(surface: DiscoveredTaskSurface, config: TaskGeneratorConfig
       '---BEGIN SKILL---',
       surface.skillMarkdown,
       '---END SKILL---',
+      referenceContext,
       '',
       'Discovered prompt surface snapshot (capabilities for reference):',
       '---BEGIN SURFACE SNAPSHOT---',
@@ -77,13 +79,15 @@ function buildPrompt(surface: DiscoveredTaskSurface, config: TaskGeneratorConfig
     '',
     'Return a JSON object with EXACTLY this shape and no other keys:',
     '{"tasks":[{"id":"string","prompt":"string","expected_actions":[{"name":"string","args":{"key":"value"}}]}]}',
+    'Optional when a task requires a companion skill file: add "expected_reads":["exact/reference/path.md"].',
     '',
     'STRICT SCHEMA RULES - violations cause test failures:',
-    '- Each task object has EXACTLY three keys: id, prompt, expected_actions.',
+    '- Each task object has id, prompt, expected_actions, and may include expected_reads.',
     '- Do NOT add keys like: cli_command, instruction, action, description, expected_outcome, expected_args, source, steps, calls.',
     '- expected_actions is an ARRAY of objects, each with exactly two keys: name and args.',
     '- name is the action name string (e.g. "account create", "network list").',
     '- args is a flat object of key-value argument pairs (e.g. {"name": "my-wallet"}).',
+    '- expected_reads must use exact paths from the Companion skill references section when the task requires them.',
     '',
     `Task count limit: produce at most ${clampedMax} tasks.`,
     `Seed for deterministic variety: ${config.seed}.`,
@@ -99,11 +103,28 @@ function buildPrompt(surface: DiscoveredTaskSurface, config: TaskGeneratorConfig
     '---BEGIN SKILL---',
     surface.skillMarkdown,
     '---END SKILL---',
+    referenceContext,
     '',
     `Discovered ${surface.snapshot.surface} surface snapshot:`,
     '---BEGIN SURFACE SNAPSHOT---',
     JSON.stringify(surface.snapshot, null, 2),
     '---END SURFACE SNAPSHOT---',
+  ].join('\n');
+}
+
+function buildReferenceContext(surface: DiscoveredTaskSurface): string {
+  const references = surface.skillReferences ?? [];
+  if (references.length === 0) return '';
+
+  return [
+    '',
+    'Companion skill references available at benchmark runtime via skill_read(path):',
+    'If generated tasks depend on these companion instructions, include expected_reads with the exact path.',
+    ...references.flatMap((reference) => [
+      `---BEGIN REFERENCE path="${reference.path}"---`,
+      reference.content,
+      '---END REFERENCE---',
+    ]),
   ].join('\n');
 }
 
@@ -235,6 +256,7 @@ function validateTask(task: unknown, index: number, knownCapabilityKeys?: string
   }
 
   const expected_actions = rawExpectedActions.map((action, actionIndex) => validateExpectedAction(taskId, action, actionIndex));
+  const expected_reads = validateExpectedReads(candidate['expected_reads'], taskId);
 
   // Extract capabilityId for prompt-surface tasks. The field is stored as-is here;
   // grounding validates it against the known capability keys and rejects bad values.
@@ -245,8 +267,22 @@ function validateTask(task: unknown, index: number, knownCapabilityKeys?: string
     id: taskId,
     prompt: taskPrompt,
     expected_actions,
+    ...(expected_reads ? { expected_reads } : {}),
     ...(capabilityId !== undefined ? { capabilityId } : {}),
   };
+}
+
+function validateExpectedReads(rawReads: unknown, taskId: string): string[] | undefined {
+  if (rawReads === undefined) return undefined;
+  if (!Array.isArray(rawReads)) {
+    throw new Error(`Task ${taskId} expected_reads must be an array when present`);
+  }
+  for (const [index, entry] of rawReads.entries()) {
+    if (typeof entry !== 'string' || entry.trim() === '') {
+      throw new Error(`Task ${taskId} expected_reads[${index}] must be a non-empty string`);
+    }
+  }
+  return rawReads.map((entry) => entry.trim());
 }
 
 function validateExpectedAction(taskId: string, action: unknown, actionIndex: number): ExpectedAction {

--- a/src/tasks/ground.ts
+++ b/src/tasks/ground.ts
@@ -3,7 +3,11 @@ import type { SurfaceSnapshot } from '../project/types.js';
 
 import type { GeneratedTask, GroundedTasksResult } from './types.js';
 
-export function groundTasks(tasks: GeneratedTask[], snapshot: SurfaceSnapshot): GroundedTasksResult {
+export function groundTasks(
+  tasks: GeneratedTask[],
+  snapshot: SurfaceSnapshot,
+  allowedExpectedReads?: Set<string>,
+): GroundedTasksResult {
   const kept: GeneratedTask[] = [];
   const rejected: Array<{ task: GeneratedTask; reason: string }> = [];
 
@@ -11,7 +15,7 @@ export function groundTasks(tasks: GeneratedTask[], snapshot: SurfaceSnapshot): 
   const actions = new Map(snapshot.actions.map((action) => [action.name, action]));
 
   for (const task of tasks) {
-    const rejection = getRejectionReason(task, seenIds, actions, snapshot.surface);
+    const rejection = getRejectionReason(task, seenIds, actions, snapshot.surface, allowedExpectedReads);
     if (rejection) {
       rejected.push({ task, reason: rejection });
       continue;
@@ -29,6 +33,7 @@ function getRejectionReason(
   seenIds: Set<string>,
   actions: Map<string, SurfaceSnapshot['actions'][number]>,
   surface: SurfaceSnapshot['surface'],
+  allowedExpectedReads?: Set<string>,
 ): string | null {
   const expectedActions = task.expected_actions;
   if (seenIds.has(task.id)) {
@@ -74,6 +79,14 @@ function getRejectionReason(
     for (const requiredArg of action.args.filter((arg) => arg.required)) {
       if (!(requiredArg.name in args)) {
         return `task "${task.id}" is missing required param "${requiredArg.name}" for action "${actionName}"`;
+      }
+    }
+  }
+
+  if (allowedExpectedReads) {
+    for (const readPath of task.expected_reads ?? []) {
+      if (!allowedExpectedReads.has(readPath)) {
+        return `task "${task.id}" uses unknown expected_reads path "${readPath}"`;
       }
     }
   }

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -90,7 +90,8 @@ export async function generateTasksForProject(
   console.log(`[optimize] Model proposed ${generated.length} tasks.`);
 
   console.log('[optimize] Grounding generated tasks against the discovered surface snapshot...');
-  const grounded = groundTasks(generated, filteredSurface.snapshot);
+  const allowedExpectedReads = new Set((filteredSurface.skillReferences ?? []).map((reference) => reference.path));
+  const grounded = groundTasks(generated, filteredSurface.snapshot, allowedExpectedReads);
   if (grounded.kept.length === 0) {
     throw new Error('Task generation produced zero valid tasks after grounding');
   }

--- a/src/tasks/types.ts
+++ b/src/tasks/types.ts
@@ -5,6 +5,7 @@ export interface GeneratedTask {
   id: string;
   prompt: string;
   expected_actions: ExpectedAction[];
+  expected_reads?: string[];
   capabilityId?: string;  // prompt surface only; SDK/CLI/MCP don't set this
 }
 
@@ -21,6 +22,7 @@ export interface DiscoveredTaskSurface {
   project: ResolvedProjectConfig;
   skillMarkdown: string;
   skillPath: string;
+  skillReferences?: Array<{ path: string; source: string; content: string }>;
   snapshot: SurfaceSnapshot;
 }
 

--- a/tests/smoke-cli.ts
+++ b/tests/smoke-cli.ts
@@ -424,9 +424,19 @@ await test('skill_read serves only frozen allowed skill references', async () =>
   assert(String(leadingSlash).startsWith('Error:'), 'leading slash variant should not match configured path');
   assertEqual(reads.length, 1, 'unconfigured leading slash variant must not be recorded as successful');
 
+  const repoRelative = await executor('skill_read', { path: '../gws-shared/SKILL.md' });
+  assert(String(repoRelative).includes('Expected shared reference body'), 'repo-relative alias should resolve to companion content');
+  assertEqual(reads.length, 2, 'resolved alias read should be recorded');
+  assertEqual(reads[1], 'gws-shared/SKILL.md', 'alias read should normalize to canonical prompt path');
+
+  const fullPath = await executor('skill_read', { path: '/tmp/references-v1/gws-shared/SKILL.md' });
+  assert(String(fullPath).includes('Expected shared reference body'), 'full-path alias should resolve to companion content');
+  assertEqual(reads.length, 3, 'full-path alias read should be recorded');
+  assertEqual(reads[2], 'gws-shared/SKILL.md', 'full-path alias should normalize to canonical prompt path');
+
   const denied = await executor('skill_read', { path: '../secret.md' });
   assert(String(denied).startsWith('Error:'), 'path traversal read should be rejected');
-  assertEqual(reads.length, 1, 'rejected read must not be recorded as successful');
+  assertEqual(reads.length, 3, 'rejected read must not be recorded as successful');
 });
 
 await test('expected_reads pass/fail helper', () => {

--- a/tests/smoke-cli.ts
+++ b/tests/smoke-cli.ts
@@ -6,6 +6,7 @@ import { extractShellBlock, parseShellCommands, extractFromCliMarkdown } from '.
 import { extract } from '../src/benchmark/extractors/index.js';
 import { loadCliCommands, loadTasks } from '../src/benchmark/config.js';
 import { evaluateTask } from '../src/benchmark/evaluator.js';
+import { buildSystemPrompt } from '../src/benchmark/prompts.js';
 import { createSkillReadExecutor } from '../src/benchmark/runner.js';
 import { evaluateExpectedReads } from '../src/benchmark/read-evaluator.js';
 import { fetchSkill } from '../src/benchmark/skill-fetcher.js';
@@ -402,6 +403,38 @@ await test('fetchSkill keeps reference paths stable for optimized local skill co
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+await test('prompt surface system prompt lists bundled companion files', () => {
+  const systemPrompt = buildSystemPrompt(
+    {
+      version: { source: 'local', commitSha: 'local', ref: 'file', fetchedAt: new Date(0).toISOString() },
+      content: '# Main skill\nRead the references when needed.\n',
+      references: [
+        {
+          path: 'forms.md',
+          source: '/tmp/forms.md',
+          content: '# Forms\n',
+        },
+        {
+          path: 'reference.md',
+          source: '/tmp/reference.md',
+          content: '# Reference\n',
+        },
+      ],
+    },
+    'pdf-skill',
+    {
+      surface: 'prompt',
+      companionSkillPaths: ['forms.md', 'reference.md'],
+    },
+  );
+
+  assert(systemPrompt.includes('# Main skill'), 'prompt surface should still include main skill content');
+  assert(systemPrompt.includes('Companion skill files available:'), 'prompt surface should list bundled companion files');
+  assert(systemPrompt.includes('- forms.md'), 'prompt surface should include forms.md in bundled file list');
+  assert(systemPrompt.includes('- reference.md'), 'prompt surface should include reference.md in bundled file list');
+  assert(systemPrompt.includes('skill_read(path)'), 'prompt surface should mention skill_read for bundled files');
 });
 
 await test('skill_read serves only frozen allowed skill references', async () => {

--- a/tests/smoke-cli.ts
+++ b/tests/smoke-cli.ts
@@ -334,8 +334,9 @@ await test('loadTasks: preserves CLI required flag metadata', () => {
     }), 'utf-8');
 
     const tasks = loadTasks(tasksPath);
-    assertEqual((tasks[0].expected_actions[0] as any).cli.required[0], '--params', 'first required flag should be preserved');
-    assertEqual((tasks[0].expected_actions[0] as any).cli.required[1], '--page-all', 'second required flag should be preserved');
+    const required = tasks[0].expected_actions[0].cli?.required ?? [];
+    assertEqual(required[0], '--params', 'first required flag should be preserved');
+    assertEqual(required[1], '--page-all', 'second required flag should be preserved');
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -359,10 +360,10 @@ await test('fetchSkill loads local companion skill references', async () => {
       source: mainPath,
       references: [sharedPath],
       cache: false,
-    } as any);
+    });
 
     assert(fetched !== null, 'fetchSkill should return skill content');
-    const references = (fetched as any).references as Array<{ path: string; content: string }>;
+    const references = fetched.references ?? [];
     assertEqual(references.length, 1, 'one local reference should be loaded');
     assertEqual(references[0].path, 'gws-shared/SKILL.md', 'reference path should be slash-normalized and stable');
     assert(references[0].content.includes('Expected shared companion text'), 'shared reference content should be loaded');
@@ -394,25 +395,25 @@ await test('fetchSkill keeps reference paths stable for optimized local skill co
       referenceBaseSource: mainPath,
       references: [sharedPath],
       cache: false,
-    } as any);
+    });
 
     assert(fetched !== null, 'fetchSkill should return skill content');
-    assertEqual((fetched as any).references[0].path, 'gws-shared/SKILL.md', 'optimized skill copy should keep original reference path');
+    assertEqual(fetched.references?.[0]?.path, 'gws-shared/SKILL.md', 'optimized skill copy should keep original reference path');
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
 });
 
 await test('skill_read serves only frozen allowed skill references', async () => {
-  const built = (createSkillReadExecutor as any)([
+  const built = createSkillReadExecutor([
     {
       path: 'gws-shared/SKILL.md',
       source: '/tmp/gws-shared/SKILL.md',
       content: 'Expected shared reference body',
     },
   ]);
-  const executor = typeof built === 'function' ? built : built.executor;
-  const reads: string[] = built.reads ?? built.successfulReads ?? built.readPaths ?? [];
+  const { executor } = built;
+  const reads = built.readPaths;
 
   const ok = await executor('skill_read', { path: 'gws-shared/SKILL.md' });
   assert(String(ok).includes('Expected shared reference body'), 'skill_read should return allowed reference content');

--- a/tests/smoke-cli.ts
+++ b/tests/smoke-cli.ts
@@ -1,10 +1,14 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import { extractShellBlock, parseShellCommands, extractFromCliMarkdown } from '../src/benchmark/extractors/cli-extractor.js';
 import { extract } from '../src/benchmark/extractors/index.js';
 import { loadCliCommands } from '../src/benchmark/config.js';
+import { evaluateTask } from '../src/benchmark/evaluator.js';
+import { createSkillReadExecutor } from '../src/benchmark/runner.js';
+import { evaluateExpectedReads } from '../src/benchmark/read-evaluator.js';
+import { fetchSkill } from '../src/benchmark/skill-fetcher.js';
 import type { BenchmarkConfig, LLMResponse } from '../src/benchmark/types.js';
 
 let passed = 0;
@@ -307,6 +311,193 @@ await test('loadCliCommands: rejects entries without command', () => {
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+await test('fetchSkill loads local companion skill references', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'skill-optimizer-skill-'));
+  try {
+    const mainDir = join(dir, 'gws-drive');
+    const sharedDir = join(dir, 'gws-shared');
+    mkdirSync(mainDir, { recursive: true });
+    mkdirSync(sharedDir, { recursive: true });
+
+    const mainPath = join(mainDir, 'SKILL.md');
+    const sharedPath = join(sharedDir, 'SKILL.md');
+
+    writeFileSync(mainPath, '# Main skill\n', 'utf-8');
+    writeFileSync(sharedPath, '# Shared skill\nExpected shared companion text\n', 'utf-8');
+
+    const fetched = await fetchSkill({
+      source: mainPath,
+      references: [sharedPath],
+      cache: false,
+    } as any);
+
+    assert(fetched !== null, 'fetchSkill should return skill content');
+    const references = (fetched as any).references as Array<{ path: string; content: string }>;
+    assertEqual(references.length, 1, 'one local reference should be loaded');
+    assertEqual(references[0].path, 'gws-shared/SKILL.md', 'reference path should be slash-normalized and stable');
+    assert(references[0].content.includes('Expected shared companion text'), 'shared reference content should be loaded');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+await test('skill_read serves only frozen allowed skill references', async () => {
+  const built = (createSkillReadExecutor as any)([
+    {
+      path: 'gws-shared/SKILL.md',
+      source: '/tmp/gws-shared/SKILL.md',
+      content: 'Expected shared reference body',
+    },
+  ]);
+  const executor = typeof built === 'function' ? built : built.executor;
+  const reads: string[] = built.reads ?? built.successfulReads ?? built.readPaths ?? [];
+
+  const ok = await executor('skill_read', { path: 'gws-shared/SKILL.md' });
+  assert(String(ok).includes('Expected shared reference body'), 'skill_read should return allowed reference content');
+  assertEqual(reads.length, 1, 'successful read should be recorded');
+  assertEqual(reads[0], 'gws-shared/SKILL.md', 'successful read path should be tracked');
+
+  const leadingSlash = await executor('skill_read', { path: '/gws-shared/SKILL.md' });
+  assert(String(leadingSlash).startsWith('Error:'), 'leading slash variant should not match configured path');
+  assertEqual(reads.length, 1, 'unconfigured leading slash variant must not be recorded as successful');
+
+  const denied = await executor('skill_read', { path: '../secret.md' });
+  assert(String(denied).startsWith('Error:'), 'path traversal read should be rejected');
+  assertEqual(reads.length, 1, 'rejected read must not be recorded as successful');
+});
+
+await test('expected_reads pass/fail helper', () => {
+  const pass = (evaluateExpectedReads as any)(['a.md', 'b.md'], ['a.md', 'b.md', 'extra.md']);
+  assertEqual(pass.passed, true, 'extra reads should still pass expected read coverage');
+  assertEqual(pass.extra.length, 1, 'extra read should be reported');
+  assertEqual(pass.extra[0], 'extra.md', 'reported extra read should match actual extra path');
+
+  const fail = (evaluateExpectedReads as any)(['a.md', 'b.md'], ['a.md']);
+  assertEqual(fail.passed, false, 'missing expected read should fail');
+  assertEqual(fail.missing.length, 1, 'missing expected read should be reported');
+  assertEqual(fail.missing[0], 'b.md', 'missing read should identify b.md');
+});
+
+await test('CLI required flag normalization passes with mixed required forms', () => {
+  const task = {
+    id: 'cli-required-normalization',
+    prompt: 'List permissions',
+    expected_actions: [
+      {
+        name: 'gws drive permissions list',
+        args: {
+          params: { kind: 'nonempty-string' },
+          'page-all': true,
+        },
+        cli: { required: ['--params', '--page-all'] },
+      },
+    ],
+  } as any;
+
+  const extractedCalls = parseShellCommands(
+    'gws drive permissions list --params "{\"fileId\":\"FILE_ID\"}" --page-all',
+    ['gws drive permissions list'],
+  );
+
+  const taskResult = evaluateTask({
+    task,
+    model: { id: 'm', name: 'm', tier: 'low' },
+    generatedCode: 'gws drive permissions list --params "{\"fileId\":\"FILE_ID\"}" --page-all',
+    rawResponse: 'ok',
+    extractedCalls,
+    llmLatencyMs: 1,
+    knownMethods: new Set(['gws drive permissions list']),
+    surface: 'cli',
+    cliCommands: [
+      {
+        command: 'gws drive permissions list',
+        options: [
+          { name: 'params', takesValue: true },
+          { name: 'page-all', takesValue: false },
+        ],
+      },
+    ],
+  } as any);
+
+  assertEqual(taskResult.metrics.taskPassed, true, 'required CLI flags should be normalized and pass');
+});
+
+await test('CLI rejects unsupported extra flag', () => {
+  const task = {
+    id: 'cli-extra-flag-rejected',
+    prompt: 'Label something',
+    expected_actions: [
+      {
+        name: 'gws drive permissions list',
+        args: {},
+      },
+    ],
+  } as any;
+
+  const extractedCalls = parseShellCommands(
+    'gws drive permissions list --bogus true',
+    ['gws drive permissions list'],
+  );
+
+  const taskResult = evaluateTask({
+    task,
+    model: { id: 'm', name: 'm', tier: 'low' },
+    generatedCode: 'gws drive permissions list --bogus true',
+    rawResponse: 'ok',
+    extractedCalls,
+    llmLatencyMs: 1,
+    knownMethods: new Set(['gws drive permissions list']),
+    surface: 'cli',
+    cliCommands: [
+      {
+        command: 'gws drive permissions list',
+        options: [{ name: 'label', takesValue: true }],
+      },
+    ],
+  } as any);
+
+  assertEqual(taskResult.metrics.taskPassed, false, 'unsupported CLI option should fail task evaluation');
+});
+
+await test('CLI validates nested JSON flag constraints', () => {
+  const task = {
+    id: 'cli-nested-json-constraints',
+    prompt: 'List permissions with page size',
+    expected_actions: [
+      {
+        name: 'gws drive permissions list',
+        args: {
+          'params.pageSize': { kind: 'exact', value: 5 },
+        },
+      },
+    ],
+  } as any;
+
+  const extractedCalls = parseShellCommands(
+    'gws drive permissions list --params \'{"pageSize":5}\'',
+    ['gws drive permissions list'],
+  );
+
+  const taskResult = evaluateTask({
+    task,
+    model: { id: 'm', name: 'm', tier: 'low' },
+    generatedCode: 'gws drive permissions list --params \'{"pageSize":5}\'',
+    rawResponse: 'ok',
+    extractedCalls,
+    llmLatencyMs: 1,
+    knownMethods: new Set(['gws drive permissions list']),
+    surface: 'cli',
+    cliCommands: [
+      {
+        command: 'gws drive permissions list',
+        options: [{ name: 'params', takesValue: true }],
+      },
+    ],
+  } as any);
+
+  assertEqual(taskResult.metrics.taskPassed, true, 'nested JSON constraints should be validated from --params payload');
 });
 
 console.log(`\n${passed} passed, ${failed} failed\n`);

--- a/tests/smoke-cli.ts
+++ b/tests/smoke-cli.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 
 import { extractShellBlock, parseShellCommands, extractFromCliMarkdown } from '../src/benchmark/extractors/cli-extractor.js';
 import { extract } from '../src/benchmark/extractors/index.js';
-import { loadCliCommands } from '../src/benchmark/config.js';
+import { loadCliCommands, loadTasks } from '../src/benchmark/config.js';
 import { evaluateTask } from '../src/benchmark/evaluator.js';
 import { createSkillReadExecutor } from '../src/benchmark/runner.js';
 import { evaluateExpectedReads } from '../src/benchmark/read-evaluator.js';
@@ -313,6 +313,34 @@ await test('loadCliCommands: rejects entries without command', () => {
   }
 });
 
+await test('loadTasks: preserves CLI required flag metadata', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'skill-optimizer-cli-tasks-'));
+  try {
+    const tasksPath = join(dir, 'tasks.json');
+    writeFileSync(tasksPath, JSON.stringify({
+      tasks: [
+        {
+          id: 'cli-required',
+          prompt: 'List permissions.',
+          expected_actions: [
+            {
+              name: 'gws drive permissions list',
+              args: { 'params.fileId': 'FILE_ID' },
+              cli: { required: ['--params', '--page-all'] },
+            },
+          ],
+        },
+      ],
+    }), 'utf-8');
+
+    const tasks = loadTasks(tasksPath);
+    assertEqual((tasks[0].expected_actions[0] as any).cli.required[0], '--params', 'first required flag should be preserved');
+    assertEqual((tasks[0].expected_actions[0] as any).cli.required[1], '--page-all', 'second required flag should be preserved');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 await test('fetchSkill loads local companion skill references', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'skill-optimizer-skill-'));
   try {
@@ -338,6 +366,38 @@ await test('fetchSkill loads local companion skill references', async () => {
     assertEqual(references.length, 1, 'one local reference should be loaded');
     assertEqual(references[0].path, 'gws-shared/SKILL.md', 'reference path should be slash-normalized and stable');
     assert(references[0].content.includes('Expected shared companion text'), 'shared reference content should be loaded');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+await test('fetchSkill keeps reference paths stable for optimized local skill copies', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'skill-optimizer-skill-override-'));
+  try {
+    const mainDir = join(dir, 'repo', 'skills', 'gws-drive');
+    const sharedDir = join(dir, 'repo', 'skills', 'gws-shared');
+    const artifactDir = join(dir, 'artifacts');
+    mkdirSync(mainDir, { recursive: true });
+    mkdirSync(sharedDir, { recursive: true });
+    mkdirSync(artifactDir, { recursive: true });
+
+    const mainPath = join(mainDir, 'SKILL.md');
+    const sharedPath = join(sharedDir, 'SKILL.md');
+    const localCopyPath = join(artifactDir, 'skill-v1.md');
+
+    writeFileSync(mainPath, '# Main skill\n', 'utf-8');
+    writeFileSync(localCopyPath, '# Main skill copy\n', 'utf-8');
+    writeFileSync(sharedPath, '# Shared skill\n', 'utf-8');
+
+    const fetched = await fetchSkill({
+      source: localCopyPath,
+      referenceBaseSource: mainPath,
+      references: [sharedPath],
+      cache: false,
+    } as any);
+
+    assert(fetched !== null, 'fetchSkill should return skill content');
+    assertEqual((fetched as any).references[0].path, 'gws-shared/SKILL.md', 'optimized skill copy should keep original reference path');
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/smoke-generation.ts
+++ b/tests/smoke-generation.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -120,6 +120,38 @@ await test('discoverTaskSurface: resolves and loads skill/snapshot', async () =>
   }
 });
 
+await test('discoverTaskSurface: loads configured companion skill references', async () => {
+  const fixture = makeFixture();
+  try {
+    const sharedDir = join(fixture.root, 'shared');
+    const sharedPath = join(sharedDir, 'SKILL.md');
+    mkdirSync(sharedDir, { recursive: true });
+    writeFileSync(sharedPath, '# Shared reference\nUse --params for resource identifiers.\n', 'utf-8');
+    writeFileSync(fixture.benchmarkConfigPath, JSON.stringify({
+      name: 'gen-smoke',
+      target: {
+        surface: 'mcp',
+        repoPath: '.',
+        skill: { source: './SKILL.md', references: ['./shared/SKILL.md'], cache: false },
+        discovery: { mode: 'auto', sources: ['./server.ts'] },
+      },
+      benchmark: {
+        tasks: './tasks.json',
+        format: 'pi',
+        models: [{ id: 'openai/test', name: 'Test', tier: 'flagship' }],
+      },
+    }, null, 2), 'utf-8');
+
+    const surface = await discoverTaskSurface(fixture.benchmarkConfigPath);
+    const references = (surface as any).skillReferences as Array<{ path: string; content: string }>;
+    assertEqual(references.length, 1, 'one companion reference should be loaded');
+    assertEqual(references[0].path, 'shared/SKILL.md', 'reference path should match benchmark skill_read path');
+    assert(references[0].content.includes('Use --params'), 'reference content should be loaded for task generation');
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
 await test('generateCandidateTasks: parses strict JSON response', async () => {
   const fixture = makeFixture();
   try {
@@ -145,6 +177,56 @@ await test('generateCandidateTasks: parses strict JSON response', async () => {
     // ID is derived from action names (content-stable hash), not the LLM-supplied id field
     assert(/^[0-9a-f]{12}$/.test(generated[0].id), 'task id should be a 12-char hex hash of action names');
     assertEqual(generated[0].prompt, 'Create a wallet named alpha.', 'task prompt should match');
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+await test('generateCandidateTasks: includes references in prompt and preserves expected_reads', async () => {
+  const fixture = makeFixture();
+  try {
+    const sharedDir = join(fixture.root, 'shared');
+    const sharedPath = join(sharedDir, 'SKILL.md');
+    mkdirSync(sharedDir, { recursive: true });
+    writeFileSync(sharedPath, '# Shared reference\nUse --params for resource identifiers.\n', 'utf-8');
+    writeFileSync(fixture.benchmarkConfigPath, JSON.stringify({
+      name: 'gen-smoke',
+      target: {
+        surface: 'mcp',
+        repoPath: '.',
+        skill: { source: './SKILL.md', references: ['./shared/SKILL.md'], cache: false },
+        discovery: { mode: 'auto', sources: ['./server.ts'] },
+      },
+      benchmark: {
+        tasks: './tasks.json',
+        format: 'pi',
+        models: [{ id: 'openai/test', name: 'Test', tier: 'flagship' }],
+      },
+    }, null, 2), 'utf-8');
+
+    const surface = await discoverTaskSurface(fixture.benchmarkConfigPath);
+    const deps: TaskGeneratorDeps = {
+      async complete(input) {
+        assert(input.prompt.includes('Companion skill references'), 'task generator prompt should mention companion references');
+        assert(input.prompt.includes('path="shared/SKILL.md"'), 'task generator prompt should include exact skill_read path');
+        assert(input.prompt.includes('Use --params for resource identifiers.'), 'task generator prompt should include reference content');
+        return JSON.stringify({
+          tasks: [
+            {
+              id: 'task-create',
+              prompt: 'Create a wallet named alpha after reading the shared reference.',
+              expected_reads: ['shared/SKILL.md'],
+              expected_actions: [
+                { name: 'create_wallet', args: { label: 'alpha' } },
+              ],
+            },
+          ],
+        });
+      },
+    };
+
+    const generated = await generateCandidateTasks(surface, { maxTasks: 5, seed: 7 }, deps);
+    assertEqual((generated[0] as any).expected_reads?.[0], 'shared/SKILL.md', 'expected_reads should be preserved');
   } finally {
     rmSync(fixture.root, { recursive: true, force: true });
   }
@@ -274,6 +356,34 @@ await test('groundTasks: rejects unknown methods and invalid args', async () => 
   }
 });
 
+await test('groundTasks: rejects expected_reads outside configured references', async () => {
+  const fixture = makeFixture();
+  try {
+    const surface = await discoverTaskSurface(fixture.benchmarkConfigPath);
+    const tasks: GeneratedTask[] = [
+      {
+        id: 'ok-read-task',
+        prompt: 'Create a wallet after reading allowed reference.',
+        expected_actions: [{ name: 'create_wallet', args: { label: 'alpha' } }],
+        expected_reads: ['shared/SKILL.md'],
+      } as any,
+      {
+        id: 'bad-read-task',
+        prompt: 'Create a wallet after reading forbidden reference.',
+        expected_actions: [{ name: 'create_wallet', args: { label: 'beta' } }],
+        expected_reads: ['../secret.md'],
+      } as any,
+    ];
+
+    const result = groundTasks(tasks, surface.snapshot, new Set(['shared/SKILL.md']) as any);
+    assertEqual(result.kept.length, 1, 'only task with configured expected_reads should remain');
+    assertEqual(result.kept[0].id, 'ok-read-task', 'allowed read task should be kept');
+    assert(result.rejected.some((entry) => entry.reason.includes('unknown expected_reads')), 'should reject unknown expected_reads');
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
 await test('freezeGeneratedBenchmark: writes artifacts and absolute paths', async () => {
   const fixture = makeFixture();
   try {
@@ -334,6 +444,62 @@ await test('freezeGeneratedBenchmark: writes artifacts and absolute paths', asyn
     assertEqual(benchmark.benchmark.tasks, frozen.tasksPath, 'tasks should point at generated tasks path');
     assertEqual(benchmark.benchmark.surfaceSnapshot, frozen.snapshotPath, 'surface snapshot should be pinned in generated config');
     assertEqual(benchmark.optimize, undefined, 'generated benchmark config should omit optimize-only settings');
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+await test('freezeGeneratedBenchmark: preserves skill references and generated expected_reads', async () => {
+  const fixture = makeFixture();
+  try {
+    const sharedDir = join(fixture.root, 'shared');
+    const sharedPath = join(sharedDir, 'SKILL.md');
+    mkdirSync(sharedDir, { recursive: true });
+    writeFileSync(sharedPath, '# Shared reference\n', 'utf-8');
+    writeFileSync(fixture.benchmarkConfigPath, JSON.stringify({
+      name: 'gen-smoke',
+      target: {
+        surface: 'mcp',
+        repoPath: '.',
+        skill: { source: './SKILL.md', references: ['./shared/SKILL.md'], cache: false },
+        discovery: { mode: 'auto', sources: ['./server.ts'] },
+      },
+      benchmark: {
+        tasks: './tasks.json',
+        format: 'pi',
+        models: [{ id: 'openai/test', name: 'Test', tier: 'flagship' }],
+      },
+    }, null, 2), 'utf-8');
+
+    const outDir = join(fixture.root, 'generated');
+    const kept: GeneratedTask[] = [
+      {
+        id: 'frozen-task',
+        prompt: 'Create wallet after reading shared reference.',
+        expected_reads: ['shared/SKILL.md'],
+        expected_actions: [{ name: 'create_wallet', args: { label: 'frozen' } }],
+      } as any,
+    ];
+
+    const surface = await discoverTaskSurface(fixture.benchmarkConfigPath);
+    const frozen = freezeTaskArtifacts({
+      project: surface.project,
+      snapshot: surface.snapshot,
+      outputDir: outDir,
+      kept,
+      rejected: [],
+    });
+
+    const benchmark = JSON.parse(readFileSync(frozen.benchmarkPath, 'utf-8')) as {
+      target: { skill: { references?: string[] } };
+    };
+    const tasks = JSON.parse(readFileSync(frozen.tasksPath, 'utf-8')) as {
+      tasks: Array<{ expected_reads?: string[] }>;
+    };
+
+    assertEqual(benchmark.target.skill.references?.length, 1, 'skill references should be preserved in generated config');
+    assert(benchmark.target.skill.references![0].endsWith('/shared/SKILL.md'), 'skill reference should remain absolute in generated config');
+    assertEqual(tasks.tasks[0].expected_reads?.[0], 'shared/SKILL.md', 'generated tasks should preserve expected_reads');
   } finally {
     rmSync(fixture.root, { recursive: true, force: true });
   }

--- a/tests/smoke-generation.ts
+++ b/tests/smoke-generation.ts
@@ -193,7 +193,12 @@ await test('generateCandidateTasks: includes references in prompt and preserves 
     const surface = await discoverTaskSurface(fixture.benchmarkConfigPath);
     const deps: TaskGeneratorDeps = {
       async complete(input) {
+        assert(input.system.includes('benchmark dataset designer'), 'task generator system prompt should set benchmark-dataset role');
+        assert(input.prompt.includes('<dataset_quality_bar>'), 'task generator prompt should define eval dataset quality criteria');
+        assert(input.prompt.includes('<good_examples>'), 'task generator prompt should include few-shot valid task examples');
+        assert(input.prompt.includes('<final_self_check>'), 'task generator prompt should include a final self-check before JSON output');
         assert(input.prompt.includes('Companion skill references'), 'task generator prompt should mention companion references');
+        assert(input.prompt.includes('skill_read(path)'), 'task generator prompt should preserve exact skill_read(path) guidance');
         assert(input.prompt.includes('path="shared/SKILL.md"'), 'task generator prompt should include exact skill_read path');
         assert(input.prompt.includes('Use --params for resource identifiers.'), 'task generator prompt should include reference content');
         return JSON.stringify({
@@ -723,7 +728,10 @@ await test('prompt surface: generator tags tasks with capabilityId', async () =>
 
     const { summarize, translate } = fixture.capabilityKeys;
     const deps: TaskGeneratorDeps = {
-      async complete() {
+      async complete(input) {
+        assert(input.prompt.includes('<dataset_quality_bar>'), 'prompt-surface task generator prompt should define eval dataset quality criteria');
+        assert(input.prompt.includes('<prompt_surface_rules>'), 'prompt-surface task generator prompt should include prompt-specific rules');
+        assert(input.prompt.includes('<final_self_check>'), 'prompt-surface task generator prompt should include a final self-check');
         return JSON.stringify({
           tasks: [
             {

--- a/tests/smoke-generation.ts
+++ b/tests/smoke-generation.ts
@@ -105,6 +105,26 @@ function makeFixture(): {
   return { root, benchmarkConfigPath, skillPath, sourcePath };
 }
 
+function addSharedReference(fixture: ReturnType<typeof makeFixture>, content = '# Shared reference\nUse --params for resource identifiers.\n'): void {
+  const sharedDir = join(fixture.root, 'shared');
+  mkdirSync(sharedDir, { recursive: true });
+  writeFileSync(join(sharedDir, 'SKILL.md'), content, 'utf-8');
+  writeFileSync(fixture.benchmarkConfigPath, JSON.stringify({
+    name: 'gen-smoke',
+    target: {
+      surface: 'mcp',
+      repoPath: '.',
+      skill: { source: './SKILL.md', references: ['./shared/SKILL.md'], cache: false },
+      discovery: { mode: 'auto', sources: ['./server.ts'] },
+    },
+    benchmark: {
+      tasks: './tasks.json',
+      format: 'pi',
+      models: [{ id: 'openai/test', name: 'Test', tier: 'flagship' }],
+    },
+  }, null, 2), 'utf-8');
+}
+
 console.log('\n=== Task Generation Smoke Tests ===\n');
 
 await test('discoverTaskSurface: resolves and loads skill/snapshot', async () => {
@@ -123,27 +143,10 @@ await test('discoverTaskSurface: resolves and loads skill/snapshot', async () =>
 await test('discoverTaskSurface: loads configured companion skill references', async () => {
   const fixture = makeFixture();
   try {
-    const sharedDir = join(fixture.root, 'shared');
-    const sharedPath = join(sharedDir, 'SKILL.md');
-    mkdirSync(sharedDir, { recursive: true });
-    writeFileSync(sharedPath, '# Shared reference\nUse --params for resource identifiers.\n', 'utf-8');
-    writeFileSync(fixture.benchmarkConfigPath, JSON.stringify({
-      name: 'gen-smoke',
-      target: {
-        surface: 'mcp',
-        repoPath: '.',
-        skill: { source: './SKILL.md', references: ['./shared/SKILL.md'], cache: false },
-        discovery: { mode: 'auto', sources: ['./server.ts'] },
-      },
-      benchmark: {
-        tasks: './tasks.json',
-        format: 'pi',
-        models: [{ id: 'openai/test', name: 'Test', tier: 'flagship' }],
-      },
-    }, null, 2), 'utf-8');
+    addSharedReference(fixture);
 
     const surface = await discoverTaskSurface(fixture.benchmarkConfigPath);
-    const references = (surface as any).skillReferences as Array<{ path: string; content: string }>;
+    const references = surface.skillReferences ?? [];
     assertEqual(references.length, 1, 'one companion reference should be loaded');
     assertEqual(references[0].path, 'shared/SKILL.md', 'reference path should match benchmark skill_read path');
     assert(references[0].content.includes('Use --params'), 'reference content should be loaded for task generation');
@@ -185,24 +188,7 @@ await test('generateCandidateTasks: parses strict JSON response', async () => {
 await test('generateCandidateTasks: includes references in prompt and preserves expected_reads', async () => {
   const fixture = makeFixture();
   try {
-    const sharedDir = join(fixture.root, 'shared');
-    const sharedPath = join(sharedDir, 'SKILL.md');
-    mkdirSync(sharedDir, { recursive: true });
-    writeFileSync(sharedPath, '# Shared reference\nUse --params for resource identifiers.\n', 'utf-8');
-    writeFileSync(fixture.benchmarkConfigPath, JSON.stringify({
-      name: 'gen-smoke',
-      target: {
-        surface: 'mcp',
-        repoPath: '.',
-        skill: { source: './SKILL.md', references: ['./shared/SKILL.md'], cache: false },
-        discovery: { mode: 'auto', sources: ['./server.ts'] },
-      },
-      benchmark: {
-        tasks: './tasks.json',
-        format: 'pi',
-        models: [{ id: 'openai/test', name: 'Test', tier: 'flagship' }],
-      },
-    }, null, 2), 'utf-8');
+    addSharedReference(fixture);
 
     const surface = await discoverTaskSurface(fixture.benchmarkConfigPath);
     const deps: TaskGeneratorDeps = {
@@ -226,7 +212,7 @@ await test('generateCandidateTasks: includes references in prompt and preserves 
     };
 
     const generated = await generateCandidateTasks(surface, { maxTasks: 5, seed: 7 }, deps);
-    assertEqual((generated[0] as any).expected_reads?.[0], 'shared/SKILL.md', 'expected_reads should be preserved');
+    assertEqual(generated[0].expected_reads?.[0], 'shared/SKILL.md', 'expected_reads should be preserved');
   } finally {
     rmSync(fixture.root, { recursive: true, force: true });
   }
@@ -366,16 +352,16 @@ await test('groundTasks: rejects expected_reads outside configured references', 
         prompt: 'Create a wallet after reading allowed reference.',
         expected_actions: [{ name: 'create_wallet', args: { label: 'alpha' } }],
         expected_reads: ['shared/SKILL.md'],
-      } as any,
+      },
       {
         id: 'bad-read-task',
         prompt: 'Create a wallet after reading forbidden reference.',
         expected_actions: [{ name: 'create_wallet', args: { label: 'beta' } }],
         expected_reads: ['../secret.md'],
-      } as any,
+      },
     ];
 
-    const result = groundTasks(tasks, surface.snapshot, new Set(['shared/SKILL.md']) as any);
+    const result = groundTasks(tasks, surface.snapshot, new Set(['shared/SKILL.md']));
     assertEqual(result.kept.length, 1, 'only task with configured expected_reads should remain');
     assertEqual(result.kept[0].id, 'ok-read-task', 'allowed read task should be kept');
     assert(result.rejected.some((entry) => entry.reason.includes('unknown expected_reads')), 'should reject unknown expected_reads');
@@ -452,24 +438,7 @@ await test('freezeGeneratedBenchmark: writes artifacts and absolute paths', asyn
 await test('freezeGeneratedBenchmark: preserves skill references and generated expected_reads', async () => {
   const fixture = makeFixture();
   try {
-    const sharedDir = join(fixture.root, 'shared');
-    const sharedPath = join(sharedDir, 'SKILL.md');
-    mkdirSync(sharedDir, { recursive: true });
-    writeFileSync(sharedPath, '# Shared reference\n', 'utf-8');
-    writeFileSync(fixture.benchmarkConfigPath, JSON.stringify({
-      name: 'gen-smoke',
-      target: {
-        surface: 'mcp',
-        repoPath: '.',
-        skill: { source: './SKILL.md', references: ['./shared/SKILL.md'], cache: false },
-        discovery: { mode: 'auto', sources: ['./server.ts'] },
-      },
-      benchmark: {
-        tasks: './tasks.json',
-        format: 'pi',
-        models: [{ id: 'openai/test', name: 'Test', tier: 'flagship' }],
-      },
-    }, null, 2), 'utf-8');
+    addSharedReference(fixture, '# Shared reference\n');
 
     const outDir = join(fixture.root, 'generated');
     const kept: GeneratedTask[] = [
@@ -478,7 +447,7 @@ await test('freezeGeneratedBenchmark: preserves skill references and generated e
         prompt: 'Create wallet after reading shared reference.',
         expected_reads: ['shared/SKILL.md'],
         expected_actions: [{ name: 'create_wallet', args: { label: 'frozen' } }],
-      } as any,
+      },
     ];
 
     const surface = await discoverTaskSurface(fixture.benchmarkConfigPath);

--- a/tests/smoke-optimize.ts
+++ b/tests/smoke-optimize.ts
@@ -583,6 +583,79 @@ await test('runOptimizeLoop: applies defaults to partially specified manifests',
   assertEqual(result.iterations[0]?.accepted, true, 'default minImprovement should still allow acceptance');
 });
 
+await test('runOptimizeLoop: local skill mode versions companion references', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'skill-optimizer-local-refs-'));
+  try {
+    const repoDir = join(dir, 'repo');
+    const outputDir = join(dir, 'artifacts');
+    const skillPath = join(repoDir, 'skills', 'main', 'SKILL.md');
+    const refPath = join(repoDir, 'skills', 'shared', 'SKILL.md');
+    mkdirSync(join(repoDir, 'skills', 'main'), { recursive: true });
+    mkdirSync(join(repoDir, 'skills', 'shared'), { recursive: true });
+    writeFileSync(skillPath, '# Main skill\nRead the shared skill.\n', 'utf-8');
+    writeFileSync(refPath, '# Shared skill\nOriginal params guidance.\n', 'utf-8');
+
+    const manifest = makeManifest() as OptimizeManifest & {
+      skillPath: string;
+      skillReferences: Array<{ source: string; promptPath: string }>;
+    };
+    manifest.skillPath = skillPath;
+    manifest.skillReferences = [{ source: refPath, promptPath: 'shared/SKILL.md' }];
+    manifest.targetRepo.path = repoDir;
+    manifest.optimizer!.maxIterations = 1;
+    manifest.optimizer!.minImprovement = 0;
+    manifest.optimizer!.taskGeneration!.outputDir = outputDir;
+
+    const benchmarkReferenceContents: string[] = [];
+    const deps: OptimizeLoopDependencies = {
+      benchmark: {
+        run: async (_configPath, opts) => {
+          const referenceOverride = opts.skillReferenceOverrides?.[0];
+          assert(referenceOverride !== undefined, `${opts.label} should pass a local reference override`);
+          assertEqual(referenceOverride.promptPath, 'shared/SKILL.md', 'reference prompt path should stay stable');
+          benchmarkReferenceContents.push(readFileSync(referenceOverride.source, 'utf-8'));
+          const score = opts.label === 'baseline' ? 0.1 : 0.5;
+          return makeBenchmarkRunResult(makeReport(score), opts);
+        },
+      },
+      repo: {
+        ensureReady: async () => 'clean',
+        captureCheckpoint: async () => 'checkpoint-1',
+        restoreCheckpoint: async () => {},
+        updateAcceptedCheckpoint: async () => 'checkpoint-2',
+      },
+      mutation: {
+        apply: async (context) => {
+          const localReferences = context.localSkillReferences ?? [];
+          assertEqual(localReferences.length, 1, 'mutation context should include one editable local reference');
+          assert(localReferences[0]!.localPath.includes('references-v1'), 'iteration should use a versioned local reference copy');
+          writeFileSync(localReferences[0]!.localPath, '# Shared skill\nImproved params guidance.\n', 'utf-8');
+          return { summary: 'update shared reference', changedFiles: [localReferences[0]!.localPath] };
+        },
+      },
+      validation: {
+        run: async () => ({ ok: true, commands: [] }),
+      },
+      ledger: {
+        record: async () => {},
+      },
+    };
+
+    const result = await runOptimizeLoop(manifest, deps);
+    assertEqual(result.iterations[0]?.accepted, true, 'reference-only edit should be accepted when score improves');
+    assertEqual(result.iterations[0]?.changedFiles.length, 1, 'changed files should only include the file actually edited');
+    assert(result.iterations[0]?.changedFiles[0]?.includes('references-v1'), 'changed files should include the edited local reference copy');
+    assertEqual(result.iterations[0]?.editableFiles?.length, 2, 'editable files should expose the whole local skill bundle');
+    assert(result.iterations[0]?.editableFiles?.some((file) => file.endsWith('skill-v1.md')), 'editable files should include the primary local skill copy');
+    assert(result.iterations[0]?.editableFiles?.some((file) => file.includes('references-v1')), 'editable files should include the local reference copy');
+    assert(benchmarkReferenceContents[0]!.includes('Original params guidance'), 'baseline should benchmark original local reference copy');
+    assert(benchmarkReferenceContents[1]!.includes('Improved params guidance'), 'iteration should benchmark edited local reference copy');
+    assert(readFileSync(refPath, 'utf-8').includes('Original params guidance'), 'target repo reference file must remain untouched');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 await test('runOptimizeLoop: rejects requireCleanGit=false even for programmatic manifests', async () => {
   const manifest = makeManifest();
   manifest.targetRepo.requireCleanGit = false;


### PR DESCRIPTION
## Summary
- Adds exact-path bundled skill references through `skill_read(path)` and scores required `expected_reads`.
- Tightens CLI action evaluation for required flags, unsupported flags, and nested JSON args.
- Improves generated benchmark task prompts with clearer quality criteria, examples, and reference-aware guidance.

## Verification
- `npm test`
- `npx tsx tests/smoke-generation.ts`
- `npx tsx tests/smoke-cli.ts`
- `npm run typecheck`

Refs #34