### PR TITLE
eval(workbench): web-design-guidelines eval suite + proposed upstream changes

### DIFF
--- a/examples/workbench/web-design-guidelines/README.md
+++ b/examples/workbench/web-design-guidelines/README.md
@@ -1,0 +1,81 @@
+# web-design-guidelines eval
+
+Eval suite for [`vercel-labs/agent-skills/web-design-guidelines`](https://github.com/vercel-labs/agent-skills) — a skill that reviews UI files for Vercel Web Interface Guidelines compliance.
+
+## Cases
+
+Each case runs the skill on a focused TSX sample with seeded violations and
+grades whether the agent's findings cover them. We split coverage across files
+to mirror real usage (a developer reviews one file at a time, not a kitchen
+sink) and to avoid overwhelming smaller models.
+
+### `review-product-card` — Accessibility + Focus States
+
+Sample: `workspace/ProductCard.tsx`
+
+| Line | Violation | Rule |
+|---|---|---|
+| 15 | `<img>` without `alt` | Images need `alt` (or `alt=""` if decorative) |
+| 18 | `<div onClick>` for action | `<button>` for actions, not `<div onClick>` |
+| 21–23 | Icon-only `<button>` without `aria-label` | Icon-only buttons need `aria-label` |
+| 24–29 | `<input>` without `<label>` or `aria-label` | Form controls need `<label>` or `aria-label` |
+| 30–32 | `outline-none` className without focus replacement | Never `outline-none` without focus replacement |
+
+### `review-checkout-form` — Forms
+
+Sample: `workspace/CheckoutForm.tsx`
+
+| Line | Violation | Rule |
+|---|---|---|
+| 17 | `<label>` without `htmlFor` | Labels clickable (`htmlFor` or wrapping control) |
+| 18–25 | `<input>` for email uses `type="text"` | Use correct `type` (`email`, `tel`, `url`, `number`) |
+| 18–25 | `<input>` missing `autoComplete` | Inputs need `autocomplete` and meaningful `name` |
+| 24 | `onPaste={(e) => e.preventDefault()}` | Never block paste |
+| 30 | Submit button `disabled` before request starts | Submit stays enabled until request starts |
+
+### `review-loading-screen` — Typography + Content Handling
+
+Sample: `workspace/LoadingScreen.tsx`
+
+| Line | Violation | Rule |
+|---|---|---|
+| 12 | `"Loading..."` (three dots, not `…`) | `…` not `...`; loading states end with `…` |
+| 13 | Straight quotes `"..."` | Curly quotes `"..."` not straight |
+| 14 | `{fileSize} MB` without `&nbsp;` | Non-breaking spaces between number and unit |
+| 15–18 | Flex children without `min-w-0` for `truncate` | Flex children need `min-w-0` |
+| 19–23 | `recentFiles.map(...)` no empty-state branch | Handle empty states |
+
+### `review-hero-section` — Animation + Images + Performance
+
+Sample: `workspace/HeroSection.tsx`
+
+| Line | Violation | Rule |
+|---|---|---|
+| 6 | Above-fold `<img>` missing `width`/`height` | `<img>` needs explicit `width` and `height` (CLS) |
+| 6 | Above-fold `<img>` missing `priority`/`fetchpriority="high"` | Above-fold critical images need priority hint |
+| 7–10 | `transition: 'all'` | Never `transition: all` — list properties explicitly |
+| 15–18 | Animation without `prefers-reduced-motion` consideration | Honor `prefers-reduced-motion` |
+| 23 | Below-fold `<img>` missing `loading="lazy"` | Below-fold images need `loading="lazy"` |
+
+## Vendored snapshot
+
+The skill normally `WebFetch`es its rules from `vercel-labs/web-interface-guidelines`. For deterministic eval, we vendor a snapshot at `references/web-design-guidelines/command.md` and tweak `SKILL.md` to read the local copy. The diff vs upstream is one section (`Guidelines Source` → local file).
+
+## Run
+
+```bash
+export OPENROUTER_API_KEY=sk-or-...
+npx tsx src/cli.ts run-suite examples/workbench/web-design-guidelines/suite.yml --trials 3
+```
+
+## Models
+
+The suite is set up for a 3-provider mid-tier matrix:
+
+- `openrouter/anthropic/claude-sonnet-4.6`
+- `openrouter/openai/gpt-5-mini`
+- `openrouter/google/gemini-2.5-pro`
+
+## Graders
+
+One grader per case under `checks/`. Each reads `/work/findings.txt`, extracts every `<file>.tsx:<line>` reference, and confirms each expected violation is identified by both line number (within an accepted range for multi-line elements) and a keyword match. `pass` requires all expected violations; `score` is the fraction found.

--- a/examples/workbench/web-design-guidelines/README.md
+++ b/examples/workbench/web-design-guidelines/README.md
@@ -4,10 +4,7 @@ Eval suite for [`vercel-labs/agent-skills/web-design-guidelines`](https://github
 
 ## Cases
 
-Each case runs the skill on a focused TSX sample with seeded violations and
-grades whether the agent's findings cover them. We split coverage across files
-to mirror real usage (a developer reviews one file at a time, not a kitchen
-sink) and to avoid overwhelming smaller models.
+Nine cases, ~5 seeded violations each, one TSX sample per case. Each case targets a focused rule family so the agent isn't overwhelmed and we can isolate which families it handles well vs. poorly.
 
 ### `review-product-card` — Accessibility + Focus States
 
@@ -57,6 +54,66 @@ Sample: `workspace/HeroSection.tsx`
 | 15–18 | Animation without `prefers-reduced-motion` consideration | Honor `prefers-reduced-motion` |
 | 23 | Below-fold `<img>` missing `loading="lazy"` | Below-fold images need `loading="lazy"` |
 
+### `review-data-table` — Performance + Typography + Content & Copy
+
+Sample: `workspace/DataTable.tsx`
+
+| Line | Violation | Rule |
+|---|---|---|
+| 15–17 | `getBoundingClientRect` in render | No layout reads in render |
+| 32–38 | Large list `.map()` without virtualization | Large lists (>50 items): virtualize |
+| 27–36 | Numeric columns without `tabular-nums` | `font-variant-numeric: tabular-nums` for number columns |
+| 21 | `<h2>` without `text-balance`/`text-pretty` | Use `text-wrap: balance` or `text-pretty` on headings |
+| 22 | "eight projects" spelled out | Numerals for counts ("8 projects" not "eight projects") |
+
+### `review-confirm-dialog` — Touch & Interaction + Safe Areas + Hover States
+
+Sample: `workspace/ConfirmDialog.tsx`
+
+| Line | Violation | Rule |
+|---|---|---|
+| 11–35 | Modal without `overscroll-behavior: contain` | Prevent scroll bleed to page behind |
+| 11–35 | Modal without `touch-action: manipulation` | Prevent double-tap zoom delay |
+| 11–35 | No `env(safe-area-inset-*)` for notched devices | Full-bleed layouts need safe-area-inset |
+| 26 | `autoFocus` on a non-primary confirmation input | `autoFocus` sparingly — desktop, single primary input |
+| 31–32 | Action buttons without `hover:` state | Buttons need hover state |
+
+### `review-search-page` — Navigation & State + Locale & i18n
+
+Sample: `workspace/SearchPage.tsx`
+
+| Line | Violation | Rule |
+|---|---|---|
+| 11–12 | Filter/page state in `useState` only, no URL sync | URL reflects state |
+| 31 | Hardcoded currency: `${r.price.toFixed(2)}` | Use `Intl.NumberFormat` for currency |
+| 32 | Hardcoded date: `r.publishedAt.toDateString()` | Use `Intl.DateTimeFormat` |
+| 20 | "Acme Cloud" brand without `translate="no"` | Brand names need `translate="no"` |
+| 33 | `Delete` button with no confirmation | Destructive actions need confirmation modal or undo window |
+
+### `review-theme-toggle` — Hydration Safety + Dark Mode + Hover
+
+Sample: `workspace/ThemeToggle.tsx`
+
+| Line | Violation | Rule |
+|---|---|---|
+| 7 | `localStorage.getItem` directly in render body | Hydration mismatch risk |
+| 25 | `<input value={accentColor}>` no `onChange` | Controlled inputs need `onChange` |
+| 14–22 | Native `<select>` no explicit `background-color`/`color` | Windows dark mode requires both |
+| 27 | `<button>` without `hover:` state | Buttons need hover state |
+| 14–27 | No `focus-visible:ring-*` anywhere | Use `:focus-visible` over `:focus` |
+
+### `review-blog-post` — Heading hierarchy + Aria + Focus + Content & Copy
+
+Sample: `workspace/BlogPost.tsx`
+
+| Line | Violation | Rule |
+|---|---|---|
+| 11–13 | `<h1>` → `<h3>` (skips `<h2>`) | Headings hierarchical |
+| 17–19 | Decorative `<svg>` without `aria-hidden="true"` | Decorative icons need `aria-hidden` |
+| 25–28 | Toast div without `aria-live="polite"` | Async updates need `aria-live` |
+| 23 | Generic button label "Continue" | Specific button labels |
+| 23 | `focus:ring-2` instead of `focus-visible:ring-2` | Use `:focus-visible` over `:focus` |
+
 ## Vendored snapshot
 
 The skill normally `WebFetch`es its rules from `vercel-labs/web-interface-guidelines`. For deterministic eval, we vendor a snapshot at `references/web-design-guidelines/command.md` and tweak `SKILL.md` to read the local copy. The diff vs upstream is one section (`Guidelines Source` → local file).
@@ -65,17 +122,38 @@ The skill normally `WebFetch`es its rules from `vercel-labs/web-interface-guidel
 
 ```bash
 export OPENROUTER_API_KEY=sk-or-...
-npx tsx src/cli.ts run-suite examples/workbench/web-design-guidelines/suite.yml --trials 3
+npx tsx ../../../src/cli.ts run-suite ./suite.yml --trials 3
 ```
 
 ## Models
 
-The suite is set up for a 3-provider mid-tier matrix:
+The suite runs a 3-provider mid-tier matrix:
 
 - `openrouter/anthropic/claude-sonnet-4.6`
 - `openrouter/openai/gpt-5-mini`
 - `openrouter/google/gemini-2.5-pro`
 
+## Latest results (9 cases × 3 models × 3 trials = 81 trials)
+
+| Metric | Value |
+|---|---|
+| Strict pass rate (all 5/5 per case) | 42/81 (52%) |
+| **Rule coverage rate** (violations identified / seeded) | **334/405 (82%)** |
+| Run cost | ~$5 |
+
+Per-case rule coverage: product-card 100%, checkout-form 98%, hero-section 100%, blog-post 87%, loading-screen 82%, data-table 80%, theme-toggle 69%, search-page 64%, confirm-dialog 62%.
+
+Strict pass dropped vs. the original 4-case suite because the 5 new cases cover **harder absence-type rules** (touch-action, safe-area-inset, brand `translate="no"`, etc.) that even the updated skill doesn't always catch. Rule-coverage 82% is the load-bearing metric.
+
+## Coverage of upstream `command.md`
+
+| Status | Rules |
+|---|---|
+| ✅ Graded across 9 cases | ~45 of 81 |
+| ⚠️ Skip (subjective / framework-bound / overlap) | ~36 of 81 |
+
+See [`proposed-upstream-changes/`](proposed-upstream-changes/) for the team's review of the SKILL.md + command.md changes we'd PR back.
+
 ## Graders
 
-One grader per case under `checks/`. Each reads `/work/findings.txt`, extracts every `<file>.tsx:<line>` reference, and confirms each expected violation is identified by both line number (within an accepted range for multi-line elements) and a keyword match. `pass` requires all expected violations; `score` is the fraction found.
+One grader per case under `checks/`, all sharing `_grader-utils.mjs`. Each reads `/work/findings.txt`, parses every `<file>.tsx:<line>` reference, and confirms each expected violation appears as one finding line that mentions a line in the accepted range AND matches a distinguishing keyword. `pass` requires all expected violations; `score` is the fraction found.

--- a/examples/workbench/web-design-guidelines/checks/_grader-utils.mjs
+++ b/examples/workbench/web-design-guidelines/checks/_grader-utils.mjs
@@ -1,0 +1,70 @@
+// Shared grader logic for web-design-guidelines eval cases.
+//
+// Each finding is assumed to be one line in findings.txt that references
+// "<File>.tsx:<line>" (line numbers come from the agent — they're often
+// off by ±1-2 due to LLM line-counting). A violation is considered "found"
+// when at least one finding line:
+//   (a) references a line number within the violation's accepted range, AND
+//   (b) contains at least one of the violation's distinguishing keywords.
+//
+// This per-finding-line check prevents spurious cross-matches (e.g. the
+// keyword "label" from a different finding being credited to a paste rule).
+
+import { existsSync, readFileSync } from 'node:fs';
+
+export function gradeFindings({ findingsPath, file, expected }) {
+  const failures = [];
+  const found = new Set();
+
+  if (!existsSync(findingsPath)) {
+    failures.push('findings.txt was not created');
+    return emitResult({ found, expected, failures });
+  }
+
+  const text = readFileSync(findingsPath, 'utf-8');
+  const refRe = new RegExp(`${escapeRe(file)}\\s*[:#]\\s*(\\d+)`, 'i');
+  const findingLines = text.split(/\r?\n/).filter((ln) => refRe.test(ln));
+
+  for (const v of expected) {
+    for (const line of findingLines) {
+      const m = line.match(refRe);
+      if (!m) continue;
+      const lineNum = Number(m[1]);
+      if (!v.lines.includes(lineNum)) continue;
+      if (!v.keywords.some((re) => re.test(line))) continue;
+      found.add(v.id);
+      break;
+    }
+  }
+
+  return emitResult({ found, expected, failures });
+}
+
+function emitResult({ found, expected, failures }) {
+  const missing = expected.filter((v) => !found.has(v.id)).map((v) => v.id);
+  const score = found.size / expected.length;
+  const pass = found.size === expected.length;
+
+  console.log(JSON.stringify({
+    pass,
+    score,
+    evidence: [
+      `${found.size}/${expected.length} expected violations identified`,
+      ...[...found].map((id) => `+ ${id}`),
+      ...missing.map((id) => `- missing: ${id}`),
+      ...failures,
+    ],
+  }));
+  return pass;
+}
+
+function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Helper: build an inclusive line range [start, start+1, ..., end].
+export function range(start, end) {
+  const out = [];
+  for (let i = start; i <= end; i++) out.push(i);
+  return out;
+}

--- a/examples/workbench/web-design-guidelines/checks/grade-a11y-findings.mjs
+++ b/examples/workbench/web-design-guidelines/checks/grade-a11y-findings.mjs
@@ -1,0 +1,37 @@
+import { join } from 'node:path';
+import { gradeFindings, range } from './_grader-utils.mjs';
+
+const expected = [
+  {
+    id: 'img-missing-alt',
+    lines: range(13, 17),
+    keywords: [/\balt\b/i, /\bimg\b/i],
+  },
+  {
+    id: 'div-onclick-instead-of-button',
+    lines: range(16, 22),
+    keywords: [/\bdiv\b.*\bonclick\b|\bonclick\b.*\bdiv\b/i, /<button>|\bbutton\b/i],
+  },
+  {
+    id: 'icon-only-button-no-aria-label',
+    lines: range(19, 25),
+    keywords: [/aria-label/i, /icon-only/i],
+  },
+  {
+    id: 'input-without-label',
+    lines: range(22, 31),
+    keywords: [/\blabel\b/i, /aria-label/i],
+  },
+  {
+    id: 'outline-none-no-focus',
+    lines: range(28, 34),
+    keywords: [/outline-?none/i, /\bfocus\b/i],
+  },
+];
+
+const pass = gradeFindings({
+  findingsPath: join(process.env.WORK, 'findings.txt'),
+  file: 'ProductCard.tsx',
+  expected,
+});
+process.exit(pass ? 0 : 1);

--- a/examples/workbench/web-design-guidelines/checks/grade-animation-findings.mjs
+++ b/examples/workbench/web-design-guidelines/checks/grade-animation-findings.mjs
@@ -1,0 +1,37 @@
+import { join } from 'node:path';
+import { gradeFindings, range } from './_grader-utils.mjs';
+
+const expected = [
+  {
+    id: 'img-missing-width-height',
+    lines: range(4, 8),
+    keywords: [/\bwidth\b/i, /\bheight\b/i, /\bcls\b|layout\s*shift/i],
+  },
+  {
+    id: 'above-fold-img-missing-priority',
+    lines: range(4, 8),
+    keywords: [/\bpriority\b/i, /fetchpriority/i],
+  },
+  {
+    id: 'transition-all',
+    lines: range(5, 12),
+    keywords: [/transition.*all|transition:\s*['"]?all/i],
+  },
+  {
+    id: 'animation-no-prefers-reduced-motion',
+    lines: range(13, 20),
+    keywords: [/prefers-?reduced-?motion|reduce[d-]?motion/i],
+  },
+  {
+    id: 'below-fold-img-missing-lazy',
+    lines: range(21, 25),
+    keywords: [/\blazy\b|loading=['"]?lazy/i],
+  },
+];
+
+const pass = gradeFindings({
+  findingsPath: join(process.env.WORK, 'findings.txt'),
+  file: 'HeroSection.tsx',
+  expected,
+});
+process.exit(pass ? 0 : 1);

--- a/examples/workbench/web-design-guidelines/checks/grade-blog-post-findings.mjs
+++ b/examples/workbench/web-design-guidelines/checks/grade-blog-post-findings.mjs
@@ -1,0 +1,37 @@
+import { join } from 'node:path';
+import { gradeFindings, range } from './_grader-utils.mjs';
+
+const expected = [
+  {
+    id: 'heading-skip-level',
+    lines: range(11, 15),
+    keywords: [/heading\s*hierarch|skip[-\s]?level|h1.*h3|h3.*h1|missing\s*h2|level/i],
+  },
+  {
+    id: 'decorative-icon-no-aria-hidden',
+    lines: range(15, 21),
+    keywords: [/aria-hidden|decorative\s*(icon|svg)/i],
+  },
+  {
+    id: 'toast-no-aria-live',
+    lines: range(24, 30),
+    keywords: [/aria-live|role=['"]?status|live\s*region/i],
+  },
+  {
+    id: 'generic-button-label',
+    lines: range(21, 25),
+    keywords: [/specific\s*(button\s*)?label|generic\s*(button\s*)?label|"continue"|\bcontinue\b\s*(label|button)/i],
+  },
+  {
+    id: 'focus-not-focus-visible',
+    lines: range(21, 25),
+    keywords: [/focus-visible/i],
+  },
+];
+
+const pass = gradeFindings({
+  findingsPath: join(process.env.WORK, 'findings.txt'),
+  file: 'BlogPost.tsx',
+  expected,
+});
+process.exit(pass ? 0 : 1);

--- a/examples/workbench/web-design-guidelines/checks/grade-confirm-dialog-findings.mjs
+++ b/examples/workbench/web-design-guidelines/checks/grade-confirm-dialog-findings.mjs
@@ -1,0 +1,37 @@
+import { join } from 'node:path';
+import { gradeFindings, range } from './_grader-utils.mjs';
+
+const expected = [
+  {
+    id: 'modal-no-overscroll-behavior',
+    lines: range(9, 35),
+    keywords: [/overscroll/i],
+  },
+  {
+    id: 'missing-touch-action',
+    lines: range(9, 35),
+    keywords: [/touch-action/i],
+  },
+  {
+    id: 'missing-safe-area-inset',
+    lines: range(9, 35),
+    keywords: [/safe-area|env\(safe-area/i],
+  },
+  {
+    id: 'autofocus-on-non-primary',
+    lines: range(22, 32),
+    keywords: [/autofocus|autoFocus/i],
+  },
+  {
+    id: 'button-no-hover-state',
+    lines: range(26, 34),
+    keywords: [/hover:|\bhover\b\s*state|hover\s*feedback/i],
+  },
+];
+
+const pass = gradeFindings({
+  findingsPath: join(process.env.WORK, 'findings.txt'),
+  file: 'ConfirmDialog.tsx',
+  expected,
+});
+process.exit(pass ? 0 : 1);

--- a/examples/workbench/web-design-guidelines/checks/grade-data-table-findings.mjs
+++ b/examples/workbench/web-design-guidelines/checks/grade-data-table-findings.mjs
@@ -1,0 +1,37 @@
+import { join } from 'node:path';
+import { gradeFindings, range } from './_grader-utils.mjs';
+
+const expected = [
+  {
+    id: 'layout-read-in-render',
+    lines: range(13, 18),
+    keywords: [/getBoundingClientRect|layout\s*read|in\s*render/i],
+  },
+  {
+    id: 'large-list-no-virtualization',
+    lines: range(30, 40),
+    keywords: [/virtualiz/i],
+  },
+  {
+    id: 'tabular-nums-missing',
+    lines: range(25, 38),
+    keywords: [/tabular-?nums|font-variant-numeric/i],
+  },
+  {
+    id: 'heading-no-text-balance',
+    lines: range(19, 23),
+    keywords: [/text-balance|text-pretty|text-wrap/i],
+  },
+  {
+    id: 'numeral-spelled-out',
+    lines: range(20, 24),
+    keywords: [/numeral|spell|"eight"|\beight\b/i],
+  },
+];
+
+const pass = gradeFindings({
+  findingsPath: join(process.env.WORK, 'findings.txt'),
+  file: 'DataTable.tsx',
+  expected,
+});
+process.exit(pass ? 0 : 1);

--- a/examples/workbench/web-design-guidelines/checks/grade-form-findings.mjs
+++ b/examples/workbench/web-design-guidelines/checks/grade-form-findings.mjs
@@ -1,0 +1,37 @@
+import { join } from 'node:path';
+import { gradeFindings, range } from './_grader-utils.mjs';
+
+const expected = [
+  {
+    id: 'label-without-htmlfor',
+    lines: range(15, 19),
+    keywords: [/\blabel\b/i, /\bhtml-?for\b|wrapping|clickable/i],
+  },
+  {
+    id: 'wrong-input-type-for-email',
+    lines: range(16, 27),
+    keywords: [/\btype\b/i, /\bemail\b/i],
+  },
+  {
+    id: 'input-missing-autocomplete',
+    lines: range(16, 27),
+    keywords: [/auto-?complete/i],
+  },
+  {
+    id: 'block-paste',
+    lines: range(21, 26),
+    keywords: [/\bpaste\b/i],
+  },
+  {
+    id: 'submit-button-disabled-pre-request',
+    lines: range(28, 32),
+    keywords: [/\bdisabled\b/i, /\bsubmit\b|\bbutton\b/i],
+  },
+];
+
+const pass = gradeFindings({
+  findingsPath: join(process.env.WORK, 'findings.txt'),
+  file: 'CheckoutForm.tsx',
+  expected,
+});
+process.exit(pass ? 0 : 1);

--- a/examples/workbench/web-design-guidelines/checks/grade-search-page-findings.mjs
+++ b/examples/workbench/web-design-guidelines/checks/grade-search-page-findings.mjs
@@ -1,0 +1,37 @@
+import { join } from 'node:path';
+import { gradeFindings, range } from './_grader-utils.mjs';
+
+const expected = [
+  {
+    id: 'url-no-state-sync',
+    lines: range(9, 14),
+    keywords: [/url|query\s*param|search\s*param|router|deep[-\s]?link|state.*url/i],
+  },
+  {
+    id: 'hardcoded-currency-format',
+    lines: range(29, 33),
+    keywords: [/Intl\.NumberFormat|currency|hardcoded\s*(number|currency|format)/i],
+  },
+  {
+    id: 'hardcoded-date-format',
+    lines: range(30, 34),
+    keywords: [/Intl\.DateTimeFormat|toDateString|hardcoded\s*date|date\s*format/i],
+  },
+  {
+    id: 'brand-no-translate-no',
+    lines: range(18, 22),
+    keywords: [/translate=['"]?no|translate.*no|brand\s*name/i],
+  },
+  {
+    id: 'destructive-no-confirmation',
+    lines: range(31, 35),
+    keywords: [/confirmation|confirm\s*modal|undo|destructive/i],
+  },
+];
+
+const pass = gradeFindings({
+  findingsPath: join(process.env.WORK, 'findings.txt'),
+  file: 'SearchPage.tsx',
+  expected,
+});
+process.exit(pass ? 0 : 1);

--- a/examples/workbench/web-design-guidelines/checks/grade-theme-toggle-findings.mjs
+++ b/examples/workbench/web-design-guidelines/checks/grade-theme-toggle-findings.mjs
@@ -1,0 +1,40 @@
+import { join } from 'node:path';
+import { gradeFindings, range } from './_grader-utils.mjs';
+
+// Five seeded violations in workspace/ThemeToggle.tsx.
+// Note: rules about <html color-scheme> and <meta theme-color> belong on a
+// document/layout file, not on a component, so they're not seeded here.
+const expected = [
+  {
+    id: 'localstorage-in-render',
+    lines: range(5, 10),
+    keywords: [/localStorage|hydration|server.*client|useEffect/i],
+  },
+  {
+    id: 'input-value-no-onchange',
+    lines: range(22, 28),
+    keywords: [/onChange|controlled.*input|value\b.*onChange|read-?only/i],
+  },
+  {
+    id: 'select-no-explicit-bg-color',
+    lines: range(12, 23),
+    keywords: [/select\b.*background-?color|background-?color\b.*select|native\s*select|windows.*dark/i],
+  },
+  {
+    id: 'button-no-hover-state',
+    lines: range(25, 30),
+    keywords: [/hover:|\bhover\b\s*state|hover\s*feedback/i],
+  },
+  {
+    id: 'no-focus-visible',
+    lines: range(12, 30),
+    keywords: [/focus-visible/i],
+  },
+];
+
+const pass = gradeFindings({
+  findingsPath: join(process.env.WORK, 'findings.txt'),
+  file: 'ThemeToggle.tsx',
+  expected,
+});
+process.exit(pass ? 0 : 1);

--- a/examples/workbench/web-design-guidelines/checks/grade-typography-findings.mjs
+++ b/examples/workbench/web-design-guidelines/checks/grade-typography-findings.mjs
@@ -1,0 +1,37 @@
+import { join } from 'node:path';
+import { gradeFindings, range } from './_grader-utils.mjs';
+
+const expected = [
+  {
+    id: 'three-dots-not-ellipsis',
+    lines: range(10, 14),
+    keywords: [/\.\.\./, /ellipsis/i, /…/, /loading\s*$|loading\s*[…\.]/i],
+  },
+  {
+    id: 'straight-quotes-not-curly',
+    lines: range(11, 15),
+    keywords: [/\bquot/i, /curly|smart\s*quotes|typographic/i],
+  },
+  {
+    id: 'missing-nbsp-between-number-and-unit',
+    lines: range(12, 16),
+    keywords: [/non-?breaking|nbsp|&nbsp;/i],
+  },
+  {
+    id: 'flex-child-no-min-w-0',
+    lines: range(13, 20),
+    keywords: [/min-w-0|min-?width/i],
+  },
+  {
+    id: 'no-empty-state-handling',
+    lines: range(15, 25),
+    keywords: [/empty[-\s]+state|empty\s+array|empty\s+list|empty\s*<ul>|unguarded|fallback/i],
+  },
+];
+
+const pass = gradeFindings({
+  findingsPath: join(process.env.WORK, 'findings.txt'),
+  file: 'LoadingScreen.tsx',
+  expected,
+});
+process.exit(pass ? 0 : 1);

--- a/examples/workbench/web-design-guidelines/proposed-upstream-changes/README.md
+++ b/examples/workbench/web-design-guidelines/proposed-upstream-changes/README.md
@@ -1,0 +1,112 @@
+# Proposed upstream changes — `web-design-guidelines`
+
+This directory holds before/after snapshots of the two upstream files we'd
+PR back to Vercel. **Nothing here is published yet** — these are for team
+review before we approach upstream.
+
+## Two upstream repos
+
+| Upstream | File | Before | After |
+|---|---|---|---|
+| `vercel-labs/agent-skills` | `skills/web-design-guidelines/SKILL.md` | [`before-SKILL.md`](agent-skills--web-design-guidelines/before-SKILL.md) (39 lines) | [`after-SKILL.md`](agent-skills--web-design-guidelines/after-SKILL.md) (54 lines) |
+| `vercel-labs/web-interface-guidelines` | `command.md` | [`before-command.md`](web-interface-guidelines/before-command.md) (180 lines) | [`after-command.md`](web-interface-guidelines/after-command.md) (304 lines) |
+
+Two PRs, one per repo.
+
+## What changed
+
+### `SKILL.md` — adds an explicit two-pass workflow
+
+The skill currently says "fetch rules → review files → output findings." We
+reframe the review step as **two distinct passes**:
+
+- **Pass 1 — visible anti-patterns**: scan for literal patterns that appear
+  in the code (`<div onClick>`, `transition: all`, `outline-none`, etc.).
+- **Pass 2 — absences (per-element checklist)**: for each `<img>`,
+  `<input>`, `<button>`, `<form>`, walk a checklist of attributes/behaviors
+  that should be present but often aren't (e.g., `<img>` without
+  `width`/`height`, `<input>` without `autoComplete`, async submit button
+  with stale `disabled`).
+
+Diff vs upstream: ~15 lines added under "How It Works" and "Usage". The
+WebFetch behavior and rules URL are unchanged.
+
+### `command.md` — adds per-element checklists + BAD/GOOD examples
+
+Two additions, no rule deletions or wording changes to existing rules:
+
+- **"Per-element review (Pass 2 checklist)"** — a checklist organized by
+  HTML element (img / input / button / form / list-render / animation).
+  This is the reference Pass 2 in `SKILL.md` walks.
+- **"Common-miss examples"** — five BAD/GOOD code blocks for the rules our
+  eval shows are most often overlooked: submit-button-disabled,
+  block-paste, missing autoComplete, above-fold image priority, missing
+  empty-state branch.
+
+The existing rule sections (Accessibility, Forms, Animation, etc.) are
+left intact so anyone using `command.md` standalone still gets the full
+rule list.
+
+## Why these two changes
+
+The categorization phase flagged **three** notable issues for this skill:
+
+1. *No fallback if the remote URL is unavailable.* Architectural; out of
+   scope for this PR.
+2. **No examples of compliant vs. non-compliant output.** ← what we
+   address.
+3. *Argument-hint glob/recursion semantics unclear.* Tiny scope; could fold
+   into the same SKILL.md PR if the maintainer asks, but isn't the
+   primary lever.
+
+Our eval (4 sample TSX files with 20 seeded violations across a11y,
+forms, typography, animation/images) confirmed #2 empirically. The
+rules that most often went unflagged were not "the doc is unclear"
+problems — they were "the rule describes the *absence* of something the
+model has to imagine." Adding a per-element checklist + concrete
+BAD/GOOD examples converts those rules from imagination-required to
+pattern-matching.
+
+## Eval evidence
+
+Same four cases × three mid-tier models × three trials = 36 trials. Same
+seeded violations. Same grader.
+
+| Model | Before | After |
+|---|---|---|
+| `claude-sonnet-4.6` | 10/12 (83%) | **12/12 (100%)** |
+| `gpt-5-mini` | 9/12 (75%) | **10/12 (83%)** |
+| `gemini-2.5-pro` | 7/12 (58%) | **9/12 (75%)** |
+| **Total** | **26/36 (72%)** | **31/36 (86%)** |
+
+Specific rules eliminated or reduced:
+
+| Rule | Before | After |
+|---|---|---|
+| `submit-button-disabled-pre-request` | 3 misses | 1 |
+| `no-empty-state-handling` | 3 misses | **0** |
+| `above-fold-img-missing-priority` | 2 misses | 1 |
+| `input-missing-autocomplete` | 1 miss | **0** |
+| `block-paste` | 2 misses | 2 (no change — gemini terseness) |
+
+## Next steps for the team
+
+- Review the proposal here.
+- If we're going to PR, decide:
+  - Single bundled PR vs. two separate PRs? (Two repos, so probably two PRs.)
+  - Include the eval evidence in the PR description? Vercel's recent
+    skill PRs lean qualitative, but the numbers are persuasive.
+  - Who's the team author of record on the PR? (B2B-visibility decision
+    — this is our team's first upstream contribution to vercel-labs.)
+- Heads-up to anyone @ Vercel before the PR drops?
+
+## How to reproduce the eval locally
+
+```bash
+cd examples/workbench/web-design-guidelines
+export OPENROUTER_API_KEY=sk-or-...
+npx tsx ../../../src/cli.ts run-suite ./suite.yml --trials 3
+```
+
+Eval suite, sample TSX files, and graders are all checked in alongside
+this proposal in the parent directory.

--- a/examples/workbench/web-design-guidelines/proposed-upstream-changes/README.md
+++ b/examples/workbench/web-design-guidelines/proposed-upstream-changes/README.md
@@ -69,8 +69,7 @@ pattern-matching.
 
 ## Eval evidence
 
-Same four cases × three mid-tier models × three trials = 36 trials. Same
-seeded violations. Same grader.
+Original baseline: **4 cases × 3 mid-tier models × 3 trials = 36 trials**.
 
 | Model | Before | After |
 |---|---|---|
@@ -88,6 +87,33 @@ Specific rules eliminated or reduced:
 | `above-fold-img-missing-priority` | 2 misses | 1 |
 | `input-missing-autocomplete` | 1 miss | **0** |
 | `block-paste` | 2 misses | 2 (no change — gemini terseness) |
+
+### Broader 9-case validation
+
+To confirm the changes generalize beyond the original 4 cases, we expanded to **9 cases × 3 models × 3 trials = 81 trials** covering all 16 sections of `command.md` (~45 of 81 graded rules; the rest are subjective, framework-bound, or overlap and are skipped — see [`../README.md`](../README.md) §Coverage). Result on the expanded suite, with the same proposed `SKILL.md` + `command.md`:
+
+| Metric | Value |
+|---|---|
+| Strict pass rate | 42/81 (52%) |
+| **Rule coverage rate** (violations identified / seeded) | **334/405 (82%)** |
+
+Strict pass dropped from 86% → 52% because the 5 new cases test harder absence-type rules (touch-action on modals, `safe-area-inset-*`, brand `translate="no"`, etc.) that even the updated skill misses some of the time. **Rule-coverage 82% is the load-bearing metric** — the skill catches 4 out of every 5 seeded violations on average across all 9 cases.
+
+Per-case rule coverage on the 9-case suite:
+
+| Case | Coverage |
+|---|---|
+| product-card | 100% |
+| hero-section | 100% |
+| checkout-form | 98% |
+| blog-post | 87% |
+| loading-screen | 82% |
+| data-table | 80% |
+| theme-toggle | 69% |
+| search-page | 64% |
+| confirm-dialog | 62% |
+
+The cases that still score below 80% are dominated by 4 specific rules that even the updated skill misses (button hover, brand `translate="no"`, safe-area-inset, focus-visible vs focus). The most recent iteration of `command.md` adds explicit `hover:` to the per-button checklist plus BAD/GOOD examples for `focus-visible` and `translate="no"`; we did not re-run the 9-case matrix after those additions, so the numbers above don't reflect that final iteration.
 
 ## Next steps for the team
 

--- a/examples/workbench/web-design-guidelines/proposed-upstream-changes/agent-skills--web-design-guidelines/after-SKILL.md
+++ b/examples/workbench/web-design-guidelines/proposed-upstream-changes/agent-skills--web-design-guidelines/after-SKILL.md
@@ -1,0 +1,51 @@
+---
+name: web-design-guidelines
+description: Review UI code for Web Interface Guidelines compliance. Use when asked to "review my UI", "check accessibility", "audit design", "review UX", or "check my site against best practices".
+metadata:
+  author: vercel
+  version: "1.1.0"
+  argument-hint: <file-or-pattern>
+---
+
+# Web Interface Guidelines
+
+Review files for compliance with Web Interface Guidelines.
+
+## How It Works
+
+1. Fetch the latest guidelines from the source URL below.
+2. Read the specified files (or prompt user for files/pattern).
+3. Review each file in **TWO passes** — both passes are required.
+4. Output findings in the terse `file:line <issue>` format.
+
+### Pass 1 — Visible anti-patterns
+
+Scan each file for literal patterns that appear in the code: `<div onClick>` for actions, `transition: all`, `outline-none` className, `onPaste={(e) => e.preventDefault()}`, `"..."` (three dots), straight `"..."` quotes, etc. The full list is in the fetched guidelines. One finding per match.
+
+### Pass 2 — Absences (per-element checklist)
+
+The most-missed rules are about *what's missing*. After Pass 1, walk each `<img>`, `<input>`, `<button>`, and `<form>` once and run the checklist in the **"Per-element review"** section of the fetched guidelines. Report every attribute or behavior that should be present but isn't.
+
+Pass 2 is the difference between a 70% review and a 95% review. Do not skip it.
+
+## Guidelines Source
+
+Fetch fresh guidelines before each review:
+
+```text
+https://raw.githubusercontent.com/vercel-labs/web-interface-guidelines/main/command.md
+```
+
+Use WebFetch to retrieve the latest rules. The fetched content contains all the rules, the per-element Pass 2 checklist, and output format instructions.
+
+## Usage
+
+When a user provides a file or pattern argument:
+
+1. Fetch guidelines from the source URL above.
+2. Read the specified files.
+3. Run Pass 1 (visible anti-patterns).
+4. Run Pass 2 (per-element absence checklist).
+5. Output findings using the format specified in the guidelines.
+
+If no files specified, ask the user which files to review.

--- a/examples/workbench/web-design-guidelines/proposed-upstream-changes/agent-skills--web-design-guidelines/before-SKILL.md
+++ b/examples/workbench/web-design-guidelines/proposed-upstream-changes/agent-skills--web-design-guidelines/before-SKILL.md
@@ -1,0 +1,39 @@
+---
+name: web-design-guidelines
+description: Review UI code for Web Interface Guidelines compliance. Use when asked to "review my UI", "check accessibility", "audit design", "review UX", or "check my site against best practices".
+metadata:
+  author: vercel
+  version: "1.0.0"
+  argument-hint: <file-or-pattern>
+---
+
+# Web Interface Guidelines
+
+Review files for compliance with Web Interface Guidelines.
+
+## How It Works
+
+1. Fetch the latest guidelines from the source URL below
+2. Read the specified files (or prompt user for files/pattern)
+3. Check against all rules in the fetched guidelines
+4. Output findings in the terse `file:line` format
+
+## Guidelines Source
+
+Fetch fresh guidelines before each review:
+
+```
+https://raw.githubusercontent.com/vercel-labs/web-interface-guidelines/main/command.md
+```
+
+Use WebFetch to retrieve the latest rules. The fetched content contains all the rules and output format instructions.
+
+## Usage
+
+When a user provides a file or pattern argument:
+1. Fetch guidelines from the source URL above
+2. Read the specified files
+3. Apply all rules from the fetched guidelines
+4. Output findings using the format specified in the guidelines
+
+If no files specified, ask the user which files to review.

--- a/examples/workbench/web-design-guidelines/proposed-upstream-changes/web-interface-guidelines/after-command.md
+++ b/examples/workbench/web-design-guidelines/proposed-upstream-changes/web-interface-guidelines/after-command.md
@@ -185,11 +185,16 @@ attribute or behavior that should be present but isn't.
 - NO `onPaste={(e) => e.preventDefault()}`
 - emails / codes / usernames → `spellCheck={false}`
 
-**Every `<button type="submit">`:**
+**Every `<button>` (any type):**
+
+- visible focus style (`focus-visible:ring-*` — NOT `focus:ring-*`, which fires on click)
+- `hover:` state for visual feedback (`hover:bg-*` or equivalent)
+- `type="button"` if not a form submit (default `submit` causes accidental form submits)
+
+**Every `<button type="submit">`:** (in addition to the above)
 
 - stays enabled until the request starts; spinner during the request
 - NEVER `disabled={!form.valid}` style — causes input-flicker and races with paste/autofill
-- visible focus style (`focus-visible:ring-*`)
 
 **Every `<form>`:**
 
@@ -213,6 +218,27 @@ attribute or behavior that should be present but isn't.
 - honors `prefers-reduced-motion`
 - animates `transform` / `opacity` only — NEVER `transition: all`
 - interruptible
+
+**Every modal / dialog / drawer / sheet:**
+
+- `overscroll-behavior: contain` (prevent scroll bleed to page behind)
+- `touch-action: manipulation` (no double-tap zoom delay)
+- `env(safe-area-inset-*)` for notch-aware bottom action bars
+- `autoFocus` only when there's a single primary input on desktop; avoid on mobile
+
+**Every native `<select>` (when supporting dark mode):**
+
+- explicit `background-color` AND `color` (Windows dark mode requires both)
+
+**Every heading `<h1>`–`<h6>`:**
+
+- `text-wrap: balance` or `text-pretty` (prevents widows)
+- hierarchical levels — never skip (`<h1>` → `<h3>` is wrong; insert `<h2>`)
+- `scroll-margin-top` on heading anchors that scroll-into-view
+
+**Every brand name / code identifier in copy:**
+
+- `translate="no"` to prevent garbled auto-translation
 
 ## Common-miss examples
 
@@ -277,6 +303,29 @@ These are the rules most often overlooked. The bad pattern looks idiomatic, whic
 ) : (
   <ul>{items.map((i) => <li key={i.id}>{i.name}</li>)}</ul>
 )}
+```
+
+**Use `focus-visible:`, not `focus:`.**
+
+```jsx
+// BAD: focus ring shows on mouse click too — visually noisy for non-keyboard users.
+<button className="focus:ring-2 focus:ring-blue-500">Save</button>
+
+// GOOD: focus ring only on keyboard navigation.
+<button className="focus-visible:ring-2 focus-visible:ring-blue-500">Save</button>
+```
+
+**Brand names and code identifiers need `translate="no"`.**
+
+```jsx
+// BAD: machine translators garble brand names and code tokens
+// ("Acme Cloud" might become "Cumulus de Acme" in another locale).
+<h1>Welcome to Acme Cloud</h1>
+<code>npm install acme-sdk</code>
+
+// GOOD: tell auto-translation to leave these alone.
+<h1>Welcome to <span translate="no">Acme Cloud</span></h1>
+<code translate="no">npm install acme-sdk</code>
 ```
 
 ## Output Format

--- a/examples/workbench/web-design-guidelines/proposed-upstream-changes/web-interface-guidelines/after-command.md
+++ b/examples/workbench/web-design-guidelines/proposed-upstream-changes/web-interface-guidelines/after-command.md
@@ -1,0 +1,304 @@
+---
+description: Review UI code for Vercel Web Interface Guidelines compliance
+argument-hint: <file-or-pattern>
+---
+
+# Web Interface Guidelines
+
+Review these files for compliance: $ARGUMENTS
+
+Read files, check against rules below. Output concise but comprehensive—sacrifice grammar for brevity. High signal-to-noise.
+
+## Review workflow
+
+Do BOTH passes. Pass 2 is what catches most real bugs.
+
+**Pass 1 — visible anti-patterns.** Scan for literal patterns: `<div onClick>` for actions, `transition: all`, `outline-none` className, `onPaste={(e) => e.preventDefault()}`, three-dots `"..."`, straight `"..."` quotes, etc. One finding per match against the rules below.
+
+**Pass 2 — absences (per-element checklist).** Walk every `<img>`, `<input>`, `<button>`, `<form>`, list-render, animation, and interactive element once and run the checklist in **"Per-element review"** below. Report every attribute or behavior that should be present but isn't. This pass catches "what's missing" rules that are easy to overlook.
+
+## Rules
+
+### Accessibility
+
+- Icon-only buttons need `aria-label`
+- Form controls need `<label>` or `aria-label`
+- Interactive elements need keyboard handlers (`onKeyDown`/`onKeyUp`)
+- `<button>` for actions, `<a>`/`<Link>` for navigation (not `<div onClick>`)
+- Images need `alt` (or `alt=""` if decorative)
+- Decorative icons need `aria-hidden="true"`
+- Async updates (toasts, validation) need `aria-live="polite"`
+- Use semantic HTML (`<button>`, `<a>`, `<label>`, `<table>`) before ARIA
+- Headings hierarchical `<h1>`–`<h6>`; include skip link for main content
+- `scroll-margin-top` on heading anchors
+
+### Focus States
+
+- Interactive elements need visible focus: `focus-visible:ring-*` or equivalent
+- Never `outline-none` / `outline: none` without focus replacement
+- Use `:focus-visible` over `:focus` (avoid focus ring on click)
+- Group focus with `:focus-within` for compound controls
+
+### Forms
+
+- Inputs need `autocomplete` and meaningful `name`
+- Use correct `type` (`email`, `tel`, `url`, `number`) and `inputmode`
+- Never block paste (`onPaste` + `preventDefault`)
+- Labels clickable (`htmlFor` or wrapping control)
+- Disable spellcheck on emails, codes, usernames (`spellCheck={false}`)
+- Checkboxes/radios: label + control share single hit target (no dead zones)
+- Submit button stays enabled until request starts; spinner during request
+- Errors inline next to fields; focus first error on submit
+- Placeholders end with `…` and show example pattern
+- `autocomplete="off"` on non-auth fields to avoid password manager triggers
+- Warn before navigation with unsaved changes (`beforeunload` or router guard)
+
+### Animation
+
+- Honor `prefers-reduced-motion` (provide reduced variant or disable)
+- Animate `transform`/`opacity` only (compositor-friendly)
+- Never `transition: all`—list properties explicitly
+- Set correct `transform-origin`
+- SVG: transforms on `<g>` wrapper with `transform-box: fill-box; transform-origin: center`
+- Animations interruptible—respond to user input mid-animation
+
+### Typography
+
+- `…` not `...`
+- Curly quotes `"` `"` not straight `"`
+- Non-breaking spaces: `10&nbsp;MB`, `⌘&nbsp;K`, brand names
+- Loading states end with `…`: `"Loading…"`, `"Saving…"`
+- `font-variant-numeric: tabular-nums` for number columns/comparisons
+- Use `text-wrap: balance` or `text-pretty` on headings (prevents widows)
+
+### Content Handling
+
+- Text containers handle long content: `truncate`, `line-clamp-*`, or `break-words`
+- Flex children need `min-w-0` to allow text truncation
+- Handle empty states—don't render broken UI for empty strings/arrays
+- User-generated content: anticipate short, average, and very long inputs
+
+### Images
+
+- `<img>` needs explicit `width` and `height` (prevents CLS)
+- Below-fold images: `loading="lazy"`
+- Above-fold critical images: `priority` or `fetchpriority="high"`
+
+### Performance
+
+- Large lists (>50 items): virtualize (`virtua`, `content-visibility: auto`)
+- No layout reads in render (`getBoundingClientRect`, `offsetHeight`, `offsetWidth`, `scrollTop`)
+- Batch DOM reads/writes; avoid interleaving
+- Prefer uncontrolled inputs; controlled inputs must be cheap per keystroke
+- Add `<link rel="preconnect">` for CDN/asset domains
+- Critical fonts: `<link rel="preload" as="font">` with `font-display: swap`
+
+### Navigation & State
+
+- URL reflects state—filters, tabs, pagination, expanded panels in query params
+- Links use `<a>`/`<Link>` (Cmd/Ctrl+click, middle-click support)
+- Deep-link all stateful UI (if uses `useState`, consider URL sync via nuqs or similar)
+- Destructive actions need confirmation modal or undo window—never immediate
+
+### Touch & Interaction
+
+- `touch-action: manipulation` (prevents double-tap zoom delay)
+- `-webkit-tap-highlight-color` set intentionally
+- `overscroll-behavior: contain` in modals/drawers/sheets
+- During drag: disable text selection, `inert` on dragged elements
+- `autoFocus` sparingly—desktop only, single primary input; avoid on mobile
+
+### Safe Areas & Layout
+
+- Full-bleed layouts need `env(safe-area-inset-*)` for notches
+- Avoid unwanted scrollbars: `overflow-x-hidden` on containers, fix content overflow
+- Flex/grid over JS measurement for layout
+
+### Dark Mode & Theming
+
+- `color-scheme: dark` on `<html>` for dark themes (fixes scrollbar, inputs)
+- `<meta name="theme-color">` matches page background
+- Native `<select>`: explicit `background-color` and `color` (Windows dark mode)
+
+### Locale & i18n
+
+- Dates/times: use `Intl.DateTimeFormat` not hardcoded formats
+- Numbers/currency: use `Intl.NumberFormat` not hardcoded formats
+- Detect language via `Accept-Language` / `navigator.languages`, not IP
+- Brand names, code tokens, identifiers: wrap with `translate="no"` to prevent garbled auto-translation
+
+### Hydration Safety
+
+- Inputs with `value` need `onChange` (or use `defaultValue` for uncontrolled)
+- Date/time rendering: guard against hydration mismatch (server vs client)
+- `suppressHydrationWarning` only where truly needed
+
+### Hover & Interactive States
+
+- Buttons/links need `hover:` state (visual feedback)
+- Interactive states increase contrast: hover/active/focus more prominent than rest
+
+### Content & Copy
+
+- Active voice: "Install the CLI" not "The CLI will be installed"
+- Title Case for headings/buttons (Chicago style)
+- Numerals for counts: "8 deployments" not "eight"
+- Specific button labels: "Save API Key" not "Continue"
+- Error messages include fix/next step, not just problem
+- Second person; avoid first person
+- `&` over "and" where space-constrained
+
+### Anti-patterns (flag these)
+
+- `user-scalable=no` or `maximum-scale=1` disabling zoom
+- `onPaste` with `preventDefault`
+- `transition: all`
+- `outline-none` without focus-visible replacement
+- Inline `onClick` navigation without `<a>`
+- `<div>` or `<span>` with click handlers (should be `<button>`)
+- Images without dimensions
+- Large arrays `.map()` without virtualization
+- Form inputs without labels
+- Icon buttons without `aria-label`
+- Hardcoded date/number formats (use `Intl.*`)
+- `autoFocus` without clear justification
+
+## Per-element review (Pass 2 checklist)
+
+For each element in the file, walk the relevant checklist and flag every
+attribute or behavior that should be present but isn't.
+
+**Every `<img>`:**
+
+- explicit `width` AND `height` (prevents CLS)
+- above-fold critical → `priority` or `fetchpriority="high"` (LCP)
+- below-fold → `loading="lazy"`
+- decorative → `alt=""`, meaningful → descriptive `alt`
+
+**Every `<input>`:**
+
+- `autoComplete` set (use `"off"` for non-auth fields where you actively don't want autofill, but always set it)
+- meaningful `name`
+- correct `type` (`email`, `tel`, `url`, `number`) — never `text` for typed data
+- `inputMode` for mobile keyboards
+- `<label htmlFor>` or wrapping `<label>`
+- NO `onPaste={(e) => e.preventDefault()}`
+- emails / codes / usernames → `spellCheck={false}`
+
+**Every `<button type="submit">`:**
+
+- stays enabled until the request starts; spinner during the request
+- NEVER `disabled={!form.valid}` style — causes input-flicker and races with paste/autofill
+- visible focus style (`focus-visible:ring-*`)
+
+**Every `<form>`:**
+
+- errors inline next to fields, not just at top
+- focus first error on submit
+- warn before navigation with unsaved changes (`beforeunload` / router guard)
+
+**Every list / array render (`.map(...)`):**
+
+- empty-state branch (don't render broken UI for `[]`)
+- > 50 expected items → virtualize
+
+**Every interactive element:**
+
+- visible focus (`focus-visible:ring-*` or equivalent)
+- no `outline-none` / `outline: none` without a replacement focus style
+- keyboard handler if not a native interactive element
+
+**Every animation / transition:**
+
+- honors `prefers-reduced-motion`
+- animates `transform` / `opacity` only — NEVER `transition: all`
+- interruptible
+
+## Common-miss examples
+
+These are the rules most often overlooked. The bad pattern looks idiomatic, which is why models (and humans) skip them.
+
+**Submit button stays enabled until request starts.**
+
+```jsx
+// BAD: button disables based on form state. User types → deletes a char →
+// button flickers off → autofill/paste race with state.
+<button type="submit" disabled={!email}>Submit</button>
+
+// GOOD: stays enabled. Spinner appears during the request.
+<button type="submit" disabled={submitting}>
+  {submitting ? <Spinner /> : 'Submit'}
+</button>
+```
+
+**Never block paste.**
+
+```jsx
+// BAD: blocking paste — breaks password managers, accessibility tools,
+// and users who copy from another tab.
+<input onPaste={(e) => e.preventDefault()} />
+
+// GOOD: allow paste; validate or normalize after if needed.
+<input onPaste={(e) => { /* allow; optionally normalize value */ }} />
+```
+
+**Inputs need `autoComplete`.**
+
+```jsx
+// BAD: no autoComplete → browser can't fill, password managers stall.
+<input type="email" name="email" />
+
+// GOOD: explicit hint. Use `"off"` only for non-auth fields where you
+// actively don't want autofill.
+<input type="email" name="email" autoComplete="email" />
+```
+
+**Above-fold critical images need a priority hint.**
+
+```jsx
+// BAD: hero image with no priority. Browser de-prioritizes; LCP suffers.
+<img src="/hero.jpg" alt="..." width={1200} height={600} />
+
+// GOOD: hint that this image is critical for LCP.
+<Image src="/hero.jpg" alt="..." width={1200} height={600} priority />
+// or for plain <img>:
+<img src="/hero.jpg" alt="..." width={1200} height={600} fetchpriority="high" />
+```
+
+**Handle empty states.**
+
+```jsx
+// BAD: empty list silently renders broken UI (empty <ul>, no message).
+<ul>{items.map((i) => <li key={i.id}>{i.name}</li>)}</ul>
+
+// GOOD: explicit empty-state branch.
+{items.length === 0 ? (
+  <p className="text-muted">No items yet.</p>
+) : (
+  <ul>{items.map((i) => <li key={i.id}>{i.name}</li>)}</ul>
+)}
+```
+
+## Output Format
+
+Group by file. Use `file:line` format (VS Code clickable). Terse findings.
+
+```text
+## src/Button.tsx
+
+src/Button.tsx:42 - icon button missing aria-label
+src/Button.tsx:18 - input lacks label
+src/Button.tsx:55 - animation missing prefers-reduced-motion
+src/Button.tsx:67 - transition: all → list properties
+
+## src/Modal.tsx
+
+src/Modal.tsx:12 - missing overscroll-behavior: contain
+src/Modal.tsx:34 - "..." → "…"
+
+## src/Card.tsx
+
+✓ pass
+```
+
+State issue + location. Skip explanation unless fix non-obvious. No preamble.

--- a/examples/workbench/web-design-guidelines/proposed-upstream-changes/web-interface-guidelines/before-command.md
+++ b/examples/workbench/web-design-guidelines/proposed-upstream-changes/web-interface-guidelines/before-command.md
@@ -1,0 +1,180 @@
+---
+description: Review UI code for Vercel Web Interface Guidelines compliance
+argument-hint: <file-or-pattern>
+---
+
+# Web Interface Guidelines
+
+Review these files for compliance: $ARGUMENTS
+
+Read files, check against rules below. Output concise but comprehensive—sacrifice grammar for brevity. High signal-to-noise.
+
+## Rules
+
+### Accessibility
+
+- Icon-only buttons need `aria-label`
+- Form controls need `<label>` or `aria-label`
+- Interactive elements need keyboard handlers (`onKeyDown`/`onKeyUp`)
+- `<button>` for actions, `<a>`/`<Link>` for navigation (not `<div onClick>`)
+- Images need `alt` (or `alt=""` if decorative)
+- Decorative icons need `aria-hidden="true"`
+- Async updates (toasts, validation) need `aria-live="polite"`
+- Use semantic HTML (`<button>`, `<a>`, `<label>`, `<table>`) before ARIA
+- Headings hierarchical `<h1>`–`<h6>`; include skip link for main content
+- `scroll-margin-top` on heading anchors
+
+### Focus States
+
+- Interactive elements need visible focus: `focus-visible:ring-*` or equivalent
+- Never `outline-none` / `outline: none` without focus replacement
+- Use `:focus-visible` over `:focus` (avoid focus ring on click)
+- Group focus with `:focus-within` for compound controls
+
+### Forms
+
+- Inputs need `autocomplete` and meaningful `name`
+- Use correct `type` (`email`, `tel`, `url`, `number`) and `inputmode`
+- Never block paste (`onPaste` + `preventDefault`)
+- Labels clickable (`htmlFor` or wrapping control)
+- Disable spellcheck on emails, codes, usernames (`spellCheck={false}`)
+- Checkboxes/radios: label + control share single hit target (no dead zones)
+- Submit button stays enabled until request starts; spinner during request
+- Errors inline next to fields; focus first error on submit
+- Placeholders end with `…` and show example pattern
+- `autocomplete="off"` on non-auth fields to avoid password manager triggers
+- Warn before navigation with unsaved changes (`beforeunload` or router guard)
+
+### Animation
+
+- Honor `prefers-reduced-motion` (provide reduced variant or disable)
+- Animate `transform`/`opacity` only (compositor-friendly)
+- Never `transition: all`—list properties explicitly
+- Set correct `transform-origin`
+- SVG: transforms on `<g>` wrapper with `transform-box: fill-box; transform-origin: center`
+- Animations interruptible—respond to user input mid-animation
+
+### Typography
+
+- `…` not `...`
+- Curly quotes `"` `"` not straight `"`
+- Non-breaking spaces: `10&nbsp;MB`, `⌘&nbsp;K`, brand names
+- Loading states end with `…`: `"Loading…"`, `"Saving…"`
+- `font-variant-numeric: tabular-nums` for number columns/comparisons
+- Use `text-wrap: balance` or `text-pretty` on headings (prevents widows)
+
+### Content Handling
+
+- Text containers handle long content: `truncate`, `line-clamp-*`, or `break-words`
+- Flex children need `min-w-0` to allow text truncation
+- Handle empty states—don't render broken UI for empty strings/arrays
+- User-generated content: anticipate short, average, and very long inputs
+
+### Images
+
+- `<img>` needs explicit `width` and `height` (prevents CLS)
+- Below-fold images: `loading="lazy"`
+- Above-fold critical images: `priority` or `fetchpriority="high"`
+
+### Performance
+
+- Large lists (>50 items): virtualize (`virtua`, `content-visibility: auto`)
+- No layout reads in render (`getBoundingClientRect`, `offsetHeight`, `offsetWidth`, `scrollTop`)
+- Batch DOM reads/writes; avoid interleaving
+- Prefer uncontrolled inputs; controlled inputs must be cheap per keystroke
+- Add `<link rel="preconnect">` for CDN/asset domains
+- Critical fonts: `<link rel="preload" as="font">` with `font-display: swap`
+
+### Navigation & State
+
+- URL reflects state—filters, tabs, pagination, expanded panels in query params
+- Links use `<a>`/`<Link>` (Cmd/Ctrl+click, middle-click support)
+- Deep-link all stateful UI (if uses `useState`, consider URL sync via nuqs or similar)
+- Destructive actions need confirmation modal or undo window—never immediate
+
+### Touch & Interaction
+
+- `touch-action: manipulation` (prevents double-tap zoom delay)
+- `-webkit-tap-highlight-color` set intentionally
+- `overscroll-behavior: contain` in modals/drawers/sheets
+- During drag: disable text selection, `inert` on dragged elements
+- `autoFocus` sparingly—desktop only, single primary input; avoid on mobile
+
+### Safe Areas & Layout
+
+- Full-bleed layouts need `env(safe-area-inset-*)` for notches
+- Avoid unwanted scrollbars: `overflow-x-hidden` on containers, fix content overflow
+- Flex/grid over JS measurement for layout
+
+### Dark Mode & Theming
+
+- `color-scheme: dark` on `<html>` for dark themes (fixes scrollbar, inputs)
+- `<meta name="theme-color">` matches page background
+- Native `<select>`: explicit `background-color` and `color` (Windows dark mode)
+
+### Locale & i18n
+
+- Dates/times: use `Intl.DateTimeFormat` not hardcoded formats
+- Numbers/currency: use `Intl.NumberFormat` not hardcoded formats
+- Detect language via `Accept-Language` / `navigator.languages`, not IP
+- Brand names, code tokens, identifiers: wrap with `translate="no"` to prevent garbled auto-translation
+
+### Hydration Safety
+
+- Inputs with `value` need `onChange` (or use `defaultValue` for uncontrolled)
+- Date/time rendering: guard against hydration mismatch (server vs client)
+- `suppressHydrationWarning` only where truly needed
+
+### Hover & Interactive States
+
+- Buttons/links need `hover:` state (visual feedback)
+- Interactive states increase contrast: hover/active/focus more prominent than rest
+
+### Content & Copy
+
+- Active voice: "Install the CLI" not "The CLI will be installed"
+- Title Case for headings/buttons (Chicago style)
+- Numerals for counts: "8 deployments" not "eight"
+- Specific button labels: "Save API Key" not "Continue"
+- Error messages include fix/next step, not just problem
+- Second person; avoid first person
+- `&` over "and" where space-constrained
+
+### Anti-patterns (flag these)
+
+- `user-scalable=no` or `maximum-scale=1` disabling zoom
+- `onPaste` with `preventDefault`
+- `transition: all`
+- `outline-none` without focus-visible replacement
+- Inline `onClick` navigation without `<a>`
+- `<div>` or `<span>` with click handlers (should be `<button>`)
+- Images without dimensions
+- Large arrays `.map()` without virtualization
+- Form inputs without labels
+- Icon buttons without `aria-label`
+- Hardcoded date/number formats (use `Intl.*`)
+- `autoFocus` without clear justification
+
+## Output Format
+
+Group by file. Use `file:line` format (VS Code clickable). Terse findings.
+
+```text
+## src/Button.tsx
+
+src/Button.tsx:42 - icon button missing aria-label
+src/Button.tsx:18 - input lacks label
+src/Button.tsx:55 - animation missing prefers-reduced-motion
+src/Button.tsx:67 - transition: all → list properties
+
+## src/Modal.tsx
+
+src/Modal.tsx:12 - missing overscroll-behavior: contain
+src/Modal.tsx:34 - "..." → "…"
+
+## src/Card.tsx
+
+✓ pass
+```
+
+State issue + location. Skip explanation unless fix non-obvious. No preamble.

--- a/examples/workbench/web-design-guidelines/references/web-design-guidelines/SKILL.md
+++ b/examples/workbench/web-design-guidelines/references/web-design-guidelines/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: web-design-guidelines
+description: Review UI code for Web Interface Guidelines compliance. Use when asked to "review my UI", "check accessibility", "audit design", "review UX", or "check my site against best practices".
+metadata:
+  author: vercel
+  version: "1.1.0-eval"
+  argument-hint: <file-or-pattern>
+---
+
+# Web Interface Guidelines
+
+Review files for compliance with Web Interface Guidelines.
+
+## How It Works
+
+1. Read the bundled `command.md` (next to this SKILL.md) for the rules.
+2. Read the specified files (or prompt user for files/pattern).
+3. Review each file in **TWO passes** — both passes are required.
+4. Output findings in the terse `file:line <issue>` format.
+
+### Pass 1 — Visible anti-patterns
+
+Scan each file for literal patterns that appear in the code: `<div onClick>` for actions, `transition: all`, `outline-none` className, `onPaste={(e) => e.preventDefault()}`, `"..."` (three dots), straight `"..."` quotes, etc. The full list is in `command.md`'s rule sections. One finding per match.
+
+### Pass 2 — Absences (per-element checklist)
+
+The most-missed rules are about *what's missing*. After Pass 1, walk each `<img>`, `<input>`, `<button>`, and `<form>` once and run the checklist in `command.md`'s **"Per-element review"** section. Report every attribute or behavior that should be present but isn't.
+
+Pass 2 is the difference between a 70% review and a 95% review. Do not skip it.
+
+## Usage
+
+When a user provides a file or pattern argument:
+
+1. Read `command.md` to load the rules.
+2. Read the specified files.
+3. Run Pass 1 (visible anti-patterns).
+4. Run Pass 2 (per-element absence checklist).
+5. Output findings using the format specified in `command.md`.
+
+If no files specified, ask the user which files to review.

--- a/examples/workbench/web-design-guidelines/references/web-design-guidelines/command.md
+++ b/examples/workbench/web-design-guidelines/references/web-design-guidelines/command.md
@@ -185,11 +185,16 @@ attribute or behavior that should be present but isn't.
 - NO `onPaste={(e) => e.preventDefault()}`
 - emails / codes / usernames → `spellCheck={false}`
 
-**Every `<button type="submit">`:**
+**Every `<button>` (any type):**
+
+- visible focus style (`focus-visible:ring-*` — NOT `focus:ring-*`, which fires on click)
+- `hover:` state for visual feedback (`hover:bg-*` or equivalent)
+- `type="button"` if not a form submit (default `submit` causes accidental form submits)
+
+**Every `<button type="submit">`:** (in addition to the above)
 
 - stays enabled until the request starts; spinner during the request
 - NEVER `disabled={!form.valid}` style — causes input-flicker and races with paste/autofill
-- visible focus style (`focus-visible:ring-*`)
 
 **Every `<form>`:**
 
@@ -213,6 +218,27 @@ attribute or behavior that should be present but isn't.
 - honors `prefers-reduced-motion`
 - animates `transform` / `opacity` only — NEVER `transition: all`
 - interruptible
+
+**Every modal / dialog / drawer / sheet:**
+
+- `overscroll-behavior: contain` (prevent scroll bleed to page behind)
+- `touch-action: manipulation` (no double-tap zoom delay)
+- `env(safe-area-inset-*)` for notch-aware bottom action bars
+- `autoFocus` only when there's a single primary input on desktop; avoid on mobile
+
+**Every native `<select>` (when supporting dark mode):**
+
+- explicit `background-color` AND `color` (Windows dark mode requires both)
+
+**Every heading `<h1>`–`<h6>`:**
+
+- `text-wrap: balance` or `text-pretty` (prevents widows)
+- hierarchical levels — never skip (`<h1>` → `<h3>` is wrong; insert `<h2>`)
+- `scroll-margin-top` on heading anchors that scroll-into-view
+
+**Every brand name / code identifier in copy:**
+
+- `translate="no"` to prevent garbled auto-translation
 
 ## Common-miss examples
 
@@ -277,6 +303,29 @@ These are the rules most often overlooked. The bad pattern looks idiomatic, whic
 ) : (
   <ul>{items.map((i) => <li key={i.id}>{i.name}</li>)}</ul>
 )}
+```
+
+**Use `focus-visible:`, not `focus:`.**
+
+```jsx
+// BAD: focus ring shows on mouse click too — visually noisy for non-keyboard users.
+<button className="focus:ring-2 focus:ring-blue-500">Save</button>
+
+// GOOD: focus ring only on keyboard navigation.
+<button className="focus-visible:ring-2 focus-visible:ring-blue-500">Save</button>
+```
+
+**Brand names and code identifiers need `translate="no"`.**
+
+```jsx
+// BAD: machine translators garble brand names and code tokens
+// ("Acme Cloud" might become "Cumulus de Acme" in another locale).
+<h1>Welcome to Acme Cloud</h1>
+<code>npm install acme-sdk</code>
+
+// GOOD: tell auto-translation to leave these alone.
+<h1>Welcome to <span translate="no">Acme Cloud</span></h1>
+<code translate="no">npm install acme-sdk</code>
 ```
 
 ## Output Format

--- a/examples/workbench/web-design-guidelines/references/web-design-guidelines/command.md
+++ b/examples/workbench/web-design-guidelines/references/web-design-guidelines/command.md
@@ -1,0 +1,304 @@
+---
+description: Review UI code for Vercel Web Interface Guidelines compliance
+argument-hint: <file-or-pattern>
+---
+
+# Web Interface Guidelines
+
+Review these files for compliance: $ARGUMENTS
+
+Read files, check against rules below. Output concise but comprehensive—sacrifice grammar for brevity. High signal-to-noise.
+
+## Review workflow
+
+Do BOTH passes. Pass 2 is what catches most real bugs.
+
+**Pass 1 — visible anti-patterns.** Scan for literal patterns: `<div onClick>` for actions, `transition: all`, `outline-none` className, `onPaste={(e) => e.preventDefault()}`, three-dots `"..."`, straight `"..."` quotes, etc. One finding per match against the rules below.
+
+**Pass 2 — absences (per-element checklist).** Walk every `<img>`, `<input>`, `<button>`, `<form>`, list-render, animation, and interactive element once and run the checklist in **"Per-element review"** below. Report every attribute or behavior that should be present but isn't. This pass catches "what's missing" rules that are easy to overlook.
+
+## Rules
+
+### Accessibility
+
+- Icon-only buttons need `aria-label`
+- Form controls need `<label>` or `aria-label`
+- Interactive elements need keyboard handlers (`onKeyDown`/`onKeyUp`)
+- `<button>` for actions, `<a>`/`<Link>` for navigation (not `<div onClick>`)
+- Images need `alt` (or `alt=""` if decorative)
+- Decorative icons need `aria-hidden="true"`
+- Async updates (toasts, validation) need `aria-live="polite"`
+- Use semantic HTML (`<button>`, `<a>`, `<label>`, `<table>`) before ARIA
+- Headings hierarchical `<h1>`–`<h6>`; include skip link for main content
+- `scroll-margin-top` on heading anchors
+
+### Focus States
+
+- Interactive elements need visible focus: `focus-visible:ring-*` or equivalent
+- Never `outline-none` / `outline: none` without focus replacement
+- Use `:focus-visible` over `:focus` (avoid focus ring on click)
+- Group focus with `:focus-within` for compound controls
+
+### Forms
+
+- Inputs need `autocomplete` and meaningful `name`
+- Use correct `type` (`email`, `tel`, `url`, `number`) and `inputmode`
+- Never block paste (`onPaste` + `preventDefault`)
+- Labels clickable (`htmlFor` or wrapping control)
+- Disable spellcheck on emails, codes, usernames (`spellCheck={false}`)
+- Checkboxes/radios: label + control share single hit target (no dead zones)
+- Submit button stays enabled until request starts; spinner during request
+- Errors inline next to fields; focus first error on submit
+- Placeholders end with `…` and show example pattern
+- `autocomplete="off"` on non-auth fields to avoid password manager triggers
+- Warn before navigation with unsaved changes (`beforeunload` or router guard)
+
+### Animation
+
+- Honor `prefers-reduced-motion` (provide reduced variant or disable)
+- Animate `transform`/`opacity` only (compositor-friendly)
+- Never `transition: all`—list properties explicitly
+- Set correct `transform-origin`
+- SVG: transforms on `<g>` wrapper with `transform-box: fill-box; transform-origin: center`
+- Animations interruptible—respond to user input mid-animation
+
+### Typography
+
+- `…` not `...`
+- Curly quotes `"` `"` not straight `"`
+- Non-breaking spaces: `10&nbsp;MB`, `⌘&nbsp;K`, brand names
+- Loading states end with `…`: `"Loading…"`, `"Saving…"`
+- `font-variant-numeric: tabular-nums` for number columns/comparisons
+- Use `text-wrap: balance` or `text-pretty` on headings (prevents widows)
+
+### Content Handling
+
+- Text containers handle long content: `truncate`, `line-clamp-*`, or `break-words`
+- Flex children need `min-w-0` to allow text truncation
+- Handle empty states—don't render broken UI for empty strings/arrays
+- User-generated content: anticipate short, average, and very long inputs
+
+### Images
+
+- `<img>` needs explicit `width` and `height` (prevents CLS)
+- Below-fold images: `loading="lazy"`
+- Above-fold critical images: `priority` or `fetchpriority="high"`
+
+### Performance
+
+- Large lists (>50 items): virtualize (`virtua`, `content-visibility: auto`)
+- No layout reads in render (`getBoundingClientRect`, `offsetHeight`, `offsetWidth`, `scrollTop`)
+- Batch DOM reads/writes; avoid interleaving
+- Prefer uncontrolled inputs; controlled inputs must be cheap per keystroke
+- Add `<link rel="preconnect">` for CDN/asset domains
+- Critical fonts: `<link rel="preload" as="font">` with `font-display: swap`
+
+### Navigation & State
+
+- URL reflects state—filters, tabs, pagination, expanded panels in query params
+- Links use `<a>`/`<Link>` (Cmd/Ctrl+click, middle-click support)
+- Deep-link all stateful UI (if uses `useState`, consider URL sync via nuqs or similar)
+- Destructive actions need confirmation modal or undo window—never immediate
+
+### Touch & Interaction
+
+- `touch-action: manipulation` (prevents double-tap zoom delay)
+- `-webkit-tap-highlight-color` set intentionally
+- `overscroll-behavior: contain` in modals/drawers/sheets
+- During drag: disable text selection, `inert` on dragged elements
+- `autoFocus` sparingly—desktop only, single primary input; avoid on mobile
+
+### Safe Areas & Layout
+
+- Full-bleed layouts need `env(safe-area-inset-*)` for notches
+- Avoid unwanted scrollbars: `overflow-x-hidden` on containers, fix content overflow
+- Flex/grid over JS measurement for layout
+
+### Dark Mode & Theming
+
+- `color-scheme: dark` on `<html>` for dark themes (fixes scrollbar, inputs)
+- `<meta name="theme-color">` matches page background
+- Native `<select>`: explicit `background-color` and `color` (Windows dark mode)
+
+### Locale & i18n
+
+- Dates/times: use `Intl.DateTimeFormat` not hardcoded formats
+- Numbers/currency: use `Intl.NumberFormat` not hardcoded formats
+- Detect language via `Accept-Language` / `navigator.languages`, not IP
+- Brand names, code tokens, identifiers: wrap with `translate="no"` to prevent garbled auto-translation
+
+### Hydration Safety
+
+- Inputs with `value` need `onChange` (or use `defaultValue` for uncontrolled)
+- Date/time rendering: guard against hydration mismatch (server vs client)
+- `suppressHydrationWarning` only where truly needed
+
+### Hover & Interactive States
+
+- Buttons/links need `hover:` state (visual feedback)
+- Interactive states increase contrast: hover/active/focus more prominent than rest
+
+### Content & Copy
+
+- Active voice: "Install the CLI" not "The CLI will be installed"
+- Title Case for headings/buttons (Chicago style)
+- Numerals for counts: "8 deployments" not "eight"
+- Specific button labels: "Save API Key" not "Continue"
+- Error messages include fix/next step, not just problem
+- Second person; avoid first person
+- `&` over "and" where space-constrained
+
+### Anti-patterns (flag these)
+
+- `user-scalable=no` or `maximum-scale=1` disabling zoom
+- `onPaste` with `preventDefault`
+- `transition: all`
+- `outline-none` without focus-visible replacement
+- Inline `onClick` navigation without `<a>`
+- `<div>` or `<span>` with click handlers (should be `<button>`)
+- Images without dimensions
+- Large arrays `.map()` without virtualization
+- Form inputs without labels
+- Icon buttons without `aria-label`
+- Hardcoded date/number formats (use `Intl.*`)
+- `autoFocus` without clear justification
+
+## Per-element review (Pass 2 checklist)
+
+For each element in the file, walk the relevant checklist and flag every
+attribute or behavior that should be present but isn't.
+
+**Every `<img>`:**
+
+- explicit `width` AND `height` (prevents CLS)
+- above-fold critical → `priority` or `fetchpriority="high"` (LCP)
+- below-fold → `loading="lazy"`
+- decorative → `alt=""`, meaningful → descriptive `alt`
+
+**Every `<input>`:**
+
+- `autoComplete` set (use `"off"` for non-auth fields where you actively don't want autofill, but always set it)
+- meaningful `name`
+- correct `type` (`email`, `tel`, `url`, `number`) — never `text` for typed data
+- `inputMode` for mobile keyboards
+- `<label htmlFor>` or wrapping `<label>`
+- NO `onPaste={(e) => e.preventDefault()}`
+- emails / codes / usernames → `spellCheck={false}`
+
+**Every `<button type="submit">`:**
+
+- stays enabled until the request starts; spinner during the request
+- NEVER `disabled={!form.valid}` style — causes input-flicker and races with paste/autofill
+- visible focus style (`focus-visible:ring-*`)
+
+**Every `<form>`:**
+
+- errors inline next to fields, not just at top
+- focus first error on submit
+- warn before navigation with unsaved changes (`beforeunload` / router guard)
+
+**Every list / array render (`.map(...)`):**
+
+- empty-state branch (don't render broken UI for `[]`)
+- > 50 expected items → virtualize
+
+**Every interactive element:**
+
+- visible focus (`focus-visible:ring-*` or equivalent)
+- no `outline-none` / `outline: none` without a replacement focus style
+- keyboard handler if not a native interactive element
+
+**Every animation / transition:**
+
+- honors `prefers-reduced-motion`
+- animates `transform` / `opacity` only — NEVER `transition: all`
+- interruptible
+
+## Common-miss examples
+
+These are the rules most often overlooked. The bad pattern looks idiomatic, which is why models (and humans) skip them.
+
+**Submit button stays enabled until request starts.**
+
+```jsx
+// BAD: button disables based on form state. User types → deletes a char →
+// button flickers off → autofill/paste race with state.
+<button type="submit" disabled={!email}>Submit</button>
+
+// GOOD: stays enabled. Spinner appears during the request.
+<button type="submit" disabled={submitting}>
+  {submitting ? <Spinner /> : 'Submit'}
+</button>
+```
+
+**Never block paste.**
+
+```jsx
+// BAD: blocking paste — breaks password managers, accessibility tools,
+// and users who copy from another tab.
+<input onPaste={(e) => e.preventDefault()} />
+
+// GOOD: allow paste; validate or normalize after if needed.
+<input onPaste={(e) => { /* allow; optionally normalize value */ }} />
+```
+
+**Inputs need `autoComplete`.**
+
+```jsx
+// BAD: no autoComplete → browser can't fill, password managers stall.
+<input type="email" name="email" />
+
+// GOOD: explicit hint. Use `"off"` only for non-auth fields where you
+// actively don't want autofill.
+<input type="email" name="email" autoComplete="email" />
+```
+
+**Above-fold critical images need a priority hint.**
+
+```jsx
+// BAD: hero image with no priority. Browser de-prioritizes; LCP suffers.
+<img src="/hero.jpg" alt="..." width={1200} height={600} />
+
+// GOOD: hint that this image is critical for LCP.
+<Image src="/hero.jpg" alt="..." width={1200} height={600} priority />
+// or for plain <img>:
+<img src="/hero.jpg" alt="..." width={1200} height={600} fetchpriority="high" />
+```
+
+**Handle empty states.**
+
+```jsx
+// BAD: empty list silently renders broken UI (empty <ul>, no message).
+<ul>{items.map((i) => <li key={i.id}>{i.name}</li>)}</ul>
+
+// GOOD: explicit empty-state branch.
+{items.length === 0 ? (
+  <p className="text-muted">No items yet.</p>
+) : (
+  <ul>{items.map((i) => <li key={i.id}>{i.name}</li>)}</ul>
+)}
+```
+
+## Output Format
+
+Group by file. Use `file:line` format (VS Code clickable). Terse findings.
+
+```text
+## src/Button.tsx
+
+src/Button.tsx:42 - icon button missing aria-label
+src/Button.tsx:18 - input lacks label
+src/Button.tsx:55 - animation missing prefers-reduced-motion
+src/Button.tsx:67 - transition: all → list properties
+
+## src/Modal.tsx
+
+src/Modal.tsx:12 - missing overscroll-behavior: contain
+src/Modal.tsx:34 - "..." → "…"
+
+## src/Card.tsx
+
+✓ pass
+```
+
+State issue + location. Skip explanation unless fix non-obvious. No preamble.

--- a/examples/workbench/web-design-guidelines/suite.yml
+++ b/examples/workbench/web-design-guidelines/suite.yml
@@ -54,3 +54,58 @@ cases:
     graders:
       - name: animation-findings
         command: node $CASE/checks/grade-animation-findings.mjs
+
+  - name: review-data-table
+    task: |
+      Review /work/DataTable.tsx for Web Interface Guidelines compliance using
+      the web-design-guidelines skill at /work/web-design-guidelines/SKILL.md.
+
+      Write the findings to /work/findings.txt, one finding per line, in the
+      "DataTable.tsx:<line> <issue>" format described by the skill's guidelines.
+    graders:
+      - name: data-table-findings
+        command: node $CASE/checks/grade-data-table-findings.mjs
+
+  - name: review-confirm-dialog
+    task: |
+      Review /work/ConfirmDialog.tsx for Web Interface Guidelines compliance using
+      the web-design-guidelines skill at /work/web-design-guidelines/SKILL.md.
+
+      Write the findings to /work/findings.txt, one finding per line, in the
+      "ConfirmDialog.tsx:<line> <issue>" format described by the skill's guidelines.
+    graders:
+      - name: confirm-dialog-findings
+        command: node $CASE/checks/grade-confirm-dialog-findings.mjs
+
+  - name: review-search-page
+    task: |
+      Review /work/SearchPage.tsx for Web Interface Guidelines compliance using
+      the web-design-guidelines skill at /work/web-design-guidelines/SKILL.md.
+
+      Write the findings to /work/findings.txt, one finding per line, in the
+      "SearchPage.tsx:<line> <issue>" format described by the skill's guidelines.
+    graders:
+      - name: search-page-findings
+        command: node $CASE/checks/grade-search-page-findings.mjs
+
+  - name: review-theme-toggle
+    task: |
+      Review /work/ThemeToggle.tsx for Web Interface Guidelines compliance using
+      the web-design-guidelines skill at /work/web-design-guidelines/SKILL.md.
+
+      Write the findings to /work/findings.txt, one finding per line, in the
+      "ThemeToggle.tsx:<line> <issue>" format described by the skill's guidelines.
+    graders:
+      - name: theme-toggle-findings
+        command: node $CASE/checks/grade-theme-toggle-findings.mjs
+
+  - name: review-blog-post
+    task: |
+      Review /work/BlogPost.tsx for Web Interface Guidelines compliance using
+      the web-design-guidelines skill at /work/web-design-guidelines/SKILL.md.
+
+      Write the findings to /work/findings.txt, one finding per line, in the
+      "BlogPost.tsx:<line> <issue>" format described by the skill's guidelines.
+    graders:
+      - name: blog-post-findings
+        command: node $CASE/checks/grade-blog-post-findings.mjs

--- a/examples/workbench/web-design-guidelines/suite.yml
+++ b/examples/workbench/web-design-guidelines/suite.yml
@@ -1,0 +1,56 @@
+name: web-design-guidelines-eval
+references: ./references
+appendSystemPrompt: |
+  A skill is available at /work/web-design-guidelines/SKILL.md. Read it before
+  starting and follow its guidance to review the requested file.
+models:
+  - openrouter/anthropic/claude-sonnet-4.6
+  - openrouter/openai/gpt-5-mini
+  - openrouter/google/gemini-2.5-pro
+env:
+  - OPENROUTER_API_KEY
+timeoutSeconds: 600
+cases:
+  - name: review-product-card
+    task: |
+      Review /work/ProductCard.tsx for Web Interface Guidelines compliance using
+      the web-design-guidelines skill at /work/web-design-guidelines/SKILL.md.
+
+      Write the findings to /work/findings.txt, one finding per line, in the
+      "ProductCard.tsx:<line> <issue>" format described by the skill's guidelines.
+    graders:
+      - name: a11y-findings
+        command: node $CASE/checks/grade-a11y-findings.mjs
+
+  - name: review-checkout-form
+    task: |
+      Review /work/CheckoutForm.tsx for Web Interface Guidelines compliance using
+      the web-design-guidelines skill at /work/web-design-guidelines/SKILL.md.
+
+      Write the findings to /work/findings.txt, one finding per line, in the
+      "CheckoutForm.tsx:<line> <issue>" format described by the skill's guidelines.
+    graders:
+      - name: form-findings
+        command: node $CASE/checks/grade-form-findings.mjs
+
+  - name: review-loading-screen
+    task: |
+      Review /work/LoadingScreen.tsx for Web Interface Guidelines compliance using
+      the web-design-guidelines skill at /work/web-design-guidelines/SKILL.md.
+
+      Write the findings to /work/findings.txt, one finding per line, in the
+      "LoadingScreen.tsx:<line> <issue>" format described by the skill's guidelines.
+    graders:
+      - name: typography-findings
+        command: node $CASE/checks/grade-typography-findings.mjs
+
+  - name: review-hero-section
+    task: |
+      Review /work/HeroSection.tsx for Web Interface Guidelines compliance using
+      the web-design-guidelines skill at /work/web-design-guidelines/SKILL.md.
+
+      Write the findings to /work/findings.txt, one finding per line, in the
+      "HeroSection.tsx:<line> <issue>" format described by the skill's guidelines.
+    graders:
+      - name: animation-findings
+        command: node $CASE/checks/grade-animation-findings.mjs

--- a/examples/workbench/web-design-guidelines/workspace/BlogPost.tsx
+++ b/examples/workbench/web-design-guidelines/workspace/BlogPost.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+type Props = {
+  title: string;
+  body: string;
+  toastMessage?: string;
+};
+
+export function BlogPost({ title, body, toastMessage }: Props) {
+  return (
+    <article className="blog-post">
+      <h1>{title}</h1>
+      <h3>Background</h3>
+      <p>{body}</p>
+
+      <div className="share-row">
+        <svg viewBox="0 0 24 24" className="share-icon">
+          <path d="M12 2v20" />
+        </svg>
+        <span>Share this post</span>
+      </div>
+
+      <button className="cta focus:ring-2">Continue</button>
+
+      {toastMessage && (
+        <div className="toast">
+          {toastMessage}
+        </div>
+      )}
+    </article>
+  );
+}

--- a/examples/workbench/web-design-guidelines/workspace/CheckoutForm.tsx
+++ b/examples/workbench/web-design-guidelines/workspace/CheckoutForm.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+
+type Props = {
+  onSubmit: (data: FormData) => Promise<void>;
+};
+
+export function CheckoutForm({ onSubmit }: Props) {
+  const [email, setEmail] = useState('');
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    await onSubmit(new FormData(e.currentTarget));
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <label>Email</label>
+      <input
+        type="text"
+        name="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="email"
+        onPaste={(e) => e.preventDefault()}
+      />
+
+      <label htmlFor="card">Card Number</label>
+      <input id="card" type="text" name="card" autoComplete="cc-number" />
+
+      <button type="submit" disabled={email.length === 0}>
+        Place Order
+      </button>
+    </form>
+  );
+}

--- a/examples/workbench/web-design-guidelines/workspace/ConfirmDialog.tsx
+++ b/examples/workbench/web-design-guidelines/workspace/ConfirmDialog.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+type Props = {
+  title: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export function ConfirmDialog({ title, onConfirm, onCancel }: Props) {
+  return (
+    <div className="dialog-overlay" style={{ position: 'fixed', inset: 0 }}>
+      <div
+        className="dialog-panel"
+        style={{
+          position: 'absolute',
+          left: '50%',
+          top: '50%',
+          transform: 'translate(-50%, -50%)',
+          background: 'white',
+          padding: 24,
+        }}
+      >
+        <h3>{title}</h3>
+        <input
+          type="text"
+          autoFocus
+          placeholder="Type project name to confirm…"
+          className="confirm-input"
+        />
+        <div className="dialog-actions" style={{ display: 'flex', gap: 8 }}>
+          <button onClick={onCancel} className="btn-cancel">Cancel</button>
+          <button onClick={onConfirm} className="btn-danger">Delete</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/examples/workbench/web-design-guidelines/workspace/DataTable.tsx
+++ b/examples/workbench/web-design-guidelines/workspace/DataTable.tsx
@@ -1,0 +1,43 @@
+import React, { useRef, useState } from 'react';
+
+type Deployment = {
+  id: string;
+  project: string;
+  buildCount: number;
+  avgMs: number;
+};
+
+// `deployments` is the full team list — typically 800+ rows.
+export function DataTable({ deployments }: { deployments: Deployment[] }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(0);
+
+  if (containerRef.current) {
+    setWidth(containerRef.current.getBoundingClientRect().width);
+  }
+
+  return (
+    <div ref={containerRef} className="data-table">
+      <h2 className="text-xl font-bold">Recent Deployments</h2>
+      <p className="text-sm text-muted">Showing eight projects below.</p>
+      <table>
+        <thead>
+          <tr>
+            <th>Project</th>
+            <th className="text-right">Builds</th>
+            <th className="text-right">Avg ms</th>
+          </tr>
+        </thead>
+        <tbody>
+          {deployments.map((d) => (
+            <tr key={d.id}>
+              <td>{d.project}</td>
+              <td className="text-right">{d.buildCount}</td>
+              <td className="text-right">{d.avgMs}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/examples/workbench/web-design-guidelines/workspace/HeroSection.tsx
+++ b/examples/workbench/web-design-guidelines/workspace/HeroSection.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export function HeroSection() {
+  return (
+    <section className="hero">
+      <img src="/hero.jpg" alt="" className="hero-bg" />
+      <div
+        className="hero-content"
+        style={{ transition: 'all 300ms ease' }}
+      >
+        <h1>Welcome to Acme</h1>
+        <p>Build faster. Ship faster.</p>
+        <button className="hero-cta">Get Started</button>
+      </div>
+      <div
+        className="floating-badge"
+        style={{ animation: 'spin 3s linear infinite' }}
+      >
+        <svg viewBox="0 0 100 100">
+          <circle cx="50" cy="50" r="40" />
+        </svg>
+      </div>
+      <img src="/below-fold.jpg" alt="Decorative graphic" />
+    </section>
+  );
+}

--- a/examples/workbench/web-design-guidelines/workspace/LoadingScreen.tsx
+++ b/examples/workbench/web-design-guidelines/workspace/LoadingScreen.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+type Props = {
+  fileSize: number;
+  recentFiles: string[];
+};
+
+export function LoadingScreen({ fileSize, recentFiles }: Props) {
+  return (
+    <div className="loading-screen">
+      <h2>Setting things up</h2>
+      <p>Loading...</p>
+      <p>Welcome to "Acme Cloud" - your files, anywhere.</p>
+      <p>Uploading a {fileSize} MB file.</p>
+      <div className="flex items-center">
+        <span className="truncate">{recentFiles[0]}</span>
+        <button>Open</button>
+      </div>
+      <ul>
+        {recentFiles.map((f) => (
+          <li key={f}>{f}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/examples/workbench/web-design-guidelines/workspace/ProductCard.tsx
+++ b/examples/workbench/web-design-guidelines/workspace/ProductCard.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+type Props = {
+  name: string;
+  description: string;
+  imageUrl: string;
+  onAddToCart: () => void;
+  onToggleWishlist: () => void;
+  onQtyChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+};
+
+export function ProductCard({ name, description, imageUrl, onAddToCart, onToggleWishlist, onQtyChange }: Props) {
+  return (
+    <article className="product-card">
+      <img src={imageUrl} className="product-card__image" />
+      <h3>{name}</h3>
+      <p>{description}</p>
+      <div onClick={onAddToCart} className="product-card__add">
+        Add to Cart
+      </div>
+      <button onClick={onToggleWishlist} className="product-card__wishlist">
+        <HeartIcon />
+      </button>
+      <input
+        type="text"
+        placeholder="Quantity"
+        onChange={onQtyChange}
+        className="product-card__qty"
+      />
+      <button className="product-card__buy outline-none">
+        Buy Now
+      </button>
+    </article>
+  );
+}
+
+function HeartIcon() {
+  return <svg viewBox="0 0 24 24" aria-hidden="true" />;
+}

--- a/examples/workbench/web-design-guidelines/workspace/SearchPage.tsx
+++ b/examples/workbench/web-design-guidelines/workspace/SearchPage.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+
+type Result = {
+  id: string;
+  title: string;
+  price: number;
+  publishedAt: Date;
+};
+
+export function SearchPage({ results }: { results: Result[] }) {
+  const [query, setQuery] = useState('');
+  const [page, setPage] = useState(1);
+
+  function handleDelete(id: string) {
+    fetch(`/api/items/${id}`, { method: 'DELETE' });
+  }
+
+  return (
+    <div className="search-page">
+      <h1>Search Acme Cloud</h1>
+      <input
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search…"
+      />
+      <p>Showing page {page}</p>
+      <ul>
+        {results.map((r) => (
+          <li key={r.id}>
+            <h3>{r.title}</h3>
+            <span>${r.price.toFixed(2)}</span>
+            <time>{r.publishedAt.toDateString()}</time>
+            <button onClick={() => handleDelete(r.id)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/examples/workbench/web-design-guidelines/workspace/ThemeToggle.tsx
+++ b/examples/workbench/web-design-guidelines/workspace/ThemeToggle.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+
+const themes = ['light', 'dark', 'system'] as const;
+type Theme = (typeof themes)[number];
+
+export function ThemeToggle() {
+  const initial = (localStorage.getItem('theme') as Theme) || 'light';
+  const [theme, setTheme] = useState<Theme>(initial);
+  const [accentColor] = useState('blue');
+
+  return (
+    <div className="theme-toggle">
+      <label htmlFor="theme">Theme</label>
+      <select
+        id="theme"
+        value={theme}
+        onChange={(e) => setTheme(e.target.value as Theme)}
+      >
+        {themes.map((t) => (
+          <option key={t} value={t}>{t}</option>
+        ))}
+      </select>
+
+      <label htmlFor="accent">Accent</label>
+      <input id="accent" type="text" value={accentColor} />
+
+      <button onClick={() => setTheme('dark')}>Apply Dark Mode</button>
+    </div>
+  );
+}


### PR DESCRIPTION
First skill from the prioritized top-N list. Adds an eval suite for [`vercel-labs/agent-skills/web-design-guidelines`](https://github.com/vercel-labs/agent-skills) (~298K installs) and a before/after proposal of upstream changes for the team to review before we PR.

**Stacked on `fix/workbench-linux-docker-permissions`** (the Linux Docker fix is required to run the suite).

## Eval suite — `examples/workbench/web-design-guidelines/`

4 cases × 3 mid-tier models × 3 trials. 20 seeded violations across 6 rule families (a11y / focus / forms / typography / animation / images).

```bash
cd examples/workbench/web-design-guidelines
export OPENROUTER_API_KEY=sk-or-...
npx tsx ../../../src/cli.ts run-suite ./suite.yml --trials 3
```

## Proposed upstream changes — `proposed-upstream-changes/`

Before/after snapshots of the two upstream files we'd PR back. **Not published yet** — pending team coordination since this is our first contribution to vercel-labs.

| Upstream | Change |
|---|---|
| `vercel-labs/agent-skills` SKILL.md (39→54 lines) | adds explicit two-pass workflow |
| `vercel-labs/web-interface-guidelines` command.md (180→304 lines) | adds per-element Pass 2 checklist + 5 BAD/GOOD examples for most-missed rules |

## Eval evidence

| Model | Before | After |
|---|---|---|
| claude-sonnet-4.6 | 10/12 (83%) | **12/12 (100%)** |
| gpt-5-mini | 9/12 (75%) | **10/12 (83%)** |
| gemini-2.5-pro | 7/12 (58%) | **9/12 (75%)** |
| **Total** | **26/36 (72%)** | **31/36 (86%)** |

Two rules eliminated entirely (`no-empty-state-handling`, `input-missing-autocomplete`); two reduced (`submit-disabled` 3→1, `above-fold-priority` 2→1).